### PR TITLE
niels/color_mode_selector_update

### DIFF
--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -872,7 +872,7 @@ class KeypointControls(QWidget):
         logging.warning(str(self.color_mode == str(keypoints.ColorMode.INDIVIDUAL)))
         logging.warning("---")
         mode = "label"
-        if self.color_mode == str(keypoints.ColorMode.BODYPART):
+        if self.color_mode == str(keypoints.ColorMode.INDIVIDUAL):
             mode = "id"
 
         logging.warning(f"SELECTED MODE: {mode}")

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1082,7 +1082,7 @@ class KeypointControls(QWidget):
                 menu.setHidden(True)
 
     def _update_colormap(self, colormap_name):
-        for layer in self.viewer.layers:
+        for layer in self.viewer.layers.selection:
             if isinstance(layer, Points) and layer.metadata:
                 face_color_cycle_maps = build_color_cycles(
                     layer.metadata["header"], colormap_name,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -865,18 +865,10 @@ class KeypointControls(QWidget):
             return res
 
         self._display.reset()
-        logging.warning(self.color_mode)
-        logging.warning(str(keypoints.ColorMode.BODYPART))
-        logging.warning(str(keypoints.ColorMode.INDIVIDUAL))
-        logging.warning(str(self.color_mode == str(keypoints.ColorMode.BODYPART)))
-        logging.warning(str(self.color_mode == str(keypoints.ColorMode.INDIVIDUAL)))
-        logging.warning("---")
         mode = "label"
         if self.color_mode == str(keypoints.ColorMode.INDIVIDUAL):
             mode = "id"
 
-        logging.warning(f"SELECTED MODE: {mode}")
-        logging.warning("---")
         for layer in self.viewer.layers:
             if isinstance(layer, Points) and layer.metadata:
                 self._display.update_color_scheme(

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -620,7 +620,7 @@ class KeypointControls(QWidget):
         self._radio_group = self._form_mode_radio_buttons()
 
         # form color scheme display + color mode selector
-        self._color_mode_box, self._color_mode_selector = self._form_color_mode_selector()
+        self._color_grp, self._color_mode_selector = self._form_color_mode_selector()
         self._display = ColorSchemeDisplay(parent=self)
         self._color_scheme_display = self._form_color_scheme_display(self.viewer)
         self._view_scheme_cb.toggled.connect(self._show_color_scheme)
@@ -1060,7 +1060,7 @@ class KeypointControls(QWidget):
             * Sets the visibility of the "Color mode" box to True if the selected layer
                 is a multi-animal one, or False otherwise
         """
-        self._color_mode_box.setVisible(self._is_multianimal(event.value))
+        self._color_grp.setVisible(self._is_multianimal(event.value))
         menu_idx = -1
         if event.value is not None and isinstance(event.value, Points):
             menu_idx = self._layer_to_menu.get(event.value, -1)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1060,7 +1060,6 @@ class KeypointControls(QWidget):
             * Sets the visibility of the "Color mode" box to True if the selected layer
                 is a multi-animal one, or False otherwise
         """
-        logging.warning(f"COLOR MODE BOX VIS TO {self._is_multianimal(event.value)}")
         self._color_mode_box.setVisible(self._is_multianimal(event.value))
         menu_idx = -1
         if event.value is not None and isinstance(event.value, Points):
@@ -1095,15 +1094,11 @@ class KeypointControls(QWidget):
 
     @register_points_action("Change color mode")
     def cycle_through_color_modes(self, *args):
-        logging.warning("CYCLING")
-        logging.warning(f"  _active_layer_multi {self._active_layer_is_multianimal()}")
-        logging.warning(f"  color_mode {self.color_mode}")
         if (
             self._active_layer_is_multianimal()
             or self.color_mode != str(keypoints.ColorMode.BODYPART)
         ):
             self.color_mode = next(keypoints.ColorMode)
-            logging.warning(f"  UPDATING COLOR MODE TO {self.color_mode}")
 
     @property
     def label_mode(self):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1088,9 +1088,8 @@ class KeypointControls(QWidget):
                     layer.metadata["header"], colormap_name,
                 )
                 layer.metadata["face_color_cycles"] = face_color_cycle_maps
-                if self.color_mode == keypoints.ColorMode.BODYPART:
-                    face_color_prop = "label"
-                else:
+                face_color_prop = "label"
+                if self.color_mode == str(keypoints.ColorMode.INDIVIDUAL):
                     face_color_prop = "id"
 
                 layer.face_color = face_color_prop

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -865,7 +865,18 @@ class KeypointControls(QWidget):
             return res
 
         self._display.reset()
-        mode = "label" if self.color_mode == str(keypoints.ColorMode.BODYPART) else "id"
+        logging.warning(self.color_mode)
+        logging.warning(str(keypoints.ColorMode.BODYPART))
+        logging.warning(str(keypoints.ColorMode.INDIVIDUAL))
+        logging.warning(str(self.color_mode == str(keypoints.ColorMode.BODYPART)))
+        logging.warning(str(self.color_mode == str(keypoints.ColorMode.INDIVIDUAL)))
+        logging.warning("---")
+        mode = "label"
+        if self.color_mode == str(keypoints.ColorMode.BODYPART):
+            mode = "id"
+
+        logging.warning(f"SELECTED MODE: {mode}")
+        logging.warning("---")
         for layer in self.viewer.layers:
             if isinstance(layer, Points) and layer.metadata:
                 self._display.update_color_scheme(
@@ -874,7 +885,6 @@ class KeypointControls(QWidget):
                         for name, color in layer.metadata["face_color_cycles"][mode].items()
                     }
                 )
-                break
 
     def _remap_frame_indices(self, layer):
         if not self._images_meta.get("paths"):


### PR DESCRIPTION
- updates the "Color Mode" selector to only be visible for multi-animal projects (as "individual" labelling doesn't make sense in a single-animal setting)
- disables the cycling of color mode with the "F" shortcut when a multi-animal layer isn't active (so you can't change the color mode when working on a single-animal project)