### PR TITLE
Update dependencies: add PySide6, constrain numpy, support Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ A napari plugin for keypoint annotation, also used within DeepLabCut!
 
 If you installed DeepLabCut[gui], this plugin is already installed. However, you can also use this as a stand-alone keypoint annotator without using DeepLabCut. Instructions below!
 
-Start by installing PySide6 with `pip install "pyside6==6.4.2"`; this is the library we now use to build GUIs.
-
 You can then install `napari-deeplabcut` via [pip]:
 
     pip install napari-deeplabcut

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Artificial Intelligence
     Topic :: Scientific/Engineering :: Image Processing
     Topic :: Scientific/Engineering :: Visualization
@@ -30,11 +31,12 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    pyside6==6.4.2
     dask-image
     matplotlib>=3.3
     napari==0.4.18
     natsort
-    numpy
+    numpy<2
     opencv-python-headless
     pandas
     pyyaml
@@ -42,7 +44,7 @@ install_requires =
     scikit-image
     scipy
     tables
-python_requires = >=3.9
+python_requires = >=3.9,<3.12
 include_package_data = True
 package_dir =
     =src
@@ -58,7 +60,6 @@ napari.manifest =
 
 [options.extras_require]
 testing =
-    pyside6==6.4.2
     pytest
     pytest-cov
     pytest-qt


### PR DESCRIPTION
This PR addresses dependency conflicts that occur in standalone installations.
- Add pyside6==6.4.2 to main dependencies, remove manual installation from README
- Add numpy<2 constraint to avoid compatibility issues (so this includes #144)
- Update python_requires to >=3.9,<3.12 and add Python 3.11 classifier