### PR TITLE
Improve CI/CD and Compatibility Across Python Versions, Suppress RuntimeWarnings

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -26,6 +26,7 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         # Important : use quotes to avoid python version being misinterpreted (e.g. 3.10 as 3.1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     matplotlib>=3.3
     napari==0.6.6
     natsort
-    numpy
+    numpy>=1.18.5,<2.0.0
     opencv-python-headless
     pandas
     pyside6>=6.4.2

--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -40,6 +40,14 @@ except ImportError:  # pragma: no cover
 # FIXME: Circumvent the need to access window.qt_viewer
 warnings.filterwarnings("ignore", category=FutureWarning)
 
+import re
+# Suppress RuntimeWarnings caused by NaN values in dataframe
+# (encountered during model-predicted labels refinement stage)
+warnings.filterwarnings(
+    "ignore",
+    category=RuntimeWarning,
+    message=re.escape("invalid value encountered in cast"),
+)
 
 class VispyWarningFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:


### PR DESCRIPTION
This pull request expands beyond the original warning suppression to bring the plugin’s test infrastructure and dependencies in line with current DeepLabCut practices and newer Python versions.

### ⚡️ Improvements and Fixes

- **Suppress NaN RuntimeWarnings**
  Suppresses the harmless
  ```
  RuntimeWarning: invalid value encountered in cast
  ```
  triggered when keypoint data contain NaNs during label refinement.
  Implemented in `__init__.py` using Python’s `warnings` module and scoped to this specific warning only.

- **CI/CD Modernization**
  - Drop testing for **Python 3.9** (PyTables no longer provides wheels for this version).
  - Add testing for **Python 3.11** and **3.12**.
  - Unbound the **PySide6** version requirement (the previously pinned `6.4.2` is unavailable on Python 3.12).
  - Restrict NumPy to `>=1.18.5,<2.0.0`, matching the main DeepLabCut repository.

- **Test Stability**
  - Fixed a teardown failure in `silently_dock_matplotlib_canvas` by returning early if the `Window` object lacks the `_qt_window` attribute after tests.
  - Updated `CycleEnumMeta.__new__` to accept `**kwargs`, ensuring compatibility with the `boundary` keyword introduced in Python 3.11.

These changes ensure clean test runs across Linux, macOS, and Windows on Python 3.10–3.12 and reduce console clutter.