### PR TITLE
remove git hash for napari

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ project_urls =
 packages = find:
 install_requires =
     dask-image
-    napari @ git+https://github.com/napari/napari.git#ec69e69
+    napari @ git+https://github.com/napari/napari.git
     numpy
     opencv-python-headless
     pandas


### PR DESCRIPTION
as the v0.0.8 can't be deployed otherwise!
```Successfully built napari_deeplabcut-0.0.8.tar.gz and napari_deeplabcut-0.0.8-py3-none-any.whl
Uploading distributions to https://upload.pypi.org/legacy/
Uploading napari_deeplabcut-0.0.8-py3-none-any.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/39.1 kB • --:-- • ?
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/39.1 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 39.1/39.1 kB • 00:00 • 34.2 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 39.1/39.1 kB • 00:00 • 34.2 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 39.1/39.1 kB • 00:00 • 34.2 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         Invalid value for requires_dist. Error: Can't have direct dependency:  
         'napari @ git+https://github.com/napari/napari.git#ec69e69'            
Error: Process completed with exit code 1.
```