### PR TITLE
Attempt to read colormap from config

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -175,6 +175,7 @@ def read_config(configname: str) -> List[LayerData]:
 
 
 def read_hdf(filename: str) -> List[LayerData]:
+    config_path = misc.find_project_config_path(filename)
     layers = []
     for filename in glob.iglob(filename):
         temp = pd.read_hdf(filename)
@@ -187,7 +188,11 @@ def read_hdf(filename: str) -> List[LayerData]:
             old_idx = temp.columns.to_frame()
             old_idx.insert(0, "individuals", "")
             temp.columns = pd.MultiIndex.from_frame(old_idx)
-            colormap = "viridis"
+            try:
+                cfg = _load_config(config_path)
+                colormap = cfg["colormap"]
+            except FileNotFoundError:
+                colormap = "rainbow"
         else:
             colormap = "Set3"
         if isinstance(temp.index, pd.MultiIndex):

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import os
 from enum import Enum, EnumMeta
 from itertools import cycle
+from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
 from napari.utils import colormaps
+
+
+def find_project_config_path(labeled_data_path: str) -> str:
+    return str(Path(labeled_data_path).parents[2] / "config.yaml")
 
 
 def is_latest_version():


### PR DESCRIPTION
When loading data, we'll now automatically look for a config.yaml 2 folders above to get the colormap; if not found, we fallback to "rainbow" (unlike viridis before).