### PR TITLE
Bug fix: Unable to open single frame in folder for labeling

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -99,6 +99,11 @@ def read_images(path):
             "root": os.path.split(path)[0],
         },
     }
+
+    # https://github.com/soft-matter/pims/issues/452
+    if len(filepaths) == 1:
+        path = glob.glob(path)[0]
+
     return [(imread(path), params, "image")]
 
 


### PR DESCRIPTION
Addresses #80.

The issue originated from the PIMS package, which fails to open a folder containing a single image using a glob pattern (see [PIMS issue 452](https://github.com/soft-matter/pims/issues/452))