### PR TITLE
Fix data display when new keypoints are found in the config

### DIFF
--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1108,6 +1108,7 @@ class KeypointsDropdownMenu(QWidget):
         self.setLayout(layout1)
 
     def _map_individuals_to_bodyparts(self):
+        self.id2label.clear()  # Empty dict so entries are ordered as in the config
         for keypoint in self.store._keypoints:
             label = keypoint.label
             id_ = keypoint.id
@@ -1412,4 +1413,5 @@ class ColorSchemeDisplay(QScrollArea):
         self.scheme_dict = {}
         for i in reversed(range(self._layout.count())):
             w = self._layout.itemAt(i).widget()
+            w.setParent(None)
             self._layout.removeWidget(w)


### PR DESCRIPTION
I fixed 2 race conditions causing some widgets to be wrongly displayed (especially the color scheme reference) and, importantly, some internal references to the wrong Points layer to be kept in memory. This now lets me annotate new keypoints as before.