### PR TITLE
Fix `_extract_single_frame()` hdf key

### DIFF
--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -871,7 +871,7 @@ class KeypointControls(QWidget):
                     guarantee_multiindex_rows(df_prev)
                     df = pd.concat([df_prev, df])
                     df = df[~df.index.duplicated(keep="first")]
-                df.to_hdf(filepath, key="machinelabels")
+                df.to_hdf(filepath, key="df_with_missing")
 
     def _store_crop_coordinates(self, *args):
         if not (project_path := self._images_meta.get("project")):


### PR DESCRIPTION
### Description
This PR fixes an inconsistency in how machine labels are stored in _machinelabels-iter0.h5_ .

Previously:
- **Automatic extraction methods** (e.g., the _jump_ algorithm) saved labels under the key `/df_with_missing`.
- **Manual extraction method** (using napari-deeplabcut) saved labels under the key `/machinelabels`.

As a result, HDF5 files created by mixing methods could contain **two different keys** (`/df_with_missing` and `/machinelabels`), which led to errors when attempting to label new frames (see https://github.com/DeepLabCut/DeepLabCut/issues/3072).

### Change
- Updated the manual extraction method to **use** `/df_with_missing` instead of `/machinelabels`, aligning it with the automatic extraction methods.
- This ensures consistency across all extraction workflows and prevents the creation of HDF5 files with multiple, conflicting keys.

### Impact
- Existing files written with the manual method may still contain `/machinelabels`. Users encountering such files can either migrate them (by renaming the key or merging the datasets) or regenerate annotations with the fixed version.
- Going forward, all methods will consistently write to `/df_with_missing`.

### Related Issue
Fixes https://github.com/DeepLabCut/DeepLabCut/issues/3072 .