### PR TITLE
Warn about unsaved data rather than force users to save

### DIFF
--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -53,11 +53,12 @@ def test_store_crop_coordinates(viewer, images, config_path):
 def test_toggle_face_color(viewer, points):
     viewer.layers.selection.add(points)
     view = viewer.window._qt_viewer
-    assert points._face.color_properties.name == "label"
-    view.canvas.events.key_press(key=keys.Key('F'))
+    # By default, points are colored by individual with multi-animal data
     assert points._face.color_properties.name == "id"
     view.canvas.events.key_press(key=keys.Key('F'))
     assert points._face.color_properties.name == "label"
+    view.canvas.events.key_press(key=keys.Key('F'))
+    assert points._face.color_properties.name == "id"
 
 
 def test_toggle_edge_color(viewer, points):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -114,13 +114,16 @@ def _save_layers_dialog(self, selected=False):
 
 def on_close(self, event, widget):
     if widget._stores and not widget._is_saved:
-        QMessageBox.warning(
+        choice = QMessageBox.warning(
             widget,
-            "",
-            "Please save your data before closing",
-            QMessageBox.Ok,
+            "Warning",
+            "Data were not saved. Are you certain you want to leave?",
+            QMessageBox.Yes | QMessageBox.No,
         )
-        event.ignore()
+        if choice == QMessageBox.Yes:
+            event.accept()
+        else:
+            event.ignore()
     else:
         event.accept()
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -142,7 +142,7 @@ class KeypointControls(QWidget):
         status_bar = self.viewer.window._qt_window.statusBar()
         self.last_saved_label = QLabel("")
         self.last_saved_label.hide()
-        status_bar.insertPermanentWidget(0, self.last_saved_label)
+        status_bar.addPermanentWidget(self.last_saved_label)
 
         # Hack napari's Welcome overlay to show more relevant instructions
         overlay = self.viewer.window._qt_viewer._canvas_overlay


### PR DESCRIPTION
Currently, the GUI cannot be closed unless the user saves the data; this is annoying when using the GUI to only visualize data, or if discarding changes is desired.
We now rather open a Warning message box asking confirmation.

Fixes https://github.com/DeepLabCut/DeepLabCut/issues/2042