### PR TITLE
Fix loading of data with multiple scorers

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -182,6 +182,7 @@ def read_hdf(filename: str) -> List[LayerData]:
     layers = []
     for filename in glob.iglob(filename):
         temp = pd.read_hdf(filename)
+        temp = misc.merge_multiple_scorers(temp)
         header = misc.DLCHeader(temp.columns)
         temp = temp.droplevel("scorer", axis=1)
         if "individuals" not in temp.columns.names:

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -22,12 +22,15 @@ def fake_keypoints():
     n_animals = 2
     n_kpts = 3
     data = np.random.rand(n_rows, n_animals * n_kpts * 2)
-    cols = pd.MultiIndex.from_product([
-        ["me"],
-        [f"animal_{i}" for i in range(n_animals)],
-        [f"kpt_{i}" for i in range(n_kpts)],
-        ["x", "y"]
-    ], names=["scorer", "individuals", "bodyparts", "coords"])
+    cols = pd.MultiIndex.from_product(
+        [
+            ["me"],
+            [f"animal_{i}" for i in range(n_animals)],
+            [f"kpt_{i}" for i in range(n_kpts)],
+            ["x", "y"],
+        ],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
     df = pd.DataFrame(data, columns=cols, index=range(n_rows))
     return df
 
@@ -68,11 +71,12 @@ def config_path(tmp_path_factory):
         "colormap": "viridis",
         "video_sets": {
             "fake_video": [],
-        }
+        },
     }
     path = str(tmp_path_factory.mktemp("configs") / "config.yaml")
     _writer._write_config(
-        path, params=cfg,
+        path,
+        params=cfg,
     )
     return path
 
@@ -83,7 +87,7 @@ def video_path(tmp_path_factory):
     h = w = 50
     writer = cv2.VideoWriter(
         output_path,
-        cv2.VideoWriter_fourcc(*'MJPG'),
+        cv2.VideoWriter_fourcc(*"MJPG"),
         2,
         (w, h),
     )

--- a/src/napari_deeplabcut/_tests/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/test_keypoints.py
@@ -46,7 +46,7 @@ def test_point_resize(viewer, points):
 
 
 def test_add_unnanotated(store):
-    store.layer.metadata["controls"].label_mode = 'loop'
+    store.layer.metadata["controls"].label_mode = "loop"
     ind_to_remove = 0
     data = store.layer.data
     store.layer.data = data[data[:, 0] != ind_to_remove]
@@ -59,10 +59,11 @@ def test_add_unnanotated(store):
 
 
 def test_add_quick(store):
-    store.layer.metadata["controls"].label_mode = 'quick'
+    store.layer.metadata["controls"].label_mode = "quick"
     store.current_keypoint = store._keypoints[0]
     coord = store.current_step, -1, -1
     keypoints._add(store, coord=coord)
     np.testing.assert_array_equal(
-        store.layer.data[store.current_step], coord,
+        store.layer.data[store.current_step],
+        coord,
     )

--- a/src/napari_deeplabcut/_tests/test_misc.py
+++ b/src/napari_deeplabcut/_tests/test_misc.py
@@ -66,8 +66,7 @@ def test_to_os_dir_sep_invalid():
 
 def test_guarantee_multiindex_rows():
     fake_index = [
-        f"labeled-data/subfolder_{i}/image_{j}"
-        for i in range(3) for j in range(10)
+        f"labeled-data/subfolder_{i}/image_{j}" for i in range(3) for j in range(10)
     ]
     df = pd.DataFrame(index=fake_index)
     misc.guarantee_multiindex_rows(df)
@@ -94,9 +93,15 @@ def test_dlc_header():
     scorer = "me"
     animals = [f"animal_{n}" for n in range(n_animals)]
     keypoints = [f"kpt_{n}" for n in range(n_keypoints)]
-    fake_columns = pd.MultiIndex.from_product([
-        [scorer], animals, keypoints, ["x", "y", "likelihood"],
-    ], names=["scorer", "individuals", "bodyparts", "coords"])
+    fake_columns = pd.MultiIndex.from_product(
+        [
+            [scorer],
+            animals,
+            keypoints,
+            ["x", "y", "likelihood"],
+        ],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
     header = misc.DLCHeader(fake_columns)
     assert header.scorer == scorer
     header.scorer = "you"

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -64,8 +64,7 @@ def test_read_config(config_path):
 def test_read_hdf_old_index(tmp_path_factory, fake_keypoints):
     path = str(tmp_path_factory.mktemp("folder") / "data.h5")
     old_index = [
-        f"labeled-data/video/img{i}.png"
-        for i in range(fake_keypoints.shape[0])
+        f"labeled-data/video/img{i}.png" for i in range(fake_keypoints.shape[0])
     ]
     fake_keypoints.index = old_index
     fake_keypoints.to_hdf(path, key="data")
@@ -79,11 +78,13 @@ def test_read_hdf_old_index(tmp_path_factory, fake_keypoints):
 
 def test_read_hdf_new_index(tmp_path_factory, fake_keypoints):
     path = str(tmp_path_factory.mktemp("folder") / "data.h5")
-    new_index = pd.MultiIndex.from_product([
-        ["labeled-data"],
-        ["video"],
-        [f"img{i}.png" for i in range(fake_keypoints.shape[0])]
-    ])
+    new_index = pd.MultiIndex.from_product(
+        [
+            ["labeled-data"],
+            ["video"],
+            [f"img{i}.png" for i in range(fake_keypoints.shape[0])],
+        ]
+    )
     fake_keypoints.index = new_index
     fake_keypoints.to_hdf(path, key="data")
     layers = _reader.read_hdf(path)

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -5,7 +5,7 @@ from vispy import keys
 
 
 def test_guess_continuous():
-    assert _widgets.guess_continuous(np.array([0.]))
+    assert _widgets.guess_continuous(np.array([0.0]))
     assert not _widgets.guess_continuous(np.array(list("abc")))
 
 
@@ -40,7 +40,7 @@ def test_store_crop_coordinates(viewer, images, config_path):
     viewer.layers.selection.add(images)
     _ = viewer.add_shapes(
         np.random.random((4, 3)),
-        shape_type='rectangle',
+        shape_type="rectangle",
     )
     controls = _widgets.KeypointControls(viewer)
     controls._images_meta = {
@@ -55,9 +55,9 @@ def test_toggle_face_color(viewer, points):
     view = viewer.window._qt_viewer
     # By default, points are colored by individual with multi-animal data
     assert points._face.color_properties.name == "id"
-    view.canvas.events.key_press(key=keys.Key('F'))
+    view.canvas.events.key_press(key=keys.Key("F"))
     assert points._face.color_properties.name == "label"
-    view.canvas.events.key_press(key=keys.Key('F'))
+    view.canvas.events.key_press(key=keys.Key("F"))
     assert points._face.color_properties.name == "id"
 
 
@@ -65,7 +65,7 @@ def test_toggle_edge_color(viewer, points):
     viewer.layers.selection.add(points)
     view = viewer.window._qt_viewer
     np.testing.assert_array_equal(points.edge_width, 0)
-    view.canvas.events.key_press(key=keys.Key('E'))
+    view.canvas.events.key_press(key=keys.Key("E"))
     np.testing.assert_array_equal(points.edge_width, 2)
 
 
@@ -82,7 +82,7 @@ def test_keypoints_dropdown_menu(store):
     widget = _widgets.KeypointsDropdownMenu(store)
     assert "id" in widget.menus
     assert "label" in widget.menus
-    label_menu = widget.menus['label']
+    label_menu = widget.menus["label"]
     label_menu.currentText() == "kpt_0"
     widget.update_menus(event=None)
     label_menu.currentText() == "kpt_2"
@@ -92,7 +92,7 @@ def test_keypoints_dropdown_menu(store):
 
 def test_keypoints_dropdown_menu_smart_reset(store):
     widget = _widgets.KeypointsDropdownMenu(store)
-    label_menu = widget.menus['label']
+    label_menu = widget.menus["label"]
     label_menu.update_to("kpt_2")
     widget._locked = True
     widget.smart_reset(event=None)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -52,7 +52,7 @@ from napari_deeplabcut.misc import (
 )
 
 
-Tip = namedtuple('Tip', ['msg', 'pos'])
+Tip = namedtuple("Tip", ["msg", "pos"])
 
 
 class Tutorial(QDialog):
@@ -67,15 +67,35 @@ class Tutorial(QDialog):
 
         self._current_tip = 0
         self._tips = [
-            Tip("Load a folder of annotated data\n(and optionally a config file if labeling from scratch)\nfrom the menu File > Open File or Open Folder.\nAlternatively, files and folders of images can be dragged\nand dropped onto the main window.", (0.35, 0.15)),
-            Tip("Data layers will be listed at the bottom left;\ntheir visibility can be toggled by clicking on the small eye icon.", (0.1, 0.65)),
-            Tip("Corresponding layer controls can be found at the top left.\nSwitch between labeling and selection mode using the numeric keys 2 and 3,\nor clicking on the + or -> icons.", (0.1, 0.2)),
-            Tip("There are three keypoint labeling modes:\nthe key M can be used to cycle between them.", (0.65, 0.05)),
-            Tip("When done labeling, save your data by selecting the Points layer\nand hitting Ctrl+S (or File > Save Selected Layer(s)...).", (0.1, 0.65)),
-            Tip("Read more at <a href='https://github.com/DeepLabCut/napari-deeplabcut#usage'>napari-deeplabcut</a>", (0.4, 0.4)),
+            Tip(
+                "Load a folder of annotated data\n(and optionally a config file if labeling from scratch)\nfrom the menu File > Open File or Open Folder.\nAlternatively, files and folders of images can be dragged\nand dropped onto the main window.",
+                (0.35, 0.15),
+            ),
+            Tip(
+                "Data layers will be listed at the bottom left;\ntheir visibility can be toggled by clicking on the small eye icon.",
+                (0.1, 0.65),
+            ),
+            Tip(
+                "Corresponding layer controls can be found at the top left.\nSwitch between labeling and selection mode using the numeric keys 2 and 3,\nor clicking on the + or -> icons.",
+                (0.1, 0.2),
+            ),
+            Tip(
+                "There are three keypoint labeling modes:\nthe key M can be used to cycle between them.",
+                (0.65, 0.05),
+            ),
+            Tip(
+                "When done labeling, save your data by selecting the Points layer\nand hitting Ctrl+S (or File > Save Selected Layer(s)...).",
+                (0.1, 0.65),
+            ),
+            Tip(
+                "Read more at <a href='https://github.com/DeepLabCut/napari-deeplabcut#usage'>napari-deeplabcut</a>",
+                (0.4, 0.4),
+            ),
         ]
 
-        buttons = QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Abort
+        buttons = (
+            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Abort
+        )
         self.button_box = QDialogButtonBox(buttons)
         self.button_box.accepted.connect(self.accept)
         self.button_box.rejected.connect(self.reject)
@@ -97,7 +117,9 @@ class Tutorial(QDialog):
             self.reject()
         tip = self._tips[self._current_tip]
         msg = tip.msg
-        if self._current_tip < 5:  # No emoji in the last tip otherwise the hyperlink breaks
+        if (
+            self._current_tip < 5
+        ):  # No emoji in the last tip otherwise the hyperlink breaks
             msg = "💡\n\n" + msg
         self.message.setText(msg)
         self.count.setText(f"Tip {self._current_tip + 1}|{len(self._tips)}")
@@ -173,50 +195,41 @@ def _paste_data(self, store):
 
     if len(self._clipboard.keys()) > 0:
         not_disp = self._slice_input.not_displayed
-        data = deepcopy(self._clipboard['data'])
+        data = deepcopy(self._clipboard["data"])
         offset = [
-            self._slice_indices[i] - self._clipboard['indices'][i]
-            for i in not_disp
+            self._slice_indices[i] - self._clipboard["indices"][i] for i in not_disp
         ]
         data[:, not_disp] = data[:, not_disp] + np.array(offset)
         self._data = np.append(self.data, data, axis=0)
-        self._shown = np.append(
-            self.shown, deepcopy(self._clipboard['shown']), axis=0
-        )
-        self._size = np.append(
-            self.size, deepcopy(self._clipboard['size']), axis=0
-        )
+        self._shown = np.append(self.shown, deepcopy(self._clipboard["shown"]), axis=0)
+        self._size = np.append(self.size, deepcopy(self._clipboard["size"]), axis=0)
         self._symbol = np.append(
-            self.symbol, deepcopy(self._clipboard['symbol']), axis=0
+            self.symbol, deepcopy(self._clipboard["symbol"]), axis=0
         )
 
-        self._feature_table.append(self._clipboard['features'])
+        self._feature_table.append(self._clipboard["features"])
 
-        self.text._paste(**self._clipboard['text'])
+        self.text._paste(**self._clipboard["text"])
 
         self._edge_width = np.append(
             self.edge_width,
-            deepcopy(self._clipboard['edge_width']),
+            deepcopy(self._clipboard["edge_width"]),
             axis=0,
         )
         self._edge._paste(
-            colors=self._clipboard['edge_color'],
-            properties=_features_to_properties(
-                self._clipboard['features']
-            ),
+            colors=self._clipboard["edge_color"],
+            properties=_features_to_properties(self._clipboard["features"]),
         )
         self._face._paste(
-            colors=self._clipboard['face_color'],
-            properties=_features_to_properties(
-                self._clipboard['features']
-            ),
+            colors=self._clipboard["face_color"],
+            properties=_features_to_properties(self._clipboard["features"]),
         )
 
         self._selected_view = list(
-            range(npoints, npoints + len(self._clipboard['data']))
+            range(npoints, npoints + len(self._clipboard["data"]))
         )
         self._selected_data = set(
-            range(totpoints, totpoints + len(self._clipboard['data']))
+            range(totpoints, totpoints + len(self._clipboard["data"]))
         )
         self.refresh()
 
@@ -449,16 +462,17 @@ class KeypointControls(QWidget):
                         "properties": points_layer.properties,
                     },
                 )
-                df = df.iloc[ind:ind + 1]
+                df = df.iloc[ind : ind + 1]
                 df.index = pd.MultiIndex.from_tuples([Path(output_path).parts[-3:]])
-                filepath = os.path.join(image_layer.metadata["root"], "machinelabels-iter0.h5")
+                filepath = os.path.join(
+                    image_layer.metadata["root"], "machinelabels-iter0.h5"
+                )
                 if Path(filepath).is_file():
                     df_prev = pd.read_hdf(filepath)
                     guarantee_multiindex_rows(df_prev)
                     df = pd.concat([df_prev, df])
                     df = df[~df.index.duplicated(keep="first")]
                 df.to_hdf(filepath, key="machinelabels")
-
 
     def _store_crop_coordinates(self, *args):
         if not (project_path := self._images_meta.get("project")):
@@ -605,8 +619,10 @@ class KeypointControls(QWidget):
                 new_keypoint_set = set(layer.metadata["header"].bodyparts)
                 diff = new_keypoint_set.difference(current_keypoint_set)
                 if diff:
-                    answer = QMessageBox.question(self, "", "Do you want to display the new keypoints only?")
-                    if answer  == QMessageBox.Yes:
+                    answer = QMessageBox.question(
+                        self, "", "Do you want to display the new keypoints only?"
+                    )
+                    if answer == QMessageBox.Yes:
                         self.viewer.layers[-2].shown = False
 
                     self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
@@ -620,9 +636,13 @@ class KeypointControls(QWidget):
 
                 # Always update the colormap to reflect the one in the config.yaml file
                 for _layer, store in self._stores.items():
-                    _layer.metadata["face_color_cycles"] = layer.metadata["face_color_cycles"]
+                    _layer.metadata["face_color_cycles"] = layer.metadata[
+                        "face_color_cycles"
+                    ]
                     _layer.face_color = "label"
-                    _layer.face_color_cycle = layer.metadata["face_color_cycles"]["label"]
+                    _layer.face_color_cycle = layer.metadata["face_color_cycles"][
+                        "label"
+                    ]
                     _layer.events.face_color()
                     store.layer = _layer
                 self._update_color_scheme()
@@ -795,7 +815,9 @@ class KeypointsDropdownMenu(QWidget):
             menu.currentTextChanged.connect(self.refresh_label_menu)
             self.menus["id"] = menu
         self.menus["label"] = create_dropdown_menu(
-            self.store, self.id2label[id_], "label",
+            self.store,
+            self.id2label[id_],
+            "label",
         )
 
     def _update_items(self):
@@ -837,7 +859,9 @@ class KeypointsDropdownMenu(QWidget):
             if keypoint not in already_annotated:
                 unannotated = keypoint
                 break
-        self.store.current_keypoint = unannotated if unannotated else self.store._keypoints[0]
+        self.store.current_keypoint = (
+            unannotated if unannotated else self.store._keypoints[0]
+        )
 
 
 def create_dropdown_menu(store, items, attr):


### PR DESCRIPTION
This is required, e.g., to load data after extracting outlier frames with models coming from different shuffles.
Detections are merged in a manner retaining detections of highest confidence.

Closes https://github.com/DeepLabCut/DeepLabCut/issues/2321