### PR TITLE
Upgrade & refactor plugin

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10"]
+        python-version: [3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.10, 3.11, 3.12]
+        # Important : use quotes to avoid python version being misinterpreted (e.g. 3.10 as 3.1)
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,3 @@ venv/
 
 # written by setuptools_scm
 **/_version.py
-

--- a/.napari/DESCRIPTION.md
+++ b/.napari/DESCRIPTION.md
@@ -5,18 +5,18 @@ the functionality of your plugin. Its content will be rendered on your plugin's
 napari hub page.
 
 The sections below are given as a guide for the flow of information only, and
-are in no way prescriptive. You should feel free to merge, remove, add and 
-rename sections at will to make this document work best for your plugin. 
+are in no way prescriptive. You should feel free to merge, remove, add and
+rename sections at will to make this document work best for your plugin.
 
 # Description
 
-This should be a detailed description of the context of your plugin and its 
+This should be a detailed description of the context of your plugin and its
 intended purpose.
 
 If you have videos or screenshots of your plugin in action, you should include them
-here as well, to make them front and center for new users. 
+here as well, to make them front and center for new users.
 
-You should use absolute links to these assets, so that we can easily display them 
+You should use absolute links to these assets, so that we can easily display them
 on the hub. The easiest way to include a video is to use a GIF, for example hosted
 on imgur. You can then reference this GIF as an image.
 
@@ -59,7 +59,7 @@ anywhere, feel free to also include this information here.
 This section should go through step-by-step examples of how your plugin should be used.
 Where your plugin provides multiple dock widgets or functions, you should split these
 out into separate subsections for easy browsing. Include screenshots and videos
-wherever possible to elucidate your descriptions. 
+wherever possible to elucidate your descriptions.
 
 Ideally, this section should start with minimal examples for those who just want a
 quick overview of the plugin's functionality, but you should definitely link out to
@@ -72,8 +72,8 @@ for the majority of plugins. They will include instructions to pip install, and
 to install via napari itself.
 
 Most plugins can be installed out-of-the-box by just specifying the package requirements
-over in `setup.cfg`. However, if your plugin has any more complex dependencies, or 
-requires any additional preparation before (or after) installation, you should add 
+over in `setup.cfg`. However, if your plugin has any more complex dependencies, or
+requires any additional preparation before (or after) installation, you should add
 this information here.
 
 # Getting Help

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,24 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: check-docstring-first
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v3.2.0
     hooks:
       - id: setup-cfg-fmt
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
     hooks:
-      - id: flake8
-        additional_dependencies: [flake8-typing-imports==1.7.0]
-  - repo: https://github.com/myint/autoflake
-    rev: v1.4
-    hooks:
-      - id: autoflake
-        args: ["--in-place", "--remove-all-unused-imports"]
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 22.1.0
-    hooks:
-      - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
-    hooks:
-      - id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
+      # Run the formatter.
+      - id: ruff-format
+      # Run the linter.
+      - id: ruff-check
+        args: [--fix,--unsafe-fixes]
   - repo: https://github.com/tlambert03/napari-plugin-checks
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
       - id: napari-plugin-checks
   # https://mypy.readthedocs.io/en/stable/introduction.html

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [🛠️ DeepLabCut Installation](https://deeplabcut.github.io/DeepLabCut/docs/installation.html) |
 [🌎 Home Page](https://www.deeplabcut.org) |
 
-[![License: BSD-3](https://img.shields.io/badge/License-BSD3-blue.svg)](https://www.gnu.org/licenses/bsd3)
+[![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL%203.0-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 [![PyPI](https://img.shields.io/pypi/v/napari-deeplabcut.svg?color=green)](https://pypi.org/project/napari-deeplabcut)
 [![Python Version](https://img.shields.io/pypi/pyversions/napari-deeplabcut.svg?color=green)](https://python.org)
 [![tests](https://github.com/DeepLabCut/napari-deeplabcut/workflows/tests/badge.svg)](https://github.com/DeepLabCut/napari-deeplabcut/actions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,13 @@ write_to = "src/napari_deeplabcut/_version.py"
 
 [tool.pytest.ini_options]
 qt_api = "pyside6"
+
+[tool.ruff]
+lint.select = ["E", "F", "B", "I", "UP"]
+lint.ignore = ["E741"]
+target-version = "py310"
+fix = true
+line-length = 120
+
+[tool.uv]
+package = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,6 @@
 requires = ["setuptools", "wheel", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
-
-[tool.setuptools_scm]
-write_to = "src/napari_deeplabcut/_version.py"
-
-[tool.pytest.ini_options]
-qt_api = "pyside6"
-
 [tool.ruff]
 lint.select = ["E", "F", "B", "I", "UP"]
 lint.ignore = ["E741"]
@@ -18,3 +11,9 @@ line-length = 120
 
 [tool.uv]
 package = true
+
+[tool.setuptools_scm]
+write_to = "src/napari_deeplabcut/_version.py"
+
+[tool.pytest.ini_options]
+qt_api = "pyside6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
     numpy
     opencv-python-headless
     pandas
+    pyside6>=6.4.2
     pyyaml
     qtpy>=2.4
     scikit-image
@@ -55,7 +56,6 @@ napari.manifest =
 
 [options.extras_require]
 testing =
-    pyside6==6.4.2
     pytest
     pytest-cov
     pytest-qt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = napari-deeplabcut
+name = napari_deeplabcut
 description = napari + DeepLabCut annotation tool
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -29,7 +29,7 @@ packages = find:
 install_requires =
     dask-image
     matplotlib>=3.3
-    napari==0.4.18
+    napari==0.6.6
     natsort
     numpy
     opencv-python-headless

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,23 +1,20 @@
 [metadata]
-name = napari-deeplabcut
-description =napari + DeepLabCut annotation tool
+name = napari_deeplabcut
+description = napari + DeepLabCut annotation tool
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/DeepLabCut/napari-deeplabcut
 author = Team DeepLabCut, Lead by Jessy Lauer
 author_email = admin@deeplabcut.org
-license = BSD-3-Clause
-license_file = LICENSE
+license = LGPL-3.0
+license_files = LICENSE
 classifiers =
     Development Status :: 2 - Pre-Alpha
     Framework :: napari
     Intended Audience :: Developers
-    License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Artificial Intelligence
     Topic :: Scientific/Engineering :: Image Processing
     Topic :: Scientific/Engineering :: Visualization
@@ -42,7 +39,7 @@ install_requires =
     scikit-image
     scipy
     tables
-python_requires = >=3.9
+python_requires = >=3.10
 include_package_data = True
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = napari_deeplabcut
+name = napari-deeplabcut
 description = napari + DeepLabCut annotation tool
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -32,7 +32,7 @@ from ._writer import (  # noqa: F401 (explicit re-export via __all__)
 
 try:
     from ._version import version as __version__  # noqa: F401
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     __version__ = "unknown"
 
 # ---- Warnings & logging setup ------------------------------------------------

--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -1,33 +1,55 @@
+from __future__ import annotations
+
 import logging
 import warnings
+
+# ---- Package exports ---------------------------------------------------------
+
+# Re-export selected symbols so linters recognize them as used.
+__all__ = (
+    "get_config_reader",
+    "get_folder_parser",
+    "get_hdf_reader",
+    "get_image_reader",
+    "get_video_reader",
+    "write_hdf",
+    "write_masks",
+    "__version__",
+)
+
+# Import internal modules to populate the public API.
+from ._reader import (  # noqa: F401 (explicit re-export via __all__)
+    get_config_reader,
+    get_folder_parser,
+    get_hdf_reader,
+    get_image_reader,
+    get_video_reader,
+)
+from ._writer import (  # noqa: F401 (explicit re-export via __all__)
+    write_hdf,
+    write_masks,
+)
+
+try:
+    from ._version import version as __version__  # noqa: F401
+except Exception:  # pragma: no cover
+    __version__ = "unknown"
+
+# ---- Warnings & logging setup ------------------------------------------------
 
 # FIXME: Circumvent the need to access window.qt_viewer
 warnings.filterwarnings("ignore", category=FutureWarning)
 
 
 class VispyWarningFilter(logging.Filter):
-    def filter(self, record):
-        ignore_messages = [
+    def filter(self, record: logging.LogRecord) -> bool:
+        ignore_messages = (
             "delivering touch release to same window QWindow(0x0) not QWidgetWindow",
             "skipping QEventPoint",
-        ]
-        return not any(msg in record.getMessage() for msg in ignore_messages)
+        )
+        msg = record.getMessage()
+        return not any(needle in msg for needle in ignore_messages)
 
 
 vispy_logger = logging.getLogger("vispy")
 vispy_logger.addFilter(VispyWarningFilter())
-
-try:
-    from ._version import version as __version__
-except ImportError:  # pragma: no cover
-    __version__ = "unknown"
-
-
-from ._reader import (
-    get_hdf_reader,
-    get_image_reader,
-    get_video_reader,
-    get_folder_parser,
-    get_config_reader,
-)
-from ._writer import write_hdf, write_masks

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -75,7 +75,8 @@ def get_folder_parser(path):
     layers.extend(read_images(images))
     for file in Path(path).iterdir():
         if file.name.endswith(".h5"):
-            layers.extend(read_hdf(str(file)))  # Process all matching .h5 files
+            layers.extend(read_hdf(str(file)))
+            break # one h5 per annotated video
 
     return lambda _: layers
 
@@ -102,9 +103,9 @@ def read_images(path):
 
     # https://github.com/soft-matter/pims/issues/452
     if len(filepaths) == 1:
-        path = next(Path(path).parent.glob(Path(path).name))
-
-    return [(imread(path), params, "image")]
+        path = next(Path(path).parent.glob(Path(path).name), None)
+        if path is not None:
+            return [(imread(path), params, "image")]
 
 
 def _populate_metadata(
@@ -193,7 +194,7 @@ def read_hdf(filename: str) -> list[LayerData]:
     config_path = misc.find_project_config_path(filename)
     layers = []
     for file in Path(filename).parent.glob(Path(filename).name):
-        temp = pd.read_hdf(file)
+        temp = pd.read_hdf(str(file))
         temp = misc.merge_multiple_scorers(temp)
         header = misc.DLCHeader(temp.columns)
         temp = temp.droplevel("scorer", axis=1)

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -1,8 +1,6 @@
-import glob
 import json
-import os
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence
 
 import cv2
 import dask.array as da
@@ -45,9 +43,7 @@ def get_image_reader(path):
 
 
 def get_video_reader(path):
-    if isinstance(path, str) and any(
-        path.lower().endswith(ext) for ext in SUPPORTED_VIDEOS
-    ):
+    if isinstance(path, str) and any(path.lower().endswith(ext) for ext in SUPPORTED_VIDEOS):
         return read_video
     return None
 
@@ -63,24 +59,24 @@ def get_config_reader(path):
 
 
 def get_folder_parser(path):
-    if not os.path.isdir(path):
+    if not path or not Path(path).is_dir():
         return None
 
     layers = []
-    files = os.listdir(path)
+    files = Path(path).iterdir()
     images = ""
     for file in files:
-        if any(file.lower().endswith(ext) for ext in SUPPORTED_IMAGES):
-            images = os.path.join(path, f"*{os.path.splitext(file)[1]}")
+        if any(file.name.lower().endswith(ext) for ext in SUPPORTED_IMAGES):
+            images = str(Path(path) / f"*{Path(file.name).suffix}")
             break
     if not images:
         raise OSError(f"No supported images were found in {path}.")
 
     layers.extend(read_images(images))
     datafile = ""
-    for file in os.listdir(path):
-        if file.endswith(".h5"):
-            datafile = os.path.join(path, "*.h5")
+    for file in Path(path).iterdir():
+        if file.name.endswith(".h5"):
+            datafile = str(file)  # Use the actual file name
             break
     if datafile:
         layers.extend(read_hdf(datafile))
@@ -90,24 +86,24 @@ def get_folder_parser(path):
 
 def read_images(path):
     if isinstance(path, list):
-        root, ext = os.path.splitext(path[0])
-        path = os.path.join(os.path.dirname(root), f"*{ext}")
+        _root, ext = Path(path[0]).with_suffix("").suffixes[0], Path(path[0]).suffixes[1]
+        path = str(Path(path[0]).parent / f"*{ext}")
     # Retrieve filepaths exactly as parsed by pims
     filepaths = []
-    for filepath in glob.iglob(path):
+    for filepath in Path(path).parent.glob(Path(path).name):
         relpath = Path(filepath).parts[-3:]
-        filepaths.append(os.path.join(*relpath))
+        filepaths.append(str(Path(*relpath)))
     params = {
         "name": "images",
         "metadata": {
             "paths": natsorted(filepaths),
-            "root": os.path.split(path)[0],
+            "root": str(Path(path).parent),
         },
     }
 
     # https://github.com/soft-matter/pims/issues/452
     if len(filepaths) == 1:
-        path = glob.glob(path)[0]
+        path = next(Path(path).parent.glob(Path(path).name))
 
     return [(imread(path), params, "image")]
 
@@ -115,14 +111,14 @@ def read_images(path):
 def _populate_metadata(
     header: misc.DLCHeader,
     *,
-    labels: Optional[Sequence[str]] = None,
-    ids: Optional[Sequence[str]] = None,
-    likelihood: Optional[Sequence[float]] = None,
-    paths: Optional[List[str]] = None,
-    size: Optional[int] = 8,
-    pcutoff: Optional[float] = 0.6,
-    colormap: Optional[str] = "viridis",
-) -> Dict:
+    labels: Sequence[str] | None = None,
+    ids: Sequence[str] | None = None,
+    likelihood: Sequence[float] | None = None,
+    paths: list[str] | None = None,
+    size: int | None = 8,
+    pcutoff: float | None = 0.6,
+    colormap: str | None = "viridis",
+) -> dict:
     if labels is None:
         labels = header.bodyparts
     if ids is None:
@@ -143,10 +139,10 @@ def _populate_metadata(
         "face_color_cycle": face_color_cycle_maps[face_color_prop],
         "face_color": face_color_prop,
         "face_colormap": colormap,
-        "edge_color": "valid",
-        "edge_color_cycle": ["black", "red"],
-        "edge_width": 0,
-        "edge_width_is_relative": False,
+        "border_color": "valid",
+        "border_color_cycle": ["black", "red"],
+        "border_width": 0,
+        "border_width_is_relative": False,
         "size": size,
         "metadata": {
             "header": header,
@@ -173,7 +169,7 @@ def _load_config(config_path: str):
         return yaml.safe_load(file)
 
 
-def read_config(configname: str) -> List[LayerData]:
+def read_config(configname: str) -> list[LayerData]:
     config = _load_config(configname)
     header = misc.DLCHeader.from_config(config)
     metadata = _populate_metadata(
@@ -186,7 +182,7 @@ def read_config(configname: str) -> List[LayerData]:
     metadata["name"] = f"CollectedData_{config['scorer']}"
     metadata["ndim"] = 3
     metadata["property_choices"] = metadata.pop("properties")
-    metadata["metadata"]["project"] = os.path.dirname(configname)
+    metadata["metadata"]["project"] = str(Path(configname).parent)
     conversion_tables = config.get("SuperAnimalConversionTables")
     if conversion_tables is not None:
         super_animal, table = conversion_tables.popitem()
@@ -194,11 +190,11 @@ def read_config(configname: str) -> List[LayerData]:
     return [(None, metadata, "points")]
 
 
-def read_hdf(filename: str) -> List[LayerData]:
+def read_hdf(filename: str) -> list[LayerData]:
     config_path = misc.find_project_config_path(filename)
     layers = []
-    for filename in glob.iglob(filename):
-        temp = pd.read_hdf(filename)
+    for file in Path(filename).parent.glob(Path(filename).name):
+        temp = pd.read_hdf(file)
         temp = misc.merge_multiple_scorers(temp)
         header = misc.DLCHeader(temp.columns)
         temp = temp.droplevel("scorer", axis=1)
@@ -216,7 +212,7 @@ def read_hdf(filename: str) -> List[LayerData]:
         else:
             colormap = "Set3"
         if isinstance(temp.index, pd.MultiIndex):
-            temp.index = [os.path.join(*row) for row in temp.index]
+            temp.index = [str(Path(*row)) for row in temp.index]
         df = (
             temp.stack(["individuals", "bodyparts"])
             .reindex(header.individuals, level="individuals")
@@ -244,8 +240,8 @@ def read_hdf(filename: str) -> List[LayerData]:
             paths=list(paths2inds),
             colormap=colormap,
         )
-        metadata["name"] = os.path.split(filename)[1].split(".")[0]
-        metadata["metadata"]["root"] = os.path.split(filename)[0]
+        metadata["name"] = Path(filename).stem
+        metadata["metadata"]["root"] = str(Path(filename).parent)
         # Store file name in case the layer's name is edited by the user
         metadata["metadata"]["name"] = metadata["name"]
         layers.append((data, metadata, "points"))
@@ -254,7 +250,7 @@ def read_hdf(filename: str) -> List[LayerData]:
 
 class Video:
     def __init__(self, video_path):
-        if not os.path.isfile(video_path):
+        if not Path(video_path).is_file():
             raise ValueError(f'Video path "{video_path}" does not point to a file.')
 
         self.path = video_path
@@ -308,21 +304,16 @@ def read_video(filename: str, opencv: bool = True):
         try:
             stream = PyAVReaderIndexed(filename)
         except ImportError:
-            raise ImportError("`pip install av` to use the PyAV video reader.")
+            raise ImportError("`pip install av` to use the PyAV video reader.") from None
 
         shape = stream.frame_shape
         lazy_imread = delayed(stream.get_frame)
 
-    movie = da.stack(
-        [
-            da.from_delayed(lazy_imread(i), shape=shape, dtype=np.uint8)
-            for i in range(len(stream))
-        ]
-    )
+    movie = da.stack([da.from_delayed(lazy_imread(i), shape=shape, dtype=np.uint8) for i in range(len(stream))])
     elems = list(Path(filename).parts)
     elems[-2] = "labeled-data"
-    elems[-1] = elems[-1].split(".")[0]
-    root = os.path.join(*elems)
+    elems[-1] = Path(elems[-1]).stem + Path(filename).suffix
+    root = str(Path(*elems))
     params = {
         "name": filename,
         "metadata": {

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -86,7 +86,10 @@ def get_folder_parser(path):
 
 def read_images(path):
     if isinstance(path, list):
-        _root, ext = Path(path[0]).with_suffix("").suffixes[0], Path(path[0]).suffixes[1]
+        _root, ext = (
+            Path(path[0]).with_suffix("").suffixes[0],
+            Path(path[0]).suffixes[1],
+        )
         path = str(Path(path[0]).parent / f"*{ext}")
     # Retrieve filepaths exactly as parsed by pims
     filepaths = []

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -104,8 +104,9 @@ def read_images(path):
     # https://github.com/soft-matter/pims/issues/452
     if len(filepaths) == 1:
         path = next(Path(path).parent.glob(Path(path).name), None)
-        if path is not None:
-            return [(imread(path), params, "image")]
+        if path is None:
+            return []
+    return [(imread(path), params, "image")]
 
 
 def _populate_metadata(

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -105,7 +105,7 @@ def read_images(path):
     if len(filepaths) == 1:
         path = next(Path(path).parent.glob(Path(path).name), None)
         if path is None:
-            return []
+            raise FileNotFoundError(f"No files found for pattern: {path}")
     return [(imread(path), params, "image")]
 
 

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -76,7 +76,7 @@ def get_folder_parser(path):
     for file in Path(path).iterdir():
         if file.name.endswith(".h5"):
             layers.extend(read_hdf(str(file)))
-            break # one h5 per annotated video
+            break  # one h5 per annotated video
 
     return lambda _: layers
 

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -4,6 +4,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import pytest
+from qtpy.QtWidgets import QDockWidget
 from skimage.io import imsave
 
 from napari_deeplabcut import _writer, keypoints
@@ -33,7 +34,8 @@ def viewer(make_napari_viewer_proxy):
         # proactively close dock widgets to drop any lingering Qt refs
         try:
             # close all added dock widgets (if any) before viewer is closed
-            for dw in list(viewer.window._qt_window.findChildren(type(viewer.window._qt_window))):
+            # for dw in list(viewer.window._qt_window.findChildren(type(viewer.window._qt_window))):
+            for dw in list(viewer.window._qt_window.findChildren(QDockWidget)):
                 # defensive: some Qt objects can be None during shutdown
                 if hasattr(dw, "close"):
                     dw.close()

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from skimage.io import imsave
 
 from napari_deeplabcut import _writer, keypoints
+
 # os.environ["NAPARI_DLC_HIDE_TUTORIAL"] = "True" # no longer on by default
 
 os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
@@ -66,7 +67,6 @@ def points(tmp_path_factory, viewer, fake_keypoints, qtbot):
     layer = viewer.open(output_path, plugin="napari-deeplabcut")[0]
 
     return layer
-
 
 
 @pytest.fixture

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -23,7 +23,8 @@ def viewer(make_napari_viewer_proxy):
     viewer = make_napari_viewer_proxy()
 
     # Safer : explicitly add the dock widgets
-    keypoints_dock_widget, keypoints_plugin_widget = viewer.window.add_plugin_dock_widget(
+    #  keypoints_dock_widget, keypoints_plugin_widget
+    _, _ = viewer.window.add_plugin_dock_widget(
         "napari-deeplabcut",
         "Keypoint controls",
     )
@@ -34,12 +35,12 @@ def viewer(make_napari_viewer_proxy):
         # proactively close dock widgets to drop any lingering Qt refs
         try:
             # close all added dock widgets (if any) before viewer is closed
-            # for dw in list(viewer.window._qt_window.findChildren(type(viewer.window._qt_window))):
             for dw in list(viewer.window._qt_window.findChildren(QDockWidget)):
                 # defensive: some Qt objects can be None during shutdown
                 if hasattr(dw, "close"):
                     dw.close()
         except Exception:
+            # bail if viewer or its window is already gone
             pass
 
 

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -22,7 +22,11 @@ os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
 def viewer(make_napari_viewer_proxy):
     viewer = make_napari_viewer_proxy()
 
-    # Safer : explicitly add the dock widgets
+    # Explicitly add the dock widgets
+    # NOTE The old approach of opening every plugin menu
+    # with "napari-deeplabcut" in the name is not reliable
+    # and is not recommended.
+
     #  keypoints_dock_widget, keypoints_plugin_widget
     _, _ = viewer.window.add_plugin_dock_widget(
         "napari-deeplabcut",

--- a/src/napari_deeplabcut/_tests/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/test_keypoints.py
@@ -5,31 +5,39 @@ from napari_deeplabcut import keypoints
 
 def test_store_advance_step(store):
     assert store.current_step == 0
+    # _advance_step() always moves the viewer one frame forward (with wrap-around)
     store._advance_step(event=None)
     assert store.current_step == 1
 
 
 def test_store_labels(store, fake_keypoints):
     assert store.n_steps == fake_keypoints.shape[0]
+    # Labels are derived from the header (bodyparts level); this asserts the store mirrors header order
     assert store.labels == list(fake_keypoints.columns.get_level_values("bodyparts").unique())
 
 
 def test_store_find_first_unlabeled_frame(store):
+    # With all frames annotated, finder should pick the "last" frame by convention
     store._find_first_unlabeled_frame(event=None)
     assert store.current_step == store.n_steps - 1
-    # Remove a frame to test whether it is correctly found
+
+    # Remove all annotations for a specific frame -> it becomes the first "unlabeled" frame
     ind_to_remove = 2
     data = store.layer.data
     store.layer.data = data[data[:, 0] != ind_to_remove]
     store._find_first_unlabeled_frame(event=None)
+    # Expect the navigation to jump to the first frame missing annotations
     assert store.current_step == ind_to_remove
 
 
 def test_store_keypoints(store, fake_keypoints):
     annotated_keypoints = store.annotated_keypoints
+    # Each frame has one keypoint per (bodypart, individual) pair; sanity-check the count and ordering
     assert len(annotated_keypoints) == fake_keypoints.shape[1] // 2
     assert annotated_keypoints[0].id == "animal_0"
     assert annotated_keypoints[-1].id == "animal_1"
+
+    # Cycling through keypoints does not depend on selection state and should respect the header order
     kpt = keypoints.Keypoint(label="kpt_0", id="animal_0")
     next_kpt = keypoints.Keypoint(label="kpt_1", id="animal_0")
     store.current_keypoint = kpt
@@ -46,35 +54,55 @@ def test_point_resize(qtbot, viewer, points):
     layer = viewer.layers[0]
     controls = keypoints.QtPointsControls(layer)
     qtbot.addWidget(controls)
-
     new_size = 10
     controls.changeCurrentSize(new_size)
     np.testing.assert_array_equal(points.size, new_size)
 
 
 def test_add_unannotated(store):
+    # LOOP mode: after a successful add/move, the viewer advances to the next frame
     store.layer.metadata["controls"].label_mode = "loop"
+
+    # Make frame 1 unannotated by removing all its rows from the layer data
     ind_to_remove = 1
     data = store.layer.data
     store.layer.data = data[data[:, 0] != ind_to_remove]
+
+    # Navigate to that now-unannotated frame; annotated_keypoints must be empty by definition
     store.viewer.dims.set_current_step(0, ind_to_remove)
     assert not store.annotated_keypoints
+
     n_points = store.layer.data.shape[0]
+
+    # IMPORTANT: pass coord with the CURRENT frame index so we truly add to the frame we're on
+    # Data layout is (frame, y, x)
     keypoints._add(store, coord=(ind_to_remove, 1, 1))
-    # One point added
+
+    # Exactly one new point should be appended
     assert store.layer.data.shape[0] == n_points + 1
-    # The viewer should have advanced to the NEXT frame in LOOP mode
+
+    # LOOP mode advances the viewer one step forward after the add
     expected_next = (ind_to_remove + 1) % store.n_steps
     assert store.current_step == expected_next
-    # Verify that a point was actually added to frame 1
+
+    # Sanity check: verify a point now exists on the formerly unannotated frame
     assert np.any(store.layer.data[:, 0] == ind_to_remove)
 
 
 def test_add_quick(store):
+    # QUICK mode: if the keypoint for the current frame already exists, it is MOVED; otherwise, it is ADDED.
+    # QUICK does NOT auto-advance the viewer.
     store.layer.metadata["controls"].label_mode = "quick"
+
+    # Choose a specific keypoint to act on; this determines which (label, id) is added/moved
     store.current_keypoint = store._keypoints[0]
+
+    # Add (or move) at the CURRENT frame; coord uses (frame, y, x)
     coord = store.current_step, -1, -1
     keypoints._add(store, coord=coord)
+
+    # After QUICK add/move, the point for the current frame should match the requested coord
+    # (If it existed, it was moved; if not, it was added.)
     np.testing.assert_array_equal(
         store.layer.data[store.current_step],
         coord,

--- a/src/napari_deeplabcut/_tests/test_misc.py
+++ b/src/napari_deeplabcut/_tests/test_misc.py
@@ -1,8 +1,10 @@
-import numpy as np
 import os
+
+import numpy as np
 import pandas as pd
 import pytest
-from napari_deeplabcut import misc, _reader
+
+from napari_deeplabcut import _reader, misc
 
 
 def test_unsorted_unique_numeric():
@@ -21,7 +23,7 @@ def test_encode_categories():
     categories = list("abcdabcd")
     inds, map_ = misc.encode_categories(categories, return_map=True)
     assert list(inds) == [0, 1, 2, 3, 0, 1, 2, 3]
-    assert map_ == dict(zip(list("abcd"), range(4)))
+    assert map_ == dict(zip(list("abcd"), range(4), strict=False))
     inds = misc.encode_categories(categories, return_map=False)
 
 
@@ -65,9 +67,7 @@ def test_to_os_dir_sep_invalid():
 
 
 def test_guarantee_multiindex_rows():
-    fake_index = [
-        f"labeled-data/subfolder_{i}/image_{j}" for i in range(3) for j in range(10)
-    ]
+    fake_index = [f"labeled-data/subfolder_{i}/image_{j}" for i in range(3) for j in range(10)]
     df = pd.DataFrame(index=fake_index)
     misc.guarantee_multiindex_rows(df)
     assert isinstance(df.index, pd.MultiIndex)

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
 import pytest
-from napari_deeplabcut import _reader
 from skimage.io import imsave
+
+from napari_deeplabcut import _reader
 
 
 @pytest.mark.parametrize("ext", _reader.SUPPORTED_IMAGES)
@@ -63,9 +64,7 @@ def test_read_config(config_path):
 
 def test_read_hdf_old_index(tmp_path_factory, fake_keypoints):
     path = str(tmp_path_factory.mktemp("folder") / "data.h5")
-    old_index = [
-        f"labeled-data/video/img{i}.png" for i in range(fake_keypoints.shape[0])
-    ]
+    old_index = [f"labeled-data/video/img{i}.png" for i in range(fake_keypoints.shape[0])]
     fake_keypoints.index = old_index
     fake_keypoints.to_hdf(path, key="data")
     layers = _reader.read_hdf(path)

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -13,7 +13,6 @@ def test_guess_continuous():
 
 def test_keypoint_controls(viewer, qtbot):
     controls = _widgets.KeypointControls(viewer)
-    qtbot.addWidget(controls)
     controls.label_mode = "loop"
     assert controls._radio_group.checkedButton().text() == "Loop"
     controls.cycle_through_label_modes()

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -7,8 +7,9 @@ from napari_deeplabcut import _widgets
 
 
 def test_guess_continuous():
-    assert _widgets.guess_continuous(np.array([0.0]))
-    assert not _widgets.guess_continuous(np.array(list("abc")))
+    # Hack: guess_continuous overrides napari's default logic to avoid misclassifying categorical properties
+    assert _widgets.guess_continuous(np.array([0.0]))  # Floats → continuous
+    assert not _widgets.guess_continuous(np.array(list("abc")))  # Strings → categorical
 
 
 def test_keypoint_controls(viewer, qtbot):
@@ -22,6 +23,7 @@ def test_keypoint_controls(viewer, qtbot):
 def test_save_layers(viewer, points):
     controls = _widgets.KeypointControls(viewer)
     viewer.layers.selection.add(points)
+    # _save_layers_dialog bypasses napari's Save dialog for Points layers (used in headless tests)
     _widgets._save_layers_dialog(controls)
 
 
@@ -40,22 +42,20 @@ def test_extract_single_frame(viewer, images):
 
 def test_store_crop_coordinates(viewer, images, config_path):
     viewer.layers.selection.add(images)
-    _ = viewer.add_shapes(
-        np.random.random((4, 3)),
-        shape_type="rectangle",
-    )
+    _ = viewer.add_shapes(np.random.random((4, 3)), shape_type="rectangle")
     controls = _widgets.KeypointControls(viewer)
     controls._images_meta = {
         "name": "fake_video",
         "project": os.path.dirname(config_path),
     }
+    # Stores crop coordinates from a rectangle shape into the project's config.yaml
     controls._store_crop_coordinates()
 
 
 def test_toggle_face_color(viewer, points):
     viewer.layers.selection.add(points)
     view = viewer.window._qt_viewer
-    # By default, points are colored by individual with multi-animal data
+    # Shortcut 'F' toggles coloring between "id" and "label" for multi-animal datasets
     assert points._face.color_properties.name == "id"
     view.canvas.events.key_press(key=keys.Key("F"))
     assert points._face.color_properties.name == "label"
@@ -66,6 +66,7 @@ def test_toggle_face_color(viewer, points):
 def test_toggle_edge_color(viewer, points):
     viewer.layers.selection.add(points)
     view = viewer.window._qt_viewer
+    # Shortcut 'E' toggles border width between 0 and 2
     np.testing.assert_array_equal(points.border_width, 0)
     view.canvas.events.key_press(key=keys.Key("E"))
     np.testing.assert_array_equal(points.border_width, 2)
@@ -73,39 +74,105 @@ def test_toggle_edge_color(viewer, points):
 
 def test_dropdown_menu(qtbot):
     widget = _widgets.DropdownMenu(list("abc"))
-    widget.update_to("c")
-    assert widget.currentText() == "c"
-    widget.reset()
-    assert widget.currentText() == "a"
     qtbot.add_widget(widget)
+    widget.update_to("c")  # Ensure update_to selects the correct item
+    assert widget.currentText() == "c"
+    widget.reset()  # Reset should always select the first item
+    assert widget.currentText() == "a"
 
 
-def test_keypoints_dropdown_menu(store):
+def test_keypoints_dropdown_menu_selection_updates_store(store, qtbot):
     widget = _widgets.KeypointsDropdownMenu(store)
-    assert "id" in widget.menus
-    assert "label" in widget.menus
+    qtbot.add_widget(widget)
+    id_menu = widget.menus.get("id")
     label_menu = widget.menus["label"]
-    assert label_menu.currentText() == "kpt_0"
-    widget.update_menus(event=None)
-    assert label_menu.currentText() == "kpt_0"
-    widget.refresh_label_menu("id_0")
-    assert label_menu.count() == 0
+
+    # If multi-animal, switch ID and ensure the store's id updates
+    if id_menu and id_menu.count() > 1:
+        id_menu.setCurrentIndex(1)
+        assert store.current_id == id_menu.currentText()
+
+    # Switch label and ensure the store's label updates
+    if label_menu.count() > 1:
+        label_menu.setCurrentIndex(1)
+        assert store.current_label == label_menu.currentText()
 
 
-def test_keypoints_dropdown_menu_smart_reset(store):
+def test_keypoints_dropdown_menu_single_animal_has_no_id_menu(single_animal_store, qtbot):
+    widget = _widgets.KeypointsDropdownMenu(single_animal_store)
+    qtbot.add_widget(widget)
+    assert "id" not in widget.menus
+    assert "label" in widget.menus
+    assert widget.menus["label"].count() > 0
+
+
+def test_keypoints_dropdown_menu(store, qtbot):
     widget = _widgets.KeypointsDropdownMenu(store)
+    qtbot.add_widget(widget)
+    # Menus for both "id" and "label" should exist; label menu reflects current keypoint
+    # This confirms we have multi-animal data
+    id_menu = widget.menus["id"]
+    label_menu = widget.menus["label"]
+    # Baseline: labels for the first ID
+    first_id = store.ids[0]
+    expected_labels_first = widget.id2label[first_id]
+    assert [label_menu.itemText(i) for i in range(label_menu.count())] == expected_labels_first
+
+    # Switch to a different valid ID (if present) and ensure labels update accordingly
+    if len(store.ids) > 1:
+        # Change selection in the actual menu; this triggers refresh_label_menu via signal
+        id_menu.setCurrentIndex(1)
+        second_id = id_menu.currentText()
+        expected_labels_second = widget.id2label[second_id]
+        assert [label_menu.itemText(i) for i in range(label_menu.count())] == expected_labels_second
+
+
+def test_keypoints_dropdown_menu_unknown_id_yields_empty_list(store):
+    # If an invalid ID is selected, the label menu should be empty
+    widget = _widgets.KeypointsDropdownMenu(store)
+    label_menu = widget.menus["label"]
+    widget.refresh_label_menu("__NON_EXISTENT_ID__")
+    assert label_menu.count() == 0  # defaultdict(list) → no labels
+
+
+def test_keypoints_dropdown_menu_updates_from_store_current_properties(store, qtbot):
+    widget = _widgets.KeypointsDropdownMenu(store)
+    qtbot.add_widget(widget)
+    id_menu = widget.menus.get("id")
+    label_menu = widget.menus["label"]
+
+    # Pick a valid keypoint (label/id pair) and set it as current
+    target = store._keypoints[min(2, len(store._keypoints) - 1)]
+    store.current_keypoint = target
+
+    # Simulate event callback
+    widget.update_menus(event=None)
+
+    if id_menu:
+        assert id_menu.currentText() == target.id
+    assert label_menu.currentText() == target.label
+
+
+def test_keypoints_dropdown_menu_smart_reset(store, qtbot):
+    widget = _widgets.KeypointsDropdownMenu(store)
+    qtbot.add_widget(widget)
     label_menu = widget.menus["label"]
     label_menu.update_to("kpt_2")
     widget._locked = True
     widget.smart_reset(event=None)
+    # Locked state prevents reset; current selection remains unchanged
     assert label_menu.currentText() == "kpt_2"
     widget._locked = False
+    # Unlocked: smart_reset picks the first unlabeled keypoint (or defaults to first)
     widget.smart_reset(event=None)
     assert label_menu.currentText() == "kpt_0"
 
 
-def test_color_pair():
+def test_color_pair(qtbot):
     pair = _widgets.LabelPair(color="pink", name="kpt", parent=None)
+    qtbot.add_widget(pair)
+    # LabelPair couples a color swatch with a clickable label
+    # Ensure setters update both UI and tooltip
     assert pair.part_name == "kpt"
     assert pair.color == "pink"
     pair.color = "orange"
@@ -115,10 +182,11 @@ def test_color_pair():
 
 def test_color_scheme_display(qtbot):
     widget = _widgets.ColorSchemeDisplay(None)
+    qtbot.add_widget(widget)
     widget._build()
+    # Initially empty: no color scheme entries and no layout widgets
     assert not widget.scheme_dict
     assert not widget._container.layout().count()
     widget.add_entry("keypoint", "red")
     assert widget.scheme_dict["keypoint"] == "red"
     assert widget._container.layout().count() == 1
-    qtbot.add_widget(widget)

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -1,7 +1,9 @@
-import numpy as np
 import os
-from napari_deeplabcut import _widgets
+
+import numpy as np
 from vispy import keys
+
+from napari_deeplabcut import _widgets
 
 
 def test_guess_continuous():
@@ -9,12 +11,13 @@ def test_guess_continuous():
     assert not _widgets.guess_continuous(np.array(list("abc")))
 
 
-def test_keypoint_controls(viewer):
+def test_keypoint_controls(viewer, qtbot):
     controls = _widgets.KeypointControls(viewer)
+    qtbot.addWidget(controls)
     controls.label_mode = "loop"
-    assert controls._radio_group.checkedButton().text() == "loop"
+    assert controls._radio_group.checkedButton().text() == "Loop"
     controls.cycle_through_label_modes()
-    assert controls._radio_group.checkedButton().text() == "sequential"
+    assert controls._radio_group.checkedButton().text() == "Sequential"
 
 
 def test_save_layers(viewer, points):
@@ -64,9 +67,9 @@ def test_toggle_face_color(viewer, points):
 def test_toggle_edge_color(viewer, points):
     viewer.layers.selection.add(points)
     view = viewer.window._qt_viewer
-    np.testing.assert_array_equal(points.edge_width, 0)
+    np.testing.assert_array_equal(points.border_width, 0)
     view.canvas.events.key_press(key=keys.Key("E"))
-    np.testing.assert_array_equal(points.edge_width, 2)
+    np.testing.assert_array_equal(points.border_width, 2)
 
 
 def test_dropdown_menu(qtbot):
@@ -83,9 +86,9 @@ def test_keypoints_dropdown_menu(store):
     assert "id" in widget.menus
     assert "label" in widget.menus
     label_menu = widget.menus["label"]
-    label_menu.currentText() == "kpt_0"
+    assert label_menu.currentText() == "kpt_0"
     widget.update_menus(event=None)
-    label_menu.currentText() == "kpt_2"
+    assert label_menu.currentText() == "kpt_0"
     widget.refresh_label_menu("id_0")
     assert label_menu.count() == 0
 

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -75,7 +75,8 @@ def test_toggle_edge_color(viewer, points):
 def test_dropdown_menu(qtbot):
     widget = _widgets.DropdownMenu(list("abc"))
     qtbot.add_widget(widget)
-    widget.update_to("c")  # Ensure update_to selects the correct item
+    # Ensure update_to selects the correct item
+    widget.update_to("c")
     assert widget.currentText() == "c"
     widget.reset()  # Reset should always select the first item
     assert widget.currentText() == "a"

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -735,13 +735,6 @@ class KeypointControls(QWidget):
             if self._mpl_docked:
                 self._matplotlib_canvas.hide()
 
-    # def _show_matplotlib_canvas(self, state):
-    #     if Qt.CheckState(state) == Qt.CheckState.Checked:
-    #         self._matplotlib_canvas.show()
-    #         self.viewer.window._qt_window.update()
-    #     else:
-    #         self._matplotlib_canvas.hide()
-
     @cached_property
     def settings(self):
         return QSettings()
@@ -1135,6 +1128,8 @@ class KeypointControls(QWidget):
             # Hide the color pickers, as colormaps are strictly defined by users
             controls = self.viewer.window.qt_viewer.dockLayerControls
             point_controls = controls.widget().widgets[layer]
+            # Attempt to hide several napari UI elements.
+            # To avoid potential breakage, we pass if they don't exist.
             try:
                 face_color_controls = point_controls._face_color_control.face_color_edit
                 face_color_label = point_controls._face_color_control.face_color_label

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -434,7 +434,7 @@ class KeypointMatplotlibCanvas(QWidget):
         """
         theme = napari.utils.theme.get_theme(
             self.viewer.theme,
-            # as_dict=False # deprecated in napari > 0.6.6
+            # as_dict=False # deprecated as of napari 0.6.6
         )
         _, _, bg_lightness = theme.background.as_hsl_tuple()
         return bg_lightness > 0.5
@@ -543,7 +543,8 @@ class KeypointMatplotlibCanvas(QWidget):
                 # if less than 50 frames, set max to min to avoid slider issues
                 if n_frames < self.slider.minimum():
                     self.slider.setMaximum(self.slider.minimum())
-                self.slider.setMaximum(n_frames - 1)
+                else:
+                    self.slider.setMaximum(n_frames - 1)
                 break
 
 
@@ -619,14 +620,14 @@ class KeypointControls(QWidget):
 
         self._mpl_docked = False
         self._matplotlib_canvas = KeypointMatplotlibCanvas(self.viewer)
-        self._matplotlib_cb = QCheckBox("Show trajectories", parent=self)
-        self._matplotlib_cb.setToolTip("Toggle to see trajectories in a t-y plot outside of the main video viewer")
-        self._matplotlib_cb.stateChanged.connect(self._show_matplotlib_canvas)
-        self._matplotlib_cb.setChecked(False)
-        self._matplotlib_cb.setEnabled(False)
+        self._show_traj_plot_cb = QCheckBox("Show trajectories", parent=self)
+        self._show_traj_plot_cb.setToolTip("Toggle to see trajectories in a t-y plot outside of the main video viewer")
+        self._show_traj_plot_cb.stateChanged.connect(self._show_matplotlib_canvas)
+        self._show_traj_plot_cb.setChecked(False)
+        self._show_traj_plot_cb.setEnabled(False)
         self._view_scheme_cb = QCheckBox("Show color scheme", parent=self)
 
-        grid.addWidget(self._matplotlib_cb, 0, 0)
+        grid.addWidget(self._show_traj_plot_cb, 0, 0)
         grid.addWidget(self._trail_cb, 1, 0)
         grid.addWidget(self._view_scheme_cb, 2, 0)
 
@@ -734,6 +735,13 @@ class KeypointControls(QWidget):
             if self._mpl_docked:
                 self._matplotlib_canvas.hide()
 
+    # def _show_matplotlib_canvas(self, state):
+    #     if Qt.CheckState(state) == Qt.CheckState.Checked:
+    #         self._matplotlib_canvas.show()
+    #         self.viewer.window._qt_window.update()
+    #     else:
+    #         self._matplotlib_canvas.hide()
+
     @cached_property
     def settings(self):
         return QSettings()
@@ -840,13 +848,6 @@ class KeypointControls(QWidget):
             self._trails.visible = True
         elif self._trails is not None:
             self._trails.visible = False
-
-    def _show_matplotlib_canvas(self, state):
-        if Qt.CheckState(state) == Qt.CheckState.Checked:
-            self._matplotlib_canvas.show()
-            self.viewer.window._qt_window.update()
-        else:
-            self._matplotlib_canvas.hide()
 
     def _form_video_action_menu(self):
         group_box = QGroupBox("Video")
@@ -1129,7 +1130,7 @@ class KeypointControls(QWidget):
             self._radio_box.setEnabled(True)
             self._color_grp.setEnabled(True)
             self._trail_cb.setEnabled(True)
-            self._matplotlib_cb.setEnabled(True)
+            self._show_traj_plot_cb.setEnabled(True)
 
             # Hide the color pickers, as colormaps are strictly defined by users
             controls = self.viewer.window.qt_viewer.dockLayerControls
@@ -1182,7 +1183,7 @@ class KeypointControls(QWidget):
                 menu.destroy()
             self._layer_to_menu = {}
             self._trail_cb.setEnabled(False)
-            self._matplotlib_cb.setEnabled(False)
+            self._show_traj_plot_cb.setEnabled(False)
             self.last_saved_label.hide()
         elif isinstance(layer, Image):
             self._images_meta = dict()
@@ -1191,7 +1192,7 @@ class KeypointControls(QWidget):
                 self.video_widget.setVisible(False)
         elif isinstance(layer, Tracks):
             self._trail_cb.setChecked(False)
-            self._matplotlib_cb.setChecked(False)
+            self._show_traj_plot_cb.setChecked(False)
             self._trails = None
 
     def on_active_layer_change(self, event) -> None:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -381,7 +381,7 @@ class KeypointMatplotlibCanvas(QWidget):
         self.slider.setMinimum(50)
         self.slider.setMaximum(10000)
         self.slider.setValue(50)
-        self.slider.setToolTip("Adjust the window size of frames to display around the current frame")
+        self.slider.setToolTip("Adjust the range of frames to display around the current frame")
         self.slider.setTickPosition(QSlider.TicksBelow)
         self.slider.setTickInterval(50)
         self.slider_value = QLabel(str(self.slider.value()))
@@ -412,7 +412,7 @@ class KeypointMatplotlibCanvas(QWidget):
         self.update_plot_range(Event(type_name="", value=[self.viewer.dims.current_step[0]]))
 
         self.viewer.layers.events.inserted.connect(self._load_dataframe)
-        self.viewer.dims.events.range.connect(self.update_slider_max)
+        self.viewer.dims.events.range.connect(self._update_slider_max)
         self._lines = {}
 
     def on_doubleclick(self, event):
@@ -535,7 +535,7 @@ class KeypointMatplotlibCanvas(QWidget):
 
         self._refresh_canvas(value)
 
-    def update_slider_max(self, event):
+    def _update_slider_max(self, event):
         """Update the slider's maximum value based on the number of frames in the data."""
         for layer in self.viewer.layers:
             if isinstance(layer, Image) and len(layer.data.shape) >= 3:
@@ -1241,8 +1241,8 @@ class KeypointControls(QWidget):
     def label_mode(self, mode: str | keypoints.LabelMode):
         self._label_mode = keypoints.LabelMode(mode)
         self.viewer.status = self.label_mode
-        mode_ = str(mode)
-        if mode_ == "loop":
+        mode_ = str(mode).lower()
+        if mode_ == keypoints.LabelMode.LOOP.value.lower():
             for menu in self._menus:
                 menu._locked = True
         else:
@@ -1272,7 +1272,7 @@ class KeypointControls(QWidget):
                 layer.events.face_color()
 
         for btn in self._color_mode_selector.buttons():
-            if btn.text() == str(mode):
+            if btn.text().lower() == str(mode).lower():
                 btn.setChecked(True)
                 break
 

--- a/src/napari_deeplabcut/keypoints.py
+++ b/src/napari_deeplabcut/keypoints.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
+from collections.abc import Sequence
 from enum import auto
-from typing import List, Sequence
 
 import numpy as np
 from napari._qt.layer_controls.qt_points_controls import QtPointsControls
@@ -77,8 +77,7 @@ TOOLTIPS = {
     "clicking to add an already annotated point has no effect.",
     "QUICK": "Similar to SEQUENTIAL, but trying to add an already\n"
     "annotated point actually moves it to the cursor location.",
-    "LOOP": "The currently selected point is placed frame after frame,\n"
-    "before wrapping at the end to frame 1, etc.",
+    "LOOP": "The currently selected point is placed frame after frame,\nbefore wrapping at the end to frame 1, etc.",
 }
 
 
@@ -113,11 +112,11 @@ class KeypointStore:
         return self.viewer.dims.nsteps[0]
 
     @property
-    def annotated_keypoints(self) -> List[Keypoint]:
+    def annotated_keypoints(self) -> list[Keypoint]:
         mask = self.current_mask
         labels = self.layer.properties["label"][mask]
         ids = self.layer.properties["id"][mask]
-        return [Keypoint(label, id_) for label, id_ in zip(labels, ids)]
+        return [Keypoint(label, id_) for label, id_ in zip(labels, ids, strict=False)]
 
     @property
     def current_mask(self) -> Sequence[bool]:
@@ -148,7 +147,7 @@ class KeypointStore:
             self.current_keypoint = self._keypoints[ind]
 
     @property
-    def labels(self) -> List[str]:
+    def labels(self) -> list[str]:
         return self.layer.metadata["header"].bodyparts
 
     @property
@@ -163,7 +162,7 @@ class KeypointStore:
             self.layer.current_properties = current_properties
 
     @property
-    def ids(self) -> List[str]:
+    def ids(self) -> list[str]:
         return self.layer.metadata["header"].individuals
 
     @property

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -189,7 +189,7 @@ class DLCHeader:
 
 class CycleEnumMeta(EnumMeta):
     def __new__(metacls, cls, bases, classdict, **kwargs):
-        enum_ = super().__new__(metacls, cls, bases, classdict)
+        enum_ = super().__new__(metacls, cls, bases, classdict, **kwargs)
         enum_._cycle = cycle(enum_._member_map_[name] for name in enum_._member_names_)
         return enum_
 

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from enum import Enum, EnumMeta
 from itertools import cycle
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,7 @@ def find_project_config_path(labeled_data_path: str) -> str:
 def is_latest_version():
     import json
     import urllib.request
+
     from napari_deeplabcut import __version__
 
     url = "https://pypi.org/pypi/napari-deeplabcut/json"
@@ -26,18 +27,15 @@ def is_latest_version():
     return __version__ == latest_version, latest_version
 
 
-
 def unsorted_unique(array: Sequence) -> np.ndarray:
     """Return the unsorted unique elements of an array."""
     _, inds = np.unique(array, return_index=True)
     return np.asarray(array)[np.sort(inds)]
 
 
-def encode_categories(
-    categories: List[str], return_map: bool = False
-) -> Union[List[int], Tuple[List[int], Dict]]:
+def encode_categories(categories: list[str], return_map: bool = False) -> list[int] | tuple[list[int], dict]:
     unique_cat = unsorted_unique(categories)
-    map_ = dict(zip(unique_cat, range(len(unique_cat))))
+    map_ = dict(zip(unique_cat, range(len(unique_cat)), strict=False))
     inds = np.vectorize(map_.get)(categories)
     if return_map:
         return inds, map_
@@ -65,9 +63,7 @@ def merge_multiple_scorers(
             data[mask] = -1
             idx = np.nanargmax(data[..., 2], axis=1)
             data[mask] = np.nan
-        data_best = data[
-            np.arange(n_frames)[:, None], idx, np.arange(data.shape[2])
-        ].reshape((n_frames, -1))
+        data_best = data[np.arange(n_frames)[:, None], idx, np.arange(data.shape[2])].reshape((n_frames, -1))
         df = pd.DataFrame(
             data_best,
             index=df.index,
@@ -113,17 +109,17 @@ def guarantee_multiindex_rows(df):
             pass
 
 
-def build_color_cycle(n_colors: int, colormap: Optional[str] = "viridis") -> np.ndarray:
+def build_color_cycle(n_colors: int, colormap: str | None = "viridis") -> np.ndarray:
     cmap = colormaps.ensure_colormap(colormap)
     return cmap.map(np.linspace(0, 1, n_colors))
 
 
-def build_color_cycles(header: DLCHeader, colormap: Optional[str] = "viridis"):
+def build_color_cycles(header: DLCHeader, colormap: str | None = "viridis"):
     label_colors = build_color_cycle(len(header.bodyparts), colormap)
     id_colors = build_color_cycle(len(header.individuals), colormap)
     return {
-        "label": dict(zip(header.bodyparts, label_colors)),
-        "id": dict(zip(header.individuals, id_colors)),
+        "label": dict(zip(header.bodyparts, label_colors, strict=False)),
+        "id": dict(zip(header.individuals, id_colors, strict=False)),
     }
 
 
@@ -132,7 +128,7 @@ class DLCHeader:
         self.columns = columns
 
     @classmethod
-    def from_config(cls, config: Dict) -> DLCHeader:
+    def from_config(cls, config: dict) -> DLCHeader:
         multi = config.get("multianimalproject", False)
         scorer = [config["scorer"]]
         if multi:
@@ -145,13 +141,9 @@ class DLCHeader:
                 ]
             )
             if len(config["uniquebodyparts"]):
-                temp = pd.MultiIndex.from_product(
-                    [scorer, ["single"], config["uniquebodyparts"], ["x", "y"]]
-                )
+                temp = pd.MultiIndex.from_product([scorer, ["single"], config["uniquebodyparts"], ["x", "y"]])
                 columns = columns.append(temp)
-            columns.set_names(
-                ["scorer", "individuals", "bodyparts", "coords"], inplace=True
-            )
+            columns.set_names(["scorer", "individuals", "bodyparts", "coords"], inplace=True)
         else:
             columns = pd.MultiIndex.from_product(
                 [scorer, config["bodyparts"], ["x", "y"]],
@@ -159,12 +151,8 @@ class DLCHeader:
             )
         return cls(columns)
 
-    def form_individual_bodypart_pairs(self) -> List[Tuple[str]]:
-        to_drop = [
-            name
-            for name in self.columns.names
-            if name not in ("individuals", "bodyparts")
-        ]
+    def form_individual_bodypart_pairs(self) -> list[tuple[str]]:
+        to_drop = [name for name in self.columns.names if name not in ("individuals", "bodyparts")]
         temp = self.columns.droplevel(to_drop).unique()
         if "individuals" not in temp.names:
             temp = pd.MultiIndex.from_product([self.individuals, temp])
@@ -179,28 +167,28 @@ class DLCHeader:
         self.columns = self.columns.set_levels([scorer], level="scorer")
 
     @property
-    def individuals(self) -> List[str]:
+    def individuals(self) -> list[str]:
         individuals = self._get_unique("individuals")
         if individuals is None:
             return [""]
         return individuals
 
     @property
-    def bodyparts(self) -> List[str]:
+    def bodyparts(self) -> list[str]:
         return self._get_unique("bodyparts")
 
     @property
-    def coords(self) -> List[str]:
+    def coords(self) -> list[str]:
         return self._get_unique("coords")
 
-    def _get_unique(self, name: str) -> Optional[List]:
+    def _get_unique(self, name: str) -> list | None:
         if name in self.columns.names:
             return list(unsorted_unique(self.columns.get_level_values(name)))
         return None
 
 
 class CycleEnumMeta(EnumMeta):
-    def __new__(metacls, cls, bases, classdict):
+    def __new__(metacls, cls, bases, classdict, **kwargs):
         enum_ = super().__new__(metacls, cls, bases, classdict)
         enum_._cycle = cycle(enum_._member_map_[name] for name in enum_._member_names_)
         return enum_

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310}-{linux,macos,windows}
+envlist = py{310, 311, 312}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
-
+    3.11: py311
+    3.12: py312
 [gh-actions:env]
 PLATFORM =
     ubuntu-latest: linux


### PR DESCRIPTION
- Upgrades napari to latest (0.6.6)
- Aligns python versions with DLC-supported versions
- Significantly overhauls the codebase and tests for safer, more consistent behaviour

⚠️ The following changes on main DLC `deeplabcut/gui/widgets.py::launch_napari` are required :
(see https://github.com/DeepLabCut/DeepLabCut/pull/3181 )
```python
_, _ = viewer.window.add_plugin_dock_widget(
    "napari-deeplabcut",
    "Keypoint controls",
)
```
instead of opening all napari-DLC widgets.

---

**Notes**
Required by:
- https://github.com/C-Achard/napari-deeplabcut/pull/1 : Tracking feature : CoTracker integration for automated label generation
- #152 (and upcoming new version)

---
This pull request introduces several significant updates to the codebase, focusing on modernizing Python support, improving code quality, updating dependencies and pre-commit hooks, and cleaning up platform-specific testing logic (OpenGL and Windows... :). The changes include raising the minimum supported Python version, switching to the Ruff linter/formatter, correcting the licensing to match the LICENSE file, and refactoring various parts of the code for clarity and maintainability.

**Python version and dependency updates:**

- To align with DeepLabCut, increased the minimum supported Python version from 3.9 to 3.10 across the project, including workflow matrix, `setup.cfg`, and `pyproject.toml` (`python_requires`, CI matrix) [[1]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L31-R31) [[2]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L45-R42) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11-R20).
- Fixed the incorrect license shown from BSD-3-Clause to LGPL-3.0 in `setup.cfg` and adjusted related metadata fields.

**Pre-commit and linting improvements:**

- Replaced Flake8, Black, isort, autoflake, and pyupgrade with the faster, all-in-one tool Ruff for linting and formatting in `.pre-commit-config.yaml`, and added Ruff configuration to `pyproject.toml` [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R21) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11-R20).
- Updated versions of other pre-commit hooks for better compatibility and features.

**Codebase modernization and refactoring:**

- Refactored imports and type annotations throughout the codebase to use modern Python features (e.g., `collections.abc.Sequence`, `| None` for optionals, `list[str]`) [[1]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL1-L5) [[2]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL93-R124) [[3]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL176-R175) [[4]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL189-R200).
- Replaced deprecated or ambiguous variable names and parameters for clarity, and improved file/path handling by using `pathlib.Path` instead of `os.path` and `glob` [[1]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL66-R79) [[2]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL93-R124) [[3]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL219-R218) [[4]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL247-R247) [[5]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL257-R256) [[6]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL311-R319).
- Updated the main package `__init__.py` to explicitly define `__all__`, re-export symbols, and improve logging/warning handling.

**Testing and CI enhancements:**

- Improved test fixtures and environment setup in `conftest.py` for better reliability and CI compatibility, including explicit dock widget management and environment variable settings [[1]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L1-R41) [[2]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L42-R68) [[3]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L58-R81).
- Updated tests to use more robust and modern patterns, including `qtbot` for Qt widget management and weak references to avoid resource leaks [[1]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455R1-R4) [[2]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455L13-R24) [[3]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455L45-R59).

**General code cleanup:**

- Renamed point layer properties from `edge_color` to `border_color` and related fields for consistency with latest napari conventions.
- Miscellaneous import ordering and cleanup in test modules for consistency and readability.

These changes collectively modernize the codebase, improve maintainability, and ensure compatibility with current Python and toolchain standards.

**References:**

* Python version and dependency updates:
  - Increased minimum Python version to 3.10 in CI, `setup.cfg`, and `pyproject.toml` [[1]](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L31-R31) [[2]](diffhunk://#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L45-R42) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11-R20)
  - Corrected license to match LICENSE file (LGPL-3.0) and related metadata

* Pre-commit and linting improvements:
  - Switched to Ruff for linting/formatting, removed Flake8, Black, isort, autoflake, and pyupgrade; updated pre-commit hook versions [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L3-R21) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R11-R20)

* Codebase modernization and refactoring:
  - Adopted modern type annotations, improved imports, and switched to `pathlib.Path` for file handling [[1]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL1-L5) [[2]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL66-R79) [[3]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL93-R124) [[4]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL176-R175) [[5]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL189-R200) [[6]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL219-R218) [[7]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL247-R247) [[8]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL257-R256) [[9]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL311-R319)
  - Improved package `__init__.py` for explicit exports and better logging

* Testing and CI enhancements:
  - Improved test fixtures for reliability and CI compatibility, including explicit widget cleanup and environment variable management [[1]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L1-R41) [[2]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L42-R68) [[3]](diffhunk://#diff-6dfeb32d8638a9ba26b1940c400ea6c8b606164f1ae781e8f6750a4fd85307d4L58-R81) [[4]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455R1-R4) [[5]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455L13-R24) [[6]](diffhunk://#diff-8947f4ceb45c2e0ec5fc7f6acf227726055977b7696e7ee4101ef93bd78ca455L45-R59)

* General code cleanup:
  - Renamed layer properties for napari consistency, improved imports in tests [[1]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL146-R148) [[2]](diffhunk://#diff-11981a51985da17566d254dea72eb390a6a741a0a89905033f0f244750312ae3L1-R7)