### PR TITLE
Add `lazy_imread` function to read list of images with mismatched extensions

### DIFF
--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -32,7 +32,7 @@ from ._writer import (  # noqa: F401 (explicit re-export via __all__)
 
 try:
     from ._version import version as __version__  # noqa: F401
-except Exception:  # pragma: no cover
+except ImportError:  # pragma: no cover
     __version__ = "unknown"
 
 # ---- Warnings & logging setup ------------------------------------------------

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -319,7 +319,7 @@ def _populate_metadata(
 
 def _load_superkeypoints_diagram(super_animal: str):
     path = str(Path(__file__).parent / "assets" / f"{super_animal}.jpg")
-    return imread(path), {"name": f"{super_animal}_diagram", "metadata": {"root": ""}}, "image"
+    return imread(path), {"root": ""}, "images"
 
 
 def _load_superkeypoints(super_animal: str):

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -319,7 +319,7 @@ def _populate_metadata(
 
 def _load_superkeypoints_diagram(super_animal: str):
     path = str(Path(__file__).parent / "assets" / f"{super_animal}.jpg")
-    return imread(path), {"root": ""}, "images"
+    return imread(path), {"name": f"{super_animal}_diagram", "metadata": {"root": ""}}, "image"
 
 
 def _load_superkeypoints(super_animal: str):

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -199,7 +199,8 @@ def read_images(path: str | Path | list[str | Path]) -> list[LayerData]:
         raise FileNotFoundError(f"No files found for pattern: {image_path}")
     if len(matches) > 1:
         raise ValueError(
-            f"Multiple files match the pattern '{image_path.name}', but only a single image is expected: {matches}"
+            f"Multiple files match the pattern '{image_path.name}' for this non-list path input, "
+            f"but this usage expects the pattern to resolve to a single image: {matches}"
         )
 
     # Exactly 1 match

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -11,6 +11,7 @@ from dask import delayed
 from dask_image.imread import imread
 from napari.types import LayerData
 from natsort import natsorted
+from pandas.api.types import is_numeric_dtype
 
 from napari_deeplabcut import misc
 
@@ -387,7 +388,7 @@ def read_hdf(filename: str) -> list[LayerData]:
         nrows = df.shape[0]
         data = np.empty((nrows, 3))
         image_paths = df["level_0"]
-        if np.issubdtype(image_paths.dtype, np.number):
+        if is_numeric_dtype(getattr(image_paths, "dtype", np.asarray(image_paths).dtype)):
             image_inds = image_paths.values
             paths2inds = []
         else:

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -176,7 +176,7 @@ def _lazy_imread(
     first_shape = None
     first_dtype = None
 
-    def make_delayed_array(fp: Path):
+    def make_delayed_array(fp: Path, first_shape=first_shape, first_dtype=first_dtype) -> da.Array:
         """Create a dask array for a single file."""
         return da.from_delayed(
             delayed(_read_and_normalize)(filepath=fp, normalize_func=_normalize_to_rgb),
@@ -191,18 +191,16 @@ def _lazy_imread(
             first_dtype = arr0.dtype
 
             if use_dask:
-                images.append(make_delayed_array(fp))
+                images.append(make_delayed_array(fp, first_shape=first_shape, first_dtype=first_dtype))
             else:
                 images.append(arr0)
             continue
 
         if use_dask:
-            images.append(make_delayed_array(fp))
+            images.append(make_delayed_array(fp, first_shape=first_shape, first_dtype=first_dtype))
         else:
             images.append(_read_and_normalize(filepath=fp, normalize_func=_normalize_to_rgb))
 
-    if not images:
-        raise ValueError("No images could be read from the provided paths.")
     if len(images) == 1:
         return images[0]
 

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -113,7 +113,7 @@ def _expand_image_paths(path: str | Path | list[str | Path] | tuple[str | Path, 
 
     expanded: list[Path] = []
     for p in raw_paths:
-        if p.is_dir() and not str(p).endswith(".zarr"):
+        if p.is_dir() and p.suffix.lower() != ".zarr":
             file_matches: list[Path] = []
             for ext in SUPPORTED_IMAGES:
                 file_matches.extend(p.glob(f"*{ext}"))
@@ -179,7 +179,7 @@ def _lazy_imread(
     first_shape = None
     first_dtype = None
 
-    def make_delayed_array(fp: Path, first_shape, first_dtype) -> da.Array:
+    def make_delayed_array(fp: Path, first_shape: tuple[int, ...], first_dtype: np.dtype) -> da.Array:
         """Create a dask array for a single file."""
         return da.from_delayed(
             delayed(_read_and_normalize)(filepath=fp, normalize_func=_normalize_to_rgb),

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -172,10 +172,6 @@ def _lazy_imread(
     if use_dask is None:
         use_dask = len(expanded) > 1
 
-    expanded = [p for p in expanded if p.is_file() and p.suffix.lower() in SUPPORTED_IMAGES]
-    if not expanded:
-        raise ValueError(f"No files found in {filenames} after removing subdirectories")
-
     images = []
     first_shape = None
     first_dtype = None

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -59,13 +59,14 @@ def get_config_reader(path):
 
 
 def _filter_extensions(
-    image_paths: list[Union[str, Path]],
+    image_paths: list[str | Path],
     valid_extensions: tuple[str] = SUPPORTED_IMAGES,
 ) -> list[Path]:
     """
     Filter image paths by valid extensions.
     """
     return [Path(p) for p in image_paths if Path(p).suffix.lower() in valid_extensions]
+
 
 def get_folder_parser(path):
     if not path or not Path(path).is_dir():

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -460,7 +460,7 @@ class Video:
 def read_video(filename: str, opencv: bool = True):
     if opencv:
         stream = Video(filename)
-        # NOTE OpenCV stream expects H, W, C
+        # NOTE construct output shape tuple in (H, W, C) order to match read_frame() data
         shape = stream.height, stream.width, 3
 
         def _read_frame(ind):

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -324,7 +324,10 @@ def _populate_metadata(
 
 def _load_superkeypoints_diagram(super_animal: str):
     path = str(Path(__file__).parent / "assets" / f"{super_animal}.jpg")
-    return imread(path), {"root": ""}, "images"
+    try:
+        return imread(path), {"root": ""}, "images"
+    except Exception as e:
+        raise FileNotFoundError(f"Superkeypoints diagram not found for {super_animal}.") from e
 
 
 def _load_superkeypoints(super_animal: str):

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -58,10 +58,22 @@ def get_config_reader(path):
     return read_config
 
 
+def _filter_extensions(
+    image_paths: list[Union[str, Path]],
+    valid_extensions: tuple[str] = SUPPORTED_IMAGES,
+) -> list[Path]:
+    """
+    Filter image paths by valid extensions.
+    """
+    valid_paths = [
+        p for p in image_paths
+        if Path(p).suffix.lower() in valid_extensions
+    ]
+    return valid_paths
+
 def get_folder_parser(path):
     if not path or not Path(path).is_dir():
         return None
-
     layers = []
     files = Path(path).iterdir()
     images = ""
@@ -70,7 +82,7 @@ def get_folder_parser(path):
             images = str(Path(path) / f"*{Path(file.name).suffix}")
             break
     if not images:
-        raise OSError(f"No supported images were found in {path}.")
+        raise OSError(f"No supported images were found in {path} with extensions {SUPPORTED_IMAGES}.")
 
     layers.extend(read_images(images))
     for file in Path(path).iterdir():
@@ -80,7 +92,12 @@ def get_folder_parser(path):
     return lambda _: layers
 
 
-def read_images(path):
+def read_images(
+    path: Union[str, Path] | list[Union[str, Path]]
+):
+    """
+    Read images from path, glob pattern, or list of filepaths.
+    """
     if isinstance(path, list):
         first_path = Path(path[0])
         suffixes = first_path.suffixes

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -1,3 +1,4 @@
+import cv2
 import dask.array as da
 import numpy as np
 import pandas as pd
@@ -122,6 +123,7 @@ def test_read_images_mixed_extensions_directory_ignores_unsupported(tmp_path):
     img = (np.random.rand(8, 8, 3) * 255).astype(np.uint8)
     p_jpg = tmp_path / "a.jpg"
     p_png = tmp_path / "b.png"
+    assert ".tif" not in _reader.SUPPORTED_IMAGES  # ensure tif is unsupported for this test to be valid
     p_tif = tmp_path / "c.tif"  # unsupported by SUPPORTED_IMAGES in this reader
     imsave(p_jpg, img)
     imsave(p_png, img)
@@ -367,8 +369,6 @@ def test_read_images_list_metadata_paths(tmp_path):
 
 
 def test_lazy_imread_grayscale_and_rgba(tmp_path):
-    import cv2
-
     gray = (np.random.rand(10, 10) * 255).astype(np.uint8)
     rgba = (np.random.rand(10, 10, 4) * 255).astype(np.uint8)
     p1, p2 = tmp_path / "g.png", tmp_path / "r.png"

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -238,7 +238,7 @@ def test_lazy_imread_grayscale_and_rgba(tmp_path):
     gray = (np.random.rand(10, 10) * 255).astype(np.uint8)
     rgba = (np.random.rand(10, 10, 4) * 255).astype(np.uint8)
     p1, p2 = tmp_path / "g.png", tmp_path / "r.png"
-    cv2.imwrite(str(p1), gray)  # cv2 writes BGR/GRAY
+    cv2.imwrite(str(p1), gray)  # cv2 writes BGR or grayscale by default
     cv2.imwrite(str(p2), cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGRA))
     res = _reader.lazy_imread([p1, p2], use_dask=False, stack=False)
     assert all(img.shape[-1] == 3 for img in res)

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -7,6 +7,8 @@ from skimage.io import imsave
 
 from napari_deeplabcut import _reader
 
+FAKE_EXTENSION = ".notanimage"
+
 
 @pytest.mark.parametrize("ext", _reader.SUPPORTED_IMAGES)
 def test_get_image_reader(ext):
@@ -123,11 +125,10 @@ def test_read_images_mixed_extensions_directory_ignores_unsupported(tmp_path):
     img = (np.random.rand(8, 8, 3) * 255).astype(np.uint8)
     p_jpg = tmp_path / "a.jpg"
     p_png = tmp_path / "b.png"
-    assert ".tif" not in _reader.SUPPORTED_IMAGES  # ensure tif is unsupported for this test to be valid
-    p_tif = tmp_path / "c.tif"  # unsupported by SUPPORTED_IMAGES in this reader
+    p_fake = tmp_path / f"c{FAKE_EXTENSION}"  # unsupported by SUPPORTED_IMAGES in this reader
     imsave(p_jpg, img)
     imsave(p_png, img)
-    imsave(p_tif, img)
+    imsave(p_fake, img)
 
     layers = _reader.read_images(tmp_path)  # pass directory
     assert len(layers) == 1
@@ -141,7 +142,7 @@ def test_read_images_mixed_extensions_directory_ignores_unsupported(tmp_path):
     assert len(paths) == 2
     assert any(p.endswith("a.jpg") for p in paths)
     assert any(p.endswith("b.png") for p in paths)
-    assert all(not p.endswith("c.tif") for p in paths)
+    assert all(not p.endswith(FAKE_EXTENSION) for p in paths)
 
 
 def test_lazy_imread_mixed_extensions_list(tmp_path):
@@ -166,7 +167,7 @@ def test_read_images_mixed_extensions_globs(tmp_path):
     img = (np.random.rand(7, 7, 3) * 255).astype(np.uint8)
     p1 = tmp_path / "g1.jpg"
     p2 = tmp_path / "g2.png"
-    p3 = tmp_path / "g3.tif"  # unsupported
+    p3 = tmp_path / f"g3{FAKE_EXTENSION}"  # unsupported
     imsave(p1, img)
     imsave(p2, img)
     imsave(p3, img)
@@ -182,7 +183,7 @@ def test_read_images_mixed_extensions_globs(tmp_path):
     assert len(paths) == 2
     assert any(p.endswith("g1.jpg") for p in paths)
     assert any(p.endswith("g2.png") for p in paths)
-    assert all(not p.endswith("g3.tif") for p in paths)
+    assert all(not p.endswith(FAKE_EXTENSION) for p in paths)
 
 
 def test_read_images_mixed_extensions_tuple_input(tmp_path):

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -267,7 +267,6 @@ def test_read_images_single_glob_pattern(tmp_path):
     p1 = tmp_path / "g_a.png"
     p2 = tmp_path / "g_b.png"
     p3 = tmp_path / "g_c.jpg"  # different extension; should be excluded by '*.png' glob
-    from skimage.io import imsave
 
     imsave(p1, img)
     imsave(p2, img)

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -126,10 +126,10 @@ def test_read_images_mixed_extensions_directory_ignores_unsupported(tmp_path):
     img = (np.random.rand(8, 8, 3) * 255).astype(np.uint8)
     p_jpg = tmp_path / "a.jpg"
     p_png = tmp_path / "b.png"
-    p_fake = tmp_path / f"c{FAKE_EXTENSION}"  # unsupported by SUPPORTED_IMAGES in this reader
+    p_unsupp = tmp_path / f"c{FAKE_EXTENSION}"  # unsupported by SUPPORTED_IMAGES in this reader
     imsave(p_jpg, img)
     imsave(p_png, img)
-    imsave(p_fake, img)
+    imsave(p_unsupp, img)
 
     layers = _reader.read_images(tmp_path)  # pass directory
     assert len(layers) == 1
@@ -374,7 +374,7 @@ def test_lazy_imread_grayscale_and_rgba(tmp_path):
     gray = (np.random.rand(10, 10) * 255).astype(np.uint8)
     rgba = (np.random.rand(10, 10, 4) * 255).astype(np.uint8)
     p1, p2 = tmp_path / "g.png", tmp_path / "r.png"
-    cv2.imwrite(str(p1), gray)  # cv2 writes BGR or grayscale by default
+    cv2.imwrite(str(p1), gray)  # cv2 writes grayscale as-is; color images are written as BGR 
     cv2.imwrite(str(p2), cv2.cvtColor(rgba, cv2.COLOR_RGBA2BGRA))
     res = _reader._lazy_imread([p1, p2], use_dask=False, stack=False)
     assert all(img.shape[-1] == 3 for img in res)


### PR DESCRIPTION
- [x] Merge #153 first
- [x] ~~See updates in https://github.com/C-Achard/napari-deeplabcut/pull/2~~ Everything is in the upstream branch now

**Problem description:** 
When loading an image folder, previous implementation only looked at the first file to create a glob pattern for loading all images in the folder. This has the disadvantage that files with different extensions cannot be loaded. See issue [#3160](https://github.com/DeepLabCut/DeepLabCut/issues/3160) on the DeepLabCut repository.

**Changes:**
This commit changes image reading to be more flexible: input can be a single path, a glob pattern or a list of image paths. Images of different sizes are stacked using dask delayed arrays. (Mostly inspired by napari's own default implementation.)
When loading an image folder, all files with valid image extensions are selected inside that folder. 