### PR TITLE
Fix trajectory plot coordinates and styling

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -11,6 +11,7 @@ from dask import delayed
 from dask_image.imread import imread
 from napari.types import LayerData
 from natsort import natsorted
+from pandas.api.types import is_numeric_dtype
 
 from napari_deeplabcut import misc
 
@@ -228,7 +229,7 @@ def read_hdf(filename: str) -> list[LayerData]:
         nrows = df.shape[0]
         data = np.empty((nrows, 3))
         image_paths = df["level_0"]
-        if np.issubdtype(image_paths.dtype, np.number):
+        if is_numeric_dtype(getattr(image_paths, "dtype", np.asarray(image_paths).dtype)):
             image_inds = image_paths.values
             paths2inds = []
         else:

--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -229,7 +229,10 @@ def read_hdf(filename: str) -> list[LayerData]:
         nrows = df.shape[0]
         data = np.empty((nrows, 3))
         image_paths = df["level_0"]
-        if is_numeric_dtype(getattr(image_paths, "dtype", np.asarray(image_paths).dtype)):
+        dtype = getattr(image_paths, "dtype", None)
+        if dtype is None:
+            dtype = np.asarray(image_paths).dtype
+        if is_numeric_dtype(dtype):
             image_inds = image_paths.values
             paths2inds = []
         else:

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -218,8 +218,11 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     assert canvas._window == initial_window + 100
     assert canvas.slider_value.text() == str(initial_window + 100)
 
-    # Test plot refresh on frame change
+    # Test plot refresh does nothing when plot is hidden
     canvas.update_plot_range(event=type("Event", (), {"value": [5]}))
+    assert canvas._n == 0
+    # Test plot refresh on frame change (forced as it is hidden)
+    canvas.update_plot_range(event=type("Event", (), {"value": [5]}), force=True)
     assert canvas._n == 5
     # Check that x-limits reflect the new window
     start, end = canvas.ax.get_xlim()

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -541,19 +541,8 @@ class KeypointMatplotlibCanvas(QWidget):
             # Plot trajectories
             self._lines = {}
             for keypoint in self.df.columns.get_level_values("bodyparts").unique():
-                y_sel = self.df.xs(
-                    (keypoint, "y"),
-                    axis=1,
-                    level=["bodyparts", "coords"],
-                )
-                if y_sel.empty:
-                    continue
-                # Convert to numpy and enforce "one trajectory per keypoint"
-                y = np.atleast_1d(y_sel.to_numpy().squeeze())
-                if y.ndim != 1:
-                    raise ValueError(f"Expected 1D y trajectory for keypoint={keypoint!r}, got shape={y.shape}")
-                x = np.arange(y.size)
-
+                y = self.df.xs((keypoint, "y"), axis=1, level=["bodyparts", "coords"]).to_numpy().squeeze()
+                x = np.arange(len(y))
                 color = points_layer.metadata["face_color_cycles"]["label"][keypoint]
                 lines = self.ax.plot(x, y, color=color, label=keypoint)
                 self._lines[keypoint] = lines

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -501,8 +501,8 @@ class KeypointMatplotlibCanvas(QWidget):
                 self.viewer.layers,
                 Points,
             )
-
-            if points_layer is None or not np.any(points_layer.data):
+            data = getattr(points_layer, "data", None)
+            if points_layer is None or data is None or len(data) == 0:
                 return
 
             self.show()
@@ -837,7 +837,8 @@ class KeypointControls(QWidget):
             Points,
             predicate=lambda lyr: lyr.metadata.get("tables") is not None,
         )
-        if points_layer is None or ~np.any(points_layer.data):
+        data = getattr(points_layer, "data", None)
+        if points_layer is None or data is None or not np.any(data):
             return
 
         xy = points_layer.data[:, 1:3]
@@ -845,7 +846,7 @@ class KeypointControls(QWidget):
         xy_ref = np.c_[[val for val in superkpts_dict.values()]]
         neighbors = keypoints._find_nearest_neighbors(xy, xy_ref)
         found = neighbors != -1
-        if ~np.any(found):
+        if not found.any():
             return
 
         project_path = points_layer.metadata["project"]
@@ -1065,10 +1066,9 @@ class KeypointControls(QWidget):
             Points,
             predicate=lambda lyr: "face_color_cycles" in lyr.metadata,
         ):
-            if layer:
-                self._display.update_color_scheme(
-                    {name: to_hex(color) for name, color in layer.metadata["face_color_cycles"][mode].items()}
-                )
+            self._display.update_color_scheme(
+                {name: to_hex(color) for name, color in layer.metadata["face_color_cycles"][mode].items()}
+            )
 
     def _remap_frame_indices(self, layer):
         if not self._images_meta.get("paths"):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -574,7 +574,9 @@ class KeypointMatplotlibCanvas(QWidget):
         self.slider_value.setText(str(value))
         self.update_plot_range(Event(type_name="", value=[self._n]))
 
-    def update_plot_range(self, event):
+    def update_plot_range(self, event, force=False):
+        if not self.isVisible() and not force:
+            return
         value = event.value[0]
         self._n = value
 
@@ -781,6 +783,9 @@ class KeypointControls(QWidget):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._ensure_mpl_canvas_docked()
             if self._mpl_docked:
+                self._matplotlib_canvas.update_plot_range(
+                    Event(type_name="", value=[self.viewer.dims.current_step[0]]), force=True
+                )
                 self._matplotlib_canvas.show()
         else:
             if self._mpl_docked:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -838,7 +838,7 @@ class KeypointControls(QWidget):
             predicate=lambda lyr: lyr.metadata.get("tables") is not None,
         )
         data = getattr(points_layer, "data", None)
-        if points_layer is None or data is None or not np.any(data):
+        if points_layer is None or data is None or not data.any():
             return
 
         xy = points_layer.data[:, 1:3]


### PR DESCRIPTION
A small update to the trajectory plotting utility, mostly for consistency and performance.

- Fixed Y plot coordinates not matching viewer coordinates
- Fixed orientation of trajectories (was upside down)
- Fixed broken styling changes introduced by mistake, ensuring axes and labels are color based on current napari theme.
- Avoids always updating the plot even when not shown for performance

Also updated API for finding layers in code, centralizing and ensuring consistency.

---

| Before | After |
|---|---|
| <img width="618" height="312" alt="image" src="https://github.com/user-attachments/assets/6161ba7d-e330-4a9b-adc1-53c2878e02fc" /> | <img width="505" height="300" alt="image" src="https://github.com/user-attachments/assets/9e88d603-b8c9-41cd-aec7-63a1a5ecbbc2" /> |

**Before**: light blue track shown on top instead of bottom (flipped Y), incorrect vline color, and inconsistent axis with viewer coordinates.  
**After**: trajectories match viewer coordinates/orientation, and styling correctly matches the current napari theme

---
Several plotting and UI behaviors are improved for robustness and better integration with napari's theming.
This pull request also refactors the way layers are found and filtered throughout the `napari_deeplabcut` codebase by introducing new utility functions (`find_layer`, `find_layers`, and `find_layers_of_types`) in `misc.py`. These new functions replace repetitive layer-searching code in `_widgets.py`, resulting in cleaner, more maintainable, and less error-prone logic. 

The most important changes are:

**Layer Selection Refactor:**

* Added `find_layer`, `find_layers`, and `find_layers_of_types` utility functions to `misc.py` for robust and reusable layer searching/filtering by type and predicate.
* Replaced all manual layer iteration and type-checking in `_widgets.py` with calls to the new utility functions, simplifying code in methods such as `_load_dataframe`, `_update_slider_max`, `load_superkeypoints_diagram`, `_map_keypoints`, `_extract_single_frame`, `_store_crop_coordinates`, and color mode/colormap updates. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L483-R564) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L540-L548) [[3]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L743-R803) [[4]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L774-R834) [[5]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L874-R935) [[6]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L911-R971) [[7]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L999-R1062) [[8]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1163-R1225) [[9]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1211-R1277) [[10]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1268-R1337) [[11]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L830-R885)

**Plotting and UI Improvements:**

* Improved matplotlib plot initialization and update logic: now robustly resets axes, applies napari theme colors to axes/titles, and correctly handles y-axis orientation based on image stack shape. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R417) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R431-R441) [[3]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L483-R564)
* The plot update method (`update_plot_range`) now supports a `force` parameter to allow updates even when the widget is hidden, improving reliability when toggling the plot canvas. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L529-R579) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R786-R788)
* Ensured correct slider maximum calculation by using the new layer search utilities and robustly handling 3D image stacks.

**Maintenance and Readability:**

* Removed duplicated or error-prone code blocks for layer lookup, reducing code complexity and the chance of future bugs. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L483-R564) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L540-L548) [[3]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L743-R803) [[4]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L774-R834) [[5]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L874-R935) [[6]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L911-R971) [[7]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L999-R1062) [[8]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1163-R1225) [[9]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1211-R1277) [[10]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L1268-R1337)