### PR TITLE
Minor Refactor: Replace path normalization function with standard library function

### DIFF
--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -27,27 +27,7 @@ def encode_categories(
     return inds
 
 
-def to_os_dir_sep(path: str) -> str:
-    """
-    Replace all directory separators in `path` with `os.path.sep`.
-    Function originally written by @pyzun:
-    https://github.com/DeepLabCut/napari-DeepLabCut/pull/13
-
-    Raises
-    ------
-    ValueError: if `path` contains both UNIX and Windows directory separators.
-
-    """
-    win_sep, unix_sep = "\\", "/"
-
-    # On UNIX systems, `win_sep` is a valid character in directory and file
-    # names. This function fails if both are present.
-    if win_sep in path and unix_sep in path:
-        raise ValueError(f'"{path}" may not contain both "{win_sep}" and "{unix_sep}"!')
-
-    sep = win_sep if win_sep in path else unix_sep
-
-    return os.path.sep.join(path.split(sep))
+to_os_dir_sep = os.path.normpath
 
 
 def guarantee_multiindex_rows(df):

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -27,7 +27,11 @@ def encode_categories(
     return inds
 
 
-to_os_dir_sep = os.path.normpath
+def to_os_dir_sep(self, path: str):
+    """
+    Replace all directory separators in `path` with `os.path.sep`.
+    """
+    return str(path).replace('\\', os.path.sep).replace('/', os.path.sep)
 
 
 def guarantee_multiindex_rows(df):


### PR DESCRIPTION
Hi,

This project looks very useful, and I'd love to use it for my group.  I understand it's a new project, so no worries; while doing some code review, I came across this quick improvement: replacing the `to_os_dir_sep()` function with the `os.path.normpath()` function.  They have the same interface, and the nice thing is that the `normpath()` function doesn't raise an error if it encounters a mix of path seperators.

Best wishes,

Nick