### PR TITLE
Fix KeypointStore not initializing when layers load before widget

### DIFF
--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -728,6 +728,9 @@ class KeypointControls(QWidget):
                 )
         for layer in self.viewer.layers:
             if isinstance(layer, Points) and layer.metadata.get("header"):
+                # Ensure root is set (missing on first-time labeling from config)
+                if "root" not in layer.metadata and self._images_meta.get("root"):
+                    layer.metadata["root"] = self._images_meta["root"]
                 store = keypoints.KeypointStore(self.viewer, layer)
                 self._stores[layer] = store
                 if root := layer.metadata.get("root"):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -697,6 +697,61 @@ class KeypointControls(QWidget):
         # (Of course this will be a problem if we start using it everywhere so do not reuse lightly)
         QTimer.singleShot(10, self.silently_dock_matplotlib_canvas)
 
+        # Retroactively initialize KeypointStores for Points layers that were
+        # added before this widget was fully initialized (timing issue where
+        # on_insert never fires for pre-existing layers).
+        self._init_retry_count = 0
+        QTimer.singleShot(1000, self._retroactive_store_init)
+
+    def _retroactive_store_init(self):
+        self._init_retry_count += 1
+        if self._stores:
+            return
+        has_points = any(
+            isinstance(l, Points) and l.metadata.get("header")
+            for l in self.viewer.layers
+        )
+        if not has_points:
+            if self._init_retry_count < 10:
+                QTimer.singleShot(1000, self._retroactive_store_init)
+            return
+        # Populate _images_meta from Image layers (normally done by on_insert)
+        for layer in self.viewer.layers:
+            if isinstance(layer, Image) and layer.metadata.get("root"):
+                self._images_meta.update(
+                    {
+                        "paths": layer.metadata.get("paths"),
+                        "shape": layer.level_shapes[0],
+                        "root": layer.metadata["root"],
+                        "name": layer.name,
+                    }
+                )
+        for layer in self.viewer.layers:
+            if isinstance(layer, Points) and layer.metadata.get("header"):
+                store = keypoints.KeypointStore(self.viewer, layer)
+                self._stores[layer] = store
+                if root := layer.metadata.get("root"):
+                    update_save_history(root)
+                layer.metadata["controls"] = self
+                layer.text.visible = False
+                layer.bind_key("M", self.cycle_through_label_modes)
+                layer.bind_key("F", self.cycle_through_color_modes)
+                func = partial(_paste_data, store=store)
+                layer._paste_data = MethodType(func, layer)
+                layer.add = MethodType(keypoints._add, store)
+                layer.events.add(query_next_frame=Event)
+                layer.events.query_next_frame.connect(store._advance_step)
+                layer.bind_key("Shift-Right", store._find_first_unlabeled_frame)
+                layer.bind_key("Shift-Left", store._find_first_unlabeled_frame)
+                layer.bind_key("Down", store.next_keypoint, overwrite=True)
+                layer.bind_key("Up", store.prev_keypoint, overwrite=True)
+                layer.face_color_mode = "cycle"
+                self._form_dropdown_menus(store)
+                self._radio_box.setEnabled(True)
+                self._color_grp.setEnabled(True)
+                self._trail_cb.setEnabled(True)
+                self._show_traj_plot_cb.setEnabled(True)
+
     def _ensure_mpl_canvas_docked(self) -> None:
         """
         Dock the Matplotlib canvas as a napari dock widget, exactly once,
@@ -1223,6 +1278,9 @@ class KeypointControls(QWidget):
                     store.layer = _layer
                 self._update_color_scheme()
 
+                return
+
+            if not layer.metadata.get("header"):
                 return
 
             if layer.metadata.get("tables", ""):


### PR DESCRIPTION
# Pull Request: Fix KeypointStore not initializing when layers load before widget

**Current Branch:** fix/retroactive-keypoint-store-init
**Target Branch:** main

----------
### Content

#### Summary
- When napari-deeplabcut is activated via the DeepLabCut GUI, `on_insert` may not fire for Points layers that were added before the `KeypointControls` widget was fully initialized
- This leaves `_stores` empty, which disables labeling mode controls (Sequential/Quick/Loop), keypoint cycling (Up/Down/M keys), and dropdown menus
- Added `_retroactive_store_init()` to `KeypointControls.__init__` which retries every second (up to 10 attempts) to detect and initialize any unprocessed Points layers
- Also guards `on_insert` against Points layers without DLC metadata to prevent `KeyError` crashes on missing `header`

#### Design Decisions
- **QTimer retry loop over a single delayed call**: The plugin activation via `action.trigger()` in DeepLabCut's `launch_napari()` is asynchronous, and the delay before the widget is ready varies (observed ~3-7 seconds). A retry loop with a cap is more robust than guessing a fixed delay
- **10 attempts at 1-second intervals**: Conservative upper bound; in testing the fix typically succeeds within 4-7 attempts. After 10 seconds without a Points layer, it's safe to assume none will appear from the initial load
- **Guard in `on_insert` rather than try/except**: Explicitly checking for `header` metadata is clearer than catching `KeyError`, and avoids masking unrelated errors in `KeypointStore.__init__`
- **Duplicating `on_insert` logic in `_retroactive_store_init`**: Considered calling `on_insert` directly with a synthetic event, but `on_insert` uses `event.source[-1]` which assumes specific event structure. Duplicating the store initialization logic is safer and more readable

### Evidence
- Tested on macOS (Apple M3) with DeepLabCut 3.0.0rc6, napari 0.6.6, PySide6 6.7.3
- Without fix: `_stores` is empty, all mode radio buttons disabled (`isEnabled() == False`)
- With fix: `_stores` populated after ~4-7 seconds, mode buttons enabled, Loop/Quick/Sequential modes functional, Up/Down keypoint cycling works

### References
- Related upstream issue in DLC GUI: `launch_napari()` in `deeplabcut/gui/widgets.py` calls `action.trigger()` then `viewer.open()`, but the widget may not be connected to layer events yet
- Similar report: https://forum.image.sc/t/can-only-apply-first-deeplabcut-bodypart-label-in-napari/97286

#### Files changed
- `src/napari_deeplabcut/_widgets.py` -- Add `_retroactive_store_init()` method with QTimer retry loop to `KeypointControls.__init__`; add early return guard in `on_insert` for Points layers missing `header` metadata

### Manual Testcases
- Launch DeepLabCut GUI: `python -m deeplabcut`
- Load a project and click "Label Frames"
- Select a labeled-data subfolder (e.g. `labeled-data/video_name/`)
- Verify `CollectedData_<scorer>` layer appears in napari
- Verify labeling mode radio buttons (Sequential/Quick/Loop) become enabled within ~5 seconds
- Select "Loop" mode and place keypoints — verify it auto-cycles through bodyparts
- Press M key — verify it cycles between Sequential/Quick/Loop
- Press Up/Down — verify it switches between bodyparts
- Add a manual Points layer via napari menu — verify no crash occurs

### Unit, Integration, Contract Test Coverage
- No existing tests cover this initialization path; the fix is in GUI widget startup timing

### Others

#### Difficulties
- The root cause is a race condition between `action.trigger()` (async plugin activation) and `viewer.open()` (sync layer loading) in DeepLabCut's `launch_napari()`. The widget's `on_insert` listener connects during `__init__`, but `__init__` hasn't completed when layers are already being added
- `on_insert` uses `event.source[-1]` rather than `event.value`, so creating synthetic events for retroactive processing is fragile

#### Risk Assessment
| Area | Risk | Notes |
|------|------|-------|
| Retroactive store init | Low | Only runs when `_stores` is empty; no-ops if `on_insert` already handled layers normally |
| `on_insert` guard | Low | Early return for layers without `header` metadata; no impact on normal DLC workflow |
| QTimer retry | Low | Capped at 10 attempts; each attempt is lightweight (iterates layers list) |