### PR TITLE
Expand test coverage (writer and widgets)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ napari.manifest =
 
 [options.extras_require]
 testing =
+    Pillow
     pytest
     pytest-cov
     pytest-qt

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -156,11 +156,16 @@ def _populate_metadata(
 
 def _load_superkeypoints_diagram(super_animal: str):
     path = str(Path(__file__).parent / "assets" / f"{super_animal}.jpg")
-    return imread(path), {"root": ""}, "images"
+    try:
+        return imread(path), {"root": ""}, "images"
+    except Exception as e:
+        raise FileNotFoundError(f"Superkeypoints diagram not found for {super_animal}.") from e
 
 
 def _load_superkeypoints(super_animal: str):
     path = str(Path(__file__).parent / "assets" / f"{super_animal}.json")
+    if not Path(path).is_file():
+        raise FileNotFoundError(f"Superkeypoints JSON file not found for {super_animal}.")
     with open(path) as f:
         return json.load(f)
 

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -211,6 +211,8 @@ def mapped_points(points, superkeypoints_assets, config_path):
     superkpts = superkeypoints_assets["data"]
 
     # Required by _map_keypoints to locate and write config.yaml
+    # NOTE: This relies on config_path pointing to a file directly under the
+    # project directory, so that Path(config_path).parent is the project root.
     layer.metadata["project"] = str(Path(config_path).parent)
     header = layer.metadata["header"]
     bp1, bp2 = header.bodyparts[:2]

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -157,32 +157,6 @@ def video_path(tmp_path_factory):
 
 
 @pytest.fixture
-def superkeypoints_json(tmp_path):
-    """
-    Create a directory structure that mimics:
-    <module_dir>/assets/<super_animal>.json
-    """
-    module_dir = tmp_path / "module"
-    assets_dir = module_dir / "assets"
-    assets_dir.mkdir(parents=True)
-
-    data = {
-        "SK1": [10.0, 20.0],
-        "SK2": [30.0, 40.0],
-    }
-
-    json_path = assets_dir / "fake.json"
-    json_path.write_text(json.dumps(data))
-
-    return {
-        "module_dir": module_dir,
-        "assets_dir": assets_dir,
-        "super_animal": "fake",
-        "data": data,
-    }
-
-
-@pytest.fixture
 def superkeypoints_assets(tmp_path, monkeypatch):
     """
     Create a fake module dir with the expected assets layout:

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -114,10 +114,10 @@ def test_read_video(video_path):
 
 
 @pytest.mark.parametrize(
-    "exists,expected_exception",
+    "exists",
     [
-        (True, None),
-        (False, FileNotFoundError),
+        True,
+        False,
     ],
 )
 def test_load_superkeypoints(monkeypatch, tmp_path, exists):
@@ -145,10 +145,10 @@ def test_load_superkeypoints(monkeypatch, tmp_path, exists):
 
 
 @pytest.mark.parametrize(
-    "exists,expected_exception",
+    "exists",
     [
-        (True, None),
-        (False, FileNotFoundError),
+        True,
+        False,
     ],
 )
 def test_load_superkeypoints_diagram(monkeypatch, tmp_path, exists):

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -340,8 +340,9 @@ def test_display_shortcuts_dialog(viewer, qtbot):
     assert found_svg, "Shortcuts dialog should contain a QSvgWidget with the shortcuts image."
 
 
-# NOTE SuperAnimal keypoints functionality and testing
-# may need an overhaul in the future
+# NOTE SuperAnimal keypoints functionality and testing may need an overhaul in the future:
+# these tests currently exercise only a narrow "everything fine" path and rely on specific metadata
+# layout and SuperAnimal conversion-table conventions, which makes them susceptible to API changes
 def test_widget_load_superkeypoints_diagram(viewer, qtbot, points, superkeypoints_assets):
     controls = _widgets.KeypointControls(viewer)
     qtbot.add_widget(controls)

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -3,6 +3,7 @@ import types
 
 import numpy as np
 import pytest
+from qtpy.QtSvgWidgets import QSvgWidget
 from vispy import keys
 
 from napari_deeplabcut import _widgets
@@ -331,8 +332,6 @@ def test_display_shortcuts_dialog(viewer, qtbot):
     # Ensure the SVG widget is present
     found_svg = False
     for child in dlg.children():
-        from qtpy.QtSvgWidgets import QSvgWidget
-
         if isinstance(child, QSvgWidget):
             found_svg = True
             break

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -310,3 +310,31 @@ def test_ensure_mpl_canvas_docked_exception_during_docking(viewer, qtbot):
 
     # Docking failed → remains undocked
     assert controls._mpl_docked is False
+
+
+def test_display_shortcuts_dialog(viewer, qtbot):
+    """Ensure that the Shortcuts dialog can be created and shown without errors."""
+    controls = _widgets.KeypointControls(viewer)
+    qtbot.add_widget(controls)
+
+    # Create the dialog directly
+    dlg = _widgets.Shortcuts(controls)
+    qtbot.add_widget(dlg)
+
+    # Show it non-modally
+    dlg.show()
+    qtbot.waitExposed(dlg)
+
+    # Verify it is visible
+    assert dlg.isVisible()
+
+    # Ensure the SVG widget is present
+    found_svg = False
+    for child in dlg.children():
+        from qtpy.QtSvgWidgets import QSvgWidget
+
+        if isinstance(child, QSvgWidget):
+            found_svg = True
+            break
+
+    assert found_svg, "Shortcuts dialog should contain a QSvgWidget with the shortcuts image."

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -255,10 +255,9 @@ def test_write_hdf_machine_pred_no_gt(tmp_path, fake_keypoints):
     project_root = tmp_path / "proj"
     project_root.mkdir()
 
-    # --- IMPORTANT ---
     # The writer looks for config.yaml at Path(root).parents[1] / "config.yaml".
     # With root = str(project_root), that is two levels above 'proj'.
-    cfg_path = Path(str(project_root)).parents[1] / "config.yaml"
+    cfg_path = project_root.parents[1] / "config.yaml"
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
     cfg_path.write_text("scorer: alice")
 

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -1,0 +1,333 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from skimage.io import imread
+
+from napari_deeplabcut import _writer, misc
+
+
+#  Basic tests
+def test_write_config(tmp_path):
+    cfg = {"a": 1, "b": 2}
+    path = tmp_path / "config.yaml"
+
+    _writer._write_config(str(path), cfg)
+
+    assert path.exists()
+    text = path.read_text()
+    assert "a:" in text and "b:" in text
+
+
+def test_write_image(tmp_path):
+    img = (np.random.rand(10, 10) * 255).astype(np.uint8)
+    output = tmp_path / "test.png"
+
+    _writer._write_image(img, str(output))
+
+    assert output.exists()
+    loaded = imread(str(output))
+    assert loaded.shape == img.shape
+
+
+#  Form_df — multi-animal + single-animal
+
+
+def _fake_metadata_for_df(df, paths):
+    """Helper for metadata for _form_df.
+
+    IMPORTANT: The writer assigns properties row-wise, so we must provide
+    per-row arrays (length == n_rows). We cycle through (individual, bodypart)
+    combinations so that all header columns are represented across the dataset.
+    """
+    from itertools import cycle, islice, product
+
+    header = misc.DLCHeader(df.columns)
+    n_rows = len(df)
+
+    # Build a cyclic sequence of (id, label) pairs from header
+    pairs = list(product(header.individuals, header.bodyparts))
+    if not pairs:
+        # Degenerate case; still produce per-row arrays
+        ids = ["" for _ in range(n_rows)]
+        labels = ["" for _ in range(n_rows)]
+    else:
+        cyc = cycle(pairs)
+        sel = list(islice(cyc, n_rows))
+        ids = [p[0] for p in sel]
+        labels = [p[1] for p in sel]
+
+    props = {
+        "label": labels,  # length == n_rows
+        "id": ids,  # length == n_rows
+        "likelihood": [1.0] * n_rows,  # length == n_rows
+    }
+
+    meta = {
+        "header": header,
+        "paths": paths,
+    }
+
+    return {
+        "properties": props,
+        "metadata": meta,
+    }
+
+
+def test_form_df_multi_animal(fake_keypoints):
+    n = len(fake_keypoints)
+    metadata = _fake_metadata_for_df(fake_keypoints, [f"img{i}.png" for i in range(n)])
+
+    # inds + (x,y)
+    data = np.column_stack([np.arange(n), np.random.rand(n), np.random.rand(n)])
+
+    df = _writer._form_df(data, metadata)
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == n
+
+    # MultiIndex expected for multi-animal
+    lvls = df.columns.names
+    assert lvls == ["scorer", "individuals", "bodyparts", "coords"]
+
+    # Bodyparts appear correctly
+    assert set(df.columns.get_level_values("bodyparts")) == set(fake_keypoints.columns.get_level_values("bodyparts"))
+
+
+def test_form_df_single_animal(fake_keypoints):
+    """Drop the individuals level and check that _form_df handles it."""
+    df_single = fake_keypoints.xs("animal_0", axis=1, level="individuals")
+    df_single.columns = pd.MultiIndex.from_product(
+        [
+            [df_single.columns.levels[0][0]],  # scorer
+            [""],  # empty individuals level
+            df_single.columns.levels[1],  # bodyparts
+            df_single.columns.levels[2],  # coords
+        ],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
+
+    n = len(df_single)
+    metadata = _fake_metadata_for_df(df_single, [f"img{i}.png" for i in range(n)])
+
+    # inds + (x,y)
+    points = np.column_stack([np.arange(n), np.random.rand(n), np.random.rand(n)])
+    out = _writer._form_df(points, metadata)
+
+    assert isinstance(out, pd.DataFrame)
+    assert len(out) == n
+
+    if "individuals" in out.columns.names:
+        assert all(val == "" for val in out.columns.get_level_values("individuals"))
+    else:
+        # level actually dropped — also OK
+        assert "individuals" not in out.columns.names
+
+
+#  Write_hdf — machine-prediction merge branch
+
+
+def test_write_hdf_basic(tmp_path, fake_keypoints):
+    """write_hdf should produce deterministic HDF and CSV."""
+    root = tmp_path / "proj"
+    root.mkdir()
+
+    fake_keypoints.to_hdf(root / "data.h5", key="data")
+    header = misc.DLCHeader(fake_keypoints.columns)
+
+    # Build per-row properties (length == n_rows)
+    n_rows = len(fake_keypoints)
+    from itertools import cycle, islice, product
+
+    pairs = list(product(header.individuals, header.bodyparts))
+    sel = list(islice(cycle(pairs), n_rows))
+    per_row_ids = [p[0] for p in sel]
+    per_row_labels = [p[1] for p in sel]
+
+    metadata = {
+        "name": "CollectedData_me",
+        "properties": {
+            "label": per_row_labels,
+            "id": per_row_ids,
+            "likelihood": [1.0] * n_rows,
+        },
+        "metadata": {
+            "header": header,
+            "paths": [f"img{i}.png" for i in range(n_rows)],
+            "root": str(root),
+        },
+    }
+
+    points = np.column_stack(
+        [
+            np.arange(n_rows),
+            np.random.rand(n_rows),
+            np.random.rand(n_rows),
+        ]
+    )
+
+    fname = _writer.write_hdf("whatever.h5", points, metadata)
+
+    h5_path = root / fname
+    csv_path = h5_path.with_suffix(".csv")
+
+    assert h5_path.exists()
+    assert csv_path.exists()
+
+    df = pd.read_hdf(h5_path)
+    assert isinstance(df, pd.DataFrame)
+    # Ensure one row per index
+    assert len(df) == n_rows
+
+
+def test_write_hdf_machine_prediction_merge(tmp_path, fake_keypoints):
+    """
+    Trigger the special 'machine' branch:
+      - metadata["name"] contains 'machine'
+      - an existing CollectedData*.h5 file exists
+      -> data should be merged
+    """
+    root = tmp_path / "proj"
+    root.mkdir()
+
+    # --- FIX: make GT index consistent with writer output (single-level MultiIndex) ---
+    gt = fake_keypoints.copy()
+    gt_idx = [f"img{i}.png" for i in gt.index]
+    gt.index = pd.MultiIndex.from_tuples([(x,) for x in gt_idx])  # ('img0.png',) etc.
+    gt_path = root / "CollectedData_me.h5"
+    gt.to_hdf(gt_path, key="data")
+
+    header = misc.DLCHeader(fake_keypoints.columns)
+
+    # Build per-row properties
+    n_rows = len(fake_keypoints)
+    from itertools import cycle, islice, product
+
+    pairs = list(product(header.individuals, header.bodyparts))
+    sel = list(islice(cycle(pairs), n_rows))
+    per_row_ids = [p[0] for p in sel]
+    per_row_labels = [p[1] for p in sel]
+
+    metadata = {
+        "name": "machine_predictions",
+        "properties": {
+            "label": per_row_labels,
+            "id": per_row_ids,
+            "likelihood": [1.0] * n_rows,
+        },
+        "metadata": {
+            "header": header,
+            "paths": [f"img{i}.png" for i in range(n_rows)],
+            "root": str(root),
+        },
+    }
+
+    points = np.column_stack(
+        [
+            np.arange(n_rows),
+            np.random.rand(n_rows),
+            np.random.rand(n_rows),
+        ]
+    )
+
+    fname = _writer.write_hdf("ignored.h5", points, metadata)
+    out_h5 = root / fname
+
+    df = pd.read_hdf(out_h5)
+
+    # merged data must include at least as many rows as the original
+    assert len(df) >= n_rows
+
+    # scorer should match original GT scorer
+    assert df.columns.get_level_values("scorer")[0] == "me"
+
+
+def test_write_hdf_machine_pred_no_gt(tmp_path, fake_keypoints):
+    """
+    Trigger machine branch, but **without** a CollectedData*.h5 file.
+    It should:
+       - load config.yaml to get scorer
+       - write under "CollectedData_{scorer}.h5"
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+
+    # --- IMPORTANT ---
+    # The writer looks for config.yaml at Path(root).parents[1] / "config.yaml".
+    # With root = str(project_root), that is two levels above 'proj'.
+    cfg_path = Path(str(project_root)).parents[1] / "config.yaml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text("scorer: alice")
+
+    header = misc.DLCHeader(fake_keypoints.columns)
+
+    # Build per-row properties
+    n_rows = len(fake_keypoints)
+    from itertools import cycle, islice, product
+
+    pairs = list(product(header.individuals, header.bodyparts))
+    sel = list(islice(cycle(pairs), n_rows))
+    per_row_ids = [p[0] for p in sel]
+    per_row_labels = [p[1] for p in sel]
+
+    metadata = {
+        "name": "machine_predictions",
+        "properties": {
+            "label": per_row_labels,
+            "id": per_row_ids,
+            "likelihood": [1.0] * n_rows,
+        },
+        "metadata": {
+            "header": header,
+            "paths": [f"img{i}.png" for i in range(n_rows)],
+            "root": str(project_root),
+        },
+    }
+
+    points = np.column_stack(
+        [
+            np.arange(n_rows),
+            np.random.rand(n_rows),
+            np.random.rand(n_rows),
+        ]
+    )
+
+    fname = _writer.write_hdf("ignored.h5", points, metadata)
+
+    # Should name file based on scorer
+    assert fname.startswith("CollectedData_alice")
+
+    out_h5 = project_root / fname
+    df = pd.read_hdf(out_h5)
+
+    # columns scorer should be "alice"
+    assert df.columns.get_level_values("scorer")[0] == "alice"
+
+
+#  Write_masks — verify masks & vertices
+def test_write_masks(tmp_path):
+    foldername = str(tmp_path / "masks.h5")
+
+    # fake polygon: frame index always 0
+    data = [
+        np.array([[0, 5, 5], [0, 5, 2]]).T  # (inds, y, x)
+    ]
+
+    metadata = {
+        "metadata": {
+            "shape": (1, 10, 10),
+            "paths": ["frame0.png"],
+        }
+    }
+
+    output_dir = _writer.write_masks(foldername, data, metadata)
+    out_path = Path(output_dir)
+
+    assert out_path.exists()
+
+    # mask files present
+    mask_files = list(out_path.glob("*_obj_*.png"))
+    assert mask_files
+
+    # vertices.csv must be present
+    assert (out_path / "vertices.csv").exists()

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -7,6 +7,8 @@ from skimage.io import imread
 
 from napari_deeplabcut import _writer, misc
 
+rng = np.random.default_rng(42)
+
 
 #  Basic tests
 def test_write_config(tmp_path):
@@ -22,7 +24,7 @@ def test_write_config(tmp_path):
 
 
 def test_write_image(tmp_path):
-    img = (np.random.rand(10, 10) * 255).astype(np.uint8)
+    img = (rng.random((10, 10)) * 255).astype(np.uint8)
     output = tmp_path / "test.png"
 
     _writer._write_image(img, str(output))
@@ -81,7 +83,7 @@ def test_form_df_multi_animal(fake_keypoints):
     metadata = _fake_metadata_for_df(fake_keypoints, [f"img{i}.png" for i in range(n)])
 
     # inds + (x,y)
-    data = np.column_stack([np.arange(n), np.random.rand(n), np.random.rand(n)])
+    data = np.column_stack([np.arange(n), rng.random(n), rng.random(n)])
 
     df = _writer._form_df(data, metadata)
 
@@ -116,7 +118,7 @@ def test_form_df_single_animal(fake_keypoints):
     metadata = _fake_metadata_for_df(df_single, [f"img{i}.png" for i in range(n)])
 
     # inds + (x,y)
-    points = np.column_stack([np.arange(n), np.random.rand(n), np.random.rand(n)])
+    points = np.column_stack([np.arange(n), rng.random(n), rng.random(n)])
     out = _writer._form_df(points, metadata)
 
     assert isinstance(out, pd.DataFrame)
@@ -166,8 +168,8 @@ def test_write_hdf_basic(tmp_path, fake_keypoints):
     points = np.column_stack(
         [
             np.arange(n_rows),
-            np.random.rand(n_rows),
-            np.random.rand(n_rows),
+            rng.random(n_rows),
+            rng.random(n_rows),
         ]
     )
 
@@ -230,8 +232,8 @@ def test_write_hdf_machine_prediction_merge(tmp_path, fake_keypoints):
     points = np.column_stack(
         [
             np.arange(n_rows),
-            np.random.rand(n_rows),
-            np.random.rand(n_rows),
+            rng.random(n_rows),
+            rng.random(n_rows),
         ]
     )
 
@@ -291,8 +293,8 @@ def test_write_hdf_machine_pred_no_gt(tmp_path, fake_keypoints):
     points = np.column_stack(
         [
             np.arange(n_rows),
-            np.random.rand(n_rows),
-            np.random.rand(n_rows),
+            rng.random(n_rows),
+            rng.random(n_rows),
         ]
     )
 

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -97,12 +97,15 @@ def test_form_df_multi_animal(fake_keypoints):
 def test_form_df_single_animal(fake_keypoints):
     """Drop the individuals level and check that _form_df handles it."""
     df_single = fake_keypoints.xs("animal_0", axis=1, level="individuals")
+    scorer_values = df_single.columns.get_level_values("scorer").unique()
+    bodyparts_values = df_single.columns.get_level_values("bodyparts").unique()
+    coords_values = df_single.columns.get_level_values("coords").unique()
     df_single.columns = pd.MultiIndex.from_product(
         [
-            [df_single.columns.levels[0][0]],  # scorer
+            [scorer_values[0]],  # scorer
             [""],  # empty individuals level
-            df_single.columns.levels[1],  # bodyparts
-            df_single.columns.levels[2],  # coords
+            bodyparts_values,  # bodyparts
+            coords_values,  # coords
         ],
         names=["scorer", "individuals", "bodyparts", "coords"],
     )

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import yaml
 from skimage.io import imread
 
 from napari_deeplabcut import _writer, misc
@@ -16,7 +17,8 @@ def test_write_config(tmp_path):
 
     assert path.exists()
     text = path.read_text()
-    assert "a:" in text and "b:" in text
+    loaded = yaml.safe_load(text)
+    assert loaded == cfg
 
 
 def test_write_image(tmp_path):
@@ -27,7 +29,7 @@ def test_write_image(tmp_path):
 
     assert output.exists()
     loaded = imread(str(output))
-    assert loaded.shape == img.shape
+    np.testing.assert_array_equal(loaded, img)
 
 
 #  Form_df — multi-animal + single-animal

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -771,6 +771,8 @@ class KeypointControls(QWidget):
         self._keypoint_mapping_button.clicked.connect(lambda: self._map_keypoints(super_animal))
 
     def _map_keypoints(self, super_animal: str):
+        # NOTE : this may need review in the future
+        # as there are some robustness/safety issues
         points_layer = None
         for layer in self.viewer.layers:
             if isinstance(layer, Points) and layer.metadata.get("tables"):
@@ -799,6 +801,7 @@ class KeypointControls(QWidget):
                 strict=False,
             )
         )
+        cfg["SuperAnimalConversionTables"] = conversion_tables
         _write_config(config_path, cfg)
         self.viewer.status = "Mapping to superkeypoint set successfully saved"
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -771,8 +771,11 @@ class KeypointControls(QWidget):
         self._keypoint_mapping_button.clicked.connect(lambda: self._map_keypoints(super_animal))
 
     def _map_keypoints(self, super_animal: str):
-        # NOTE : this may need review in the future
-        # as there are some robustness/safety issues
+        # NOTE: This implementation makes several assumptions that may need review:
+        # - Assumes points_layer.metadata contains "project" and "header" keys with the expected structure.
+        # - Assumes _load_superkeypoints and _load_config succeed
+        #   and return well-formed data; I/O errors are not handled.
+        # - Silently ignores keypoints that have no nearest neighbor in the superkeypoint set (no user feedback).
         points_layer = None
         for layer in self.viewer.layers:
             if isinstance(layer, Points) and layer.metadata.get("tables"):


### PR DESCRIPTION
Aims to expand test coverage of the writer module, which lacked dedicated testing so far.
Also improves coverage on other components, such as the help widgets.

---
This pull request adds comprehensive tests for the SuperAnimal keypoints functionality and refines error handling for asset loading in the napari-deeplabcut plugin. It introduces new fixtures and parameterized tests for loading and mapping superkeypoints, improves robustness by raising clear errors when assets are missing, and expands test coverage for widget interactions and writer utilities.

**Testing improvements and coverage:**

* Added new fixtures (`superkeypoints_assets`, `mapped_points`) in `conftest.py` to create realistic asset layouts and test keypoint mapping logic, enabling more robust and maintainable tests for SuperAnimal features.
* Implemented parameterized tests in `test_reader.py` to verify correct behavior of `_load_superkeypoints` and `_load_superkeypoints_diagram` with and without asset files, ensuring proper error handling and coverage of edge cases.
* Expanded widget tests in `test_widgets.py` to include shortcut dialog display, superkeypoints diagram loading, and config file writing upon keypoint mapping, increasing confidence in UI interactions and config integration.

**Error handling and robustness:**

* Improved asset loading functions in `_reader.py` to raise `FileNotFoundError` when expected diagram or JSON files are missing, making failures explicit and easier to debug.

**Writer utilities and file output testing:**

* Added comprehensive tests for writer functions in `test_writer.py`, covering config and image writing, DataFrame formation for single- and multi-animal cases, HDF/CSV output, machine prediction merging, and mask file generation, ensuring reliable data export.

**Dependency management:**

* Added `Pillow` to the `testing` extras in `setup.cfg` to support image asset creation and manipulation in tests.
