### PR TITLE
Pin `numpy<2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Artificial Intelligence
     Topic :: Scientific/Engineering :: Image Processing
     Topic :: Scientific/Engineering :: Visualization
@@ -34,7 +35,7 @@ install_requires =
     matplotlib>=3.3
     napari==0.4.18
     natsort
-    numpy
+    numpy<2
     opencv-python-headless
     pandas
     pyyaml


### PR DESCRIPTION
Pins `numpy<2` to address #143.  Add Python 3.11 to the classifiers.