### PR TITLE
Silence vispy warnings

### DIFF
--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -1,7 +1,21 @@
+import logging
 import warnings
 
 # FIXME: Circumvent the need to access window.qt_viewer
 warnings.filterwarnings("ignore", category=FutureWarning)
+
+
+class VispyWarningFilter(logging.Filter):
+    def filter(self, record):
+        ignore_messages = [
+            "delivering touch release to same window QWindow(0x0) not QWidgetWindow",
+            "skipping QEventPoint",
+        ]
+        return not any(msg in record.getMessage() for msg in ignore_messages)
+
+
+vispy_logger = logging.getLogger("vispy")
+vispy_logger.addFilter(VispyWarningFilter())
 
 try:
     from ._version import version as __version__


### PR DESCRIPTION
Remove all these ugly warnings:
```
WARNING:vispy:delivering touch release to same window QWindow(0x0) not QWidgetWindow(0x2bd848f30, name="_QtMainWindowClassWindow")
WARNING: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=789.884,646.292 gbl=789.884,646.292 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-789.884,-646.292 last=-789.884,-646.292 Δ 789.884,646.292) : no target window
WARNING:vispy:skipping QEventPoint(id=1 ts=0 pos=0,0 scn=789.884,646.292 gbl=789.884,646.292 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-789.884,-646.292 last=-789.884,-646.292 Δ 789.884,646.292) : no target window
WARNING: delivering touch release to same window QWindow(0x0) not QWidgetWindow(0x2bd848f30, name="_QtMainWindowClassWindow")
WARNING:vispy:delivering touch release to same window QWindow(0x0) not QWidgetWindow(0x2bd848f30, name="_QtMainWindowClassWindow")
WARNING: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=548.359,196.27 gbl=548.359,196.27 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-548.359,-196.27 last=-548.359,-196.27 Δ 548.359,196.27) : no target window
WARNING:vispy:skipping QEventPoint(id=1 ts=0 pos=0,0 scn=548.359,196.27 gbl=548.359,196.27 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-548.359,-196.27 last=-548.359,-196.27 Δ 548.359,196.27) : no target window
WARNING: delivering touch release to same window QWindow(0x0) not QWidgetWindow(0x2bd848f30, name="_QtMainWindowClassWindow")
WARNING:vispy:delivering touch release to same window QWindow(0x0) not QWidgetWindow(0x2bd848f30, name="_QtMainWindowClassWindow")
WARNING: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=728.55,481.413 gbl=728.55,481.413 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-728.55,-481.413 last=-728.55,-481.413 Δ 728.55,481.413) : no target window
WARNING:vispy:skipping QEventPoint(id=1 ts=0 pos=0,0 scn=728.55,481.413 gbl=728.55,481.413 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-728.55,-481.413 last=-728.55,-481.413 Δ 728.55,481.413) : no target window
```