### PR TITLE
niels/color_modes

### DIFF
--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -62,6 +62,8 @@ Tip = namedtuple("Tip", ["msg", "pos"])
 
 
 class Shortcuts(QDialog):
+    """Opens a window displaying available napari-deeplabcut shortcuts"""
+
     def __init__(self, parent):
         super().__init__(parent=parent)
         self.setParent(parent)
@@ -70,10 +72,8 @@ class Shortcuts(QDialog):
         image_path = str(Path(__file__).parent / "assets" / "napari_shortcuts.svg")
 
         vlayout = QVBoxLayout()
-        background_widget = QWidget()
-        background_widget.setStyleSheet("background-color: white;")
         svg_widget = QSvgWidget(image_path)
-        vlayout.addWidget(background_widget)
+        svg_widget.setStyleSheet("background-color: white;")
         vlayout.addWidget(svg_widget)
         self.setLayout(vlayout)
 
@@ -584,6 +584,10 @@ class KeypointControls(QWidget):
         )
         self.video_widget.setVisible(False)
 
+        # form helper display
+        help_buttons = self._form_help_buttons()
+        self._layout.addLayout(help_buttons)
+
         hlayout = QHBoxLayout()
         trail_label = QLabel("Show trails")
         self._trail_cb = QCheckBox()
@@ -610,7 +614,10 @@ class KeypointControls(QWidget):
 
         self._layout.addLayout(hlayout)
 
+        # form buttons for selection of annotation mode
         self._radio_group = self._form_mode_radio_buttons()
+
+        # form color scheme display + color mode selector
         self._color_mode_selector = self._form_color_mode_selector()
         self._display = ColorSchemeDisplay(parent=self)
         self._color_scheme_display = self._form_color_scheme_display(self.viewer)
@@ -720,6 +727,16 @@ class KeypointControls(QWidget):
         layout.addWidget(crop_button)
         group_box.setLayout(layout)
         return group_box
+
+    def _form_help_buttons(self):
+        layout = QHBoxLayout()
+        show_shortcuts = QPushButton("View shortcuts")
+        show_shortcuts.clicked.connect(self.display_shortcuts)
+        layout.addWidget(show_shortcuts)
+        tutorial = QPushButton("Start tutorial")
+        tutorial.clicked.connect(self.start_tutorial)
+        layout.addWidget(tutorial)
+        return layout
 
     def _extract_single_frame(self, *args):
         image_layer = None

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -75,7 +75,6 @@ class Shortcuts(QDialog):
         svg_widget = QSvgWidget(image_path)
         vlayout.addWidget(background_widget)
         vlayout.addWidget(svg_widget)
-        vlayout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(vlayout)
 
 

--- a/src/napari_deeplabcut/keypoints.py
+++ b/src/napari_deeplabcut/keypoints.py
@@ -34,6 +34,22 @@ QtPointsControls.changeCurrentSize = _change_size
 QtPointsControls.changeCurrentSymbol = _change_symbol
 
 
+class ColorMode(CycleEnum):
+    """Modes in which keypoints can be colored
+
+    BODYPART: the keypoints are grouped by bodypart (all bodyparts have the same color)
+    INDIVIDUAL: the keypoints are grouped by individual (all keypoints for the same
+        individual have the same color)
+    """
+
+    BODYPART = auto()
+    INDIVIDUAL = auto()
+
+    @classmethod
+    def default(cls):
+        return cls.BODYPART
+
+
 class LabelMode(CycleEnum):
     """
     Labeling modes.


### PR DESCRIPTION
# UI Update - Changing between "individual" and "bodypart" keypoint coloring modes

## Issues addressed

The color scheme display was never updated when chaning between individual and bodypart labelling.

When refinining `machine labels` (after extracting outlier frames):
- cannot change between individual/bodypart coloring when refining labels
- cannot add new keypoints 

## Changes
- create a `ColorMode` `CycleEnum` so a single color mode is selected for all points layers
  - add a radio-button selector (just like for annotation mode) to select between bodypart and individual (can still use "F" when a points layer is selected)
  - the color mode for all points layers is updated when it changes 
- adds "View shortcuts" and "Start tutorial" buttons at the top of the keypoint controls (see demo)
- have a "keypoints menu" for each points layer, and switch between the menus depending on which layer is active (fixes the bug where keypoints cannot be added to the machine_labels layer)

Below is a short demo of the fixes.

https://github.com/DeepLabCut/napari-deeplabcut/assets/45132115/e15ef815-5f3f-4356-8dd8-7f8c8c8c80c7



## Other Bug Fixes
- fix `Shortcuts` display to have a white background and not collapse on itself
- updating the color scheme reference by deleting all widgets and adding new ones was too slow and could lead to concurrency issues (when switching very quickly between both modes, an error would be thrown as a widget being added was being deleted at the same time, which lead to the error: `'PySide6.QtCore.QObject.eventFilter' called with wrong argument types: PySide6.QtCore.QObject.eventFilter(QWidgetItem, QEvent)`, `Supported signatures: PySide6.QtCore.QObject.eventFilter(PySide6.QtCore.QObject, PySide6.QtCore.QEvent)`). Widgets are now updated, with any extra widgets being made invisible and new widgets are added if needed.