### PR TITLE
Allow manual deployment

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,7 +75,10 @@ jobs:
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest
-    if: ${{ contains(github.ref, 'tags') || inputs.force_deploy }}
+    if: |
+      always() &&
+      inputs.force_deploy ||
+      (contains(github.ref, 'tags') && contains(needs.test.result, 'success'))
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -15,6 +15,11 @@ on:
       - main
       - npe2
   workflow_dispatch:
+    inputs:
+      force_deploy:
+        description: 'Force deployment even if tests fail'
+        required: true
+        type: boolean
 
 jobs:
   test:
@@ -70,7 +75,7 @@ jobs:
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags')
+    if: contains(github.ref, 'tags') || ${{ inputs.force_deploy }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -67,7 +67,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
 
       - name: Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,7 +75,7 @@ jobs:
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags') || ${{ inputs.force_deploy }}
+    if: ${{ contains(github.ref, 'tags') || inputs.force_deploy }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
It is frustrating to see the publication of new releases to PyPi fail because some GitHub's CI tests do not pass (at random..., while they all pass locally). With the current changes, one could manually trigger the `deploy` step (either from the GitHub UI or CLI), which I find convenient.