### PR TITLE
Plugin refactor [4-II]: Cropping widgets and DLC project utilities

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -17,7 +17,7 @@ from napari_deeplabcut.core.io import (
     read_images,
     read_video,
 )
-from napari_deeplabcut.core.paths import looks_like_dlc_labeled_folder
+from napari_deeplabcut.core.project_paths import looks_like_dlc_labeled_folder
 
 logger = logging.getLogger(__name__)
 

--- a/src/napari_deeplabcut/_tests/core/test_conflicts.py
+++ b/src/napari_deeplabcut/_tests/core/test_conflicts.py
@@ -8,9 +8,8 @@ import pytest
 
 import napari_deeplabcut.core.conflicts as conflicts_mod
 import napari_deeplabcut.core.dataframes as dataframes_mod
-from napari_deeplabcut.config.models import AnnotationKind
+from napari_deeplabcut.config.models import AnnotationKind, DLCProjectContext
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
-from napari_deeplabcut.core.project_paths import DLCProjectContext
 
 
 def _make_points_meta(

--- a/src/napari_deeplabcut/_tests/core/test_conflicts.py
+++ b/src/napari_deeplabcut/_tests/core/test_conflicts.py
@@ -10,6 +10,7 @@ import napari_deeplabcut.core.conflicts as conflicts_mod
 import napari_deeplabcut.core.dataframes as dataframes_mod
 from napari_deeplabcut.config.models import AnnotationKind
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
+from napari_deeplabcut.core.project_paths import DLCProjectContext
 
 
 def _make_points_meta(
@@ -138,8 +139,11 @@ def test_compute_overwrite_report_raises_when_gt_fallback_is_ambiguous(monkeypat
     )
     monkeypatch.setattr(
         conflicts_mod,
-        "infer_dataset_folder_from_points_meta",
-        lambda meta: tmp_path,
+        "infer_dlc_project_from_points_meta",
+        lambda *args, **kwargs: DLCProjectContext(
+            root_anchor=tmp_path,
+            dataset_folder=tmp_path,
+        ),
     )
 
     (tmp_path / "CollectedData_a.h5").touch()
@@ -348,8 +352,8 @@ def test_compute_overwrite_report_raises_when_gt_fallback_has_no_root_and_no_dat
     )
     monkeypatch.setattr(
         conflicts_mod,
-        "infer_dataset_folder_from_points_meta",
-        lambda meta: None,
+        "infer_dlc_project_from_points_meta",
+        lambda *args, **kwargs: DLCProjectContext(),
     )
 
     with pytest.raises(MissingProvenanceError, match="GT fallback requires root"):

--- a/src/napari_deeplabcut/_tests/core/test_paths.py
+++ b/src/napari_deeplabcut/_tests/core/test_paths.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-import napari_deeplabcut.core.paths as paths_mod
+import napari_deeplabcut.core.project_paths as paths_mod
 
 
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/_tests/core/test_paths.py
+++ b/src/napari_deeplabcut/_tests/core/test_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -74,8 +75,6 @@ def test_canonicalize_path_returns_empty_string_when_stringify_fails():
 # -----------------------------------------------------------------------------
 # PathMatchPolicy / find_matching_depth
 # -----------------------------------------------------------------------------
-
-
 def test_path_match_policy_ordered_depths():
     assert paths_mod.PathMatchPolicy.ORDERED_DEPTHS.depths == (3, 2, 1)
 
@@ -126,8 +125,6 @@ def test_find_matching_depth_returns_none_for_empty_inputs(old_paths, new_paths)
 # -----------------------------------------------------------------------------
 # config.yaml / DLC artifact heuristics
 # -----------------------------------------------------------------------------
-
-
 def test_is_config_yaml_true_only_for_existing_config_yaml(tmp_path: Path):
     cfg = tmp_path / "config.yaml"
     cfg.touch()
@@ -215,173 +212,316 @@ def test_should_force_dlc_reader_false_for_empty_or_regular_inputs(tmp_path: Pat
 
 
 # -----------------------------------------------------------------------------
-# root-anchor inference
+# normalize_anchor_candidate
 # -----------------------------------------------------------------------------
-
-
-def test_infer_root_anchor_prefers_explicit_root(tmp_path: Path):
-    opened = tmp_path / "project" / "labeled-data" / "mouse1"
-    opened.mkdir(parents=True)
-
-    explicit = tmp_path / "explicit-anchor"
-    explicit.mkdir()
-
-    assert paths_mod.infer_root_anchor(opened, explicit_root=explicit) == str(explicit)
-
-
-def test_infer_root_anchor_returns_directory_when_opening_folder(tmp_path: Path):
+def test_normalize_anchor_candidate_returns_directory_for_directory(tmp_path: Path):
     folder = tmp_path / "dataset"
     folder.mkdir()
 
-    assert paths_mod.infer_root_anchor(folder) == str(folder)
+    assert paths_mod.normalize_anchor_candidate(folder) == folder.resolve()
 
 
-def test_infer_root_anchor_returns_parent_when_opening_file(tmp_path: Path):
+def test_normalize_anchor_candidate_returns_parent_for_file(tmp_path: Path):
     folder = tmp_path / "dataset"
     folder.mkdir()
     file_path = folder / "CollectedData_Jane.h5"
     file_path.touch()
 
-    assert paths_mod.infer_root_anchor(file_path) == str(folder)
+    assert paths_mod.normalize_anchor_candidate(file_path) == folder.resolve()
 
 
-def test_infer_root_anchor_returns_none_for_missing_path(tmp_path: Path):
+def test_normalize_anchor_candidate_returns_path_for_missing_path(tmp_path: Path):
     missing = tmp_path / "does_not_exist"
-    assert paths_mod.infer_root_anchor(missing) is None
+
+    result = paths_mod.normalize_anchor_candidate(missing)
+    assert result == missing.resolve()
+
+
+def test_normalize_anchor_candidate_returns_none_for_none():
+    assert paths_mod.normalize_anchor_candidate(None) is None
 
 
 # -----------------------------------------------------------------------------
-# project-root discovery
+# find_nearest_config
 # -----------------------------------------------------------------------------
-
-
-def test_find_nearest_project_root_finds_config_in_current_directory(tmp_path: Path):
+def test_find_nearest_config_finds_config_in_current_directory(tmp_path: Path):
     project = tmp_path / "project"
     project.mkdir()
-    (project / "config.yaml").touch()
+    cfg = project / "config.yaml"
+    cfg.touch()
 
-    assert paths_mod.find_nearest_project_root(project) == str(project)
+    assert paths_mod.find_nearest_config(project) == cfg.resolve()
 
 
-def test_find_nearest_project_root_finds_parent_project_from_nested_file(tmp_path: Path):
+def test_find_nearest_config_finds_parent_project_from_nested_file(tmp_path: Path):
     project = tmp_path / "project"
     dataset = project / "labeled-data" / "mouse1"
     dataset.mkdir(parents=True)
-    (project / "config.yaml").touch()
+    cfg = project / "config.yaml"
+    cfg.touch()
 
     img = dataset / "img001.png"
     img.touch()
 
-    assert paths_mod.find_nearest_project_root(img) == str(project)
+    assert paths_mod.find_nearest_config(img) == cfg.resolve()
 
 
-def test_find_nearest_project_root_respects_max_levels(tmp_path: Path):
+def test_find_nearest_config_respects_max_levels(tmp_path: Path):
     project = tmp_path / "project"
     deep = project / "a" / "b" / "c" / "d" / "e" / "f"
     deep.mkdir(parents=True)
-    (project / "config.yaml").touch()
+    cfg = project / "config.yaml"
+    cfg.touch()
 
-    # too shallow: cannot reach project root
-    assert paths_mod.find_nearest_project_root(deep, max_levels=2) is None
-
-    # enough levels: can reach project root
-    assert paths_mod.find_nearest_project_root(deep, max_levels=6) == str(project)
+    assert paths_mod.find_nearest_config(deep, max_levels=2) is None
+    assert paths_mod.find_nearest_config(deep, max_levels=6) == cfg.resolve()
 
 
-def test_find_nearest_project_root_returns_none_when_no_config(tmp_path: Path):
+def test_find_nearest_config_returns_none_when_no_config(tmp_path: Path):
     folder = tmp_path / "no_project_here"
     folder.mkdir()
 
-    assert paths_mod.find_nearest_project_root(folder) is None
+    assert paths_mod.find_nearest_config(folder) is None
 
 
 # -----------------------------------------------------------------------------
-# anchor candidate selection
+# infer_labeled_data_folder_from_paths
 # -----------------------------------------------------------------------------
+def test_infer_labeled_data_folder_from_paths_uses_fallback_root_when_already_dataset(tmp_path: Path):
+    dataset = tmp_path / "project" / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
 
-
-def test_choose_anchor_candidate_prefers_explicit_root(tmp_path: Path):
-    opened = tmp_path / "project" / "labeled-data" / "mouse1"
-    opened.mkdir(parents=True)
-
-    explicit = tmp_path / "explicit-root"
-    explicit.mkdir()
-
-    result = paths_mod.choose_anchor_candidate(
-        opened=opened,
-        explicit_root=explicit,
-        prefer_project_root=True,
+    result = paths_mod.infer_labeled_data_folder_from_paths(
+        [],
+        fallback_root=dataset,
     )
 
-    assert result == str(explicit)
+    assert result == dataset.resolve()
 
 
-def test_choose_anchor_candidate_uses_inferred_anchor_by_default(tmp_path: Path):
-    folder = tmp_path / "dataset"
-    folder.mkdir()
-
-    result = paths_mod.choose_anchor_candidate(opened=folder)
-    assert result == str(folder)
-
-
-def test_choose_anchor_candidate_can_elevate_to_project_root(tmp_path: Path):
+def test_infer_labeled_data_folder_from_paths_builds_folder_from_project_and_relpaths(tmp_path: Path):
     project = tmp_path / "project"
-    dataset = project / "labeled-data" / "mouse1"
-    dataset.mkdir(parents=True)
-    (project / "config.yaml").touch()
+    project.mkdir()
 
-    result = paths_mod.choose_anchor_candidate(
-        opened=dataset,
-        prefer_project_root=True,
+    result = paths_mod.infer_labeled_data_folder_from_paths(
+        ["labeled-data/mouse1/img001.png"],
+        project_root=project,
     )
 
-    assert result == str(project)
+    assert result == (project / "labeled-data" / "mouse1").resolve()
 
 
-def test_choose_anchor_candidate_keeps_local_anchor_when_no_project_root_found(tmp_path: Path):
-    dataset = tmp_path / "labeled-data" / "mouse1"
-    dataset.mkdir(parents=True)
+def test_infer_labeled_data_folder_from_paths_returns_none_without_dataset_name(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
 
-    result = paths_mod.choose_anchor_candidate(
-        opened=dataset,
-        prefer_project_root=True,
+    result = paths_mod.infer_labeled_data_folder_from_paths(
+        ["images/img001.png"],
+        project_root=project,
     )
 
-    assert result == str(dataset)
+    assert result is None
 
 
-def test_choose_anchor_candidate_returns_none_when_anchor_cannot_be_inferred(tmp_path: Path):
-    missing = tmp_path / "missing"
-
-    result = paths_mod.choose_anchor_candidate(
-        opened=missing,
-        prefer_project_root=True,
+def test_infer_labeled_data_folder_from_paths_returns_none_without_project_root():
+    result = paths_mod.infer_labeled_data_folder_from_paths(
+        ["labeled-data/mouse1/img001.png"],
+        project_root=None,
     )
 
     assert result is None
 
 
 # -----------------------------------------------------------------------------
-# artifact check wrapper
+# infer_dlc_project
 # -----------------------------------------------------------------------------
+def test_infer_dlc_project_prefers_explicit_root_and_finds_config(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    other = tmp_path / "other"
+    other.mkdir()
+
+    ctx = paths_mod.infer_dlc_project(
+        explicit_root=project,
+        anchor_candidates=[other],
+        prefer_project_root=True,
+    )
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
 
 
-def test_anchor_contains_dlc_artifacts_true_when_datafiles_present(tmp_path: Path):
-    folder = tmp_path / "dataset"
-    folder.mkdir()
-    (folder / "CollectedData_Jane.h5").touch()
+def test_infer_dlc_project_keeps_local_anchor_when_prefer_project_root_false(tmp_path: Path):
+    project = tmp_path / "project"
+    dataset = project / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+    cfg = project / "config.yaml"
+    cfg.touch()
 
-    assert paths_mod.anchor_contains_dlc_artifacts(folder) is True
+    ctx = paths_mod.infer_dlc_project(
+        anchor_candidates=[dataset],
+        prefer_project_root=False,
+    )
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == dataset.resolve()
 
 
-def test_anchor_contains_dlc_artifacts_false_when_no_datafiles(tmp_path: Path):
-    folder = tmp_path / "dataset"
-    folder.mkdir()
+def test_infer_dlc_project_returns_best_effort_without_config(tmp_path: Path):
+    dataset = tmp_path / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
 
-    assert paths_mod.anchor_contains_dlc_artifacts(folder) is False
+    ctx = paths_mod.infer_dlc_project(
+        anchor_candidates=[dataset],
+        prefer_project_root=True,
+    )
+
+    assert ctx.project_root is None
+    assert ctx.config_path is None
+    assert ctx.root_anchor == dataset.resolve()
 
 
-def test_anchor_contains_dlc_artifacts_swallows_exceptions(monkeypatch):
-    monkeypatch.setattr(paths_mod, "has_dlc_datafiles", lambda anchor: (_ for _ in ()).throw(RuntimeError("boom")))
+def test_infer_dlc_project_uses_dataset_candidate_when_no_anchor_candidates(tmp_path: Path):
+    dataset = tmp_path / "project" / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
 
-    assert paths_mod.anchor_contains_dlc_artifacts("/tmp/whatever") is False
+    ctx = paths_mod.infer_dlc_project(
+        dataset_candidates=[dataset],
+    )
+
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.root_anchor == dataset.resolve()
+
+
+# -----------------------------------------------------------------------------
+# infer_dlc_project_from_opened
+# -----------------------------------------------------------------------------
+def test_infer_dlc_project_from_opened_uses_opened_path(tmp_path: Path):
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+
+    ctx = paths_mod.infer_dlc_project_from_opened(dataset)
+
+    assert ctx.root_anchor == dataset.resolve()
+    assert ctx.project_root is None
+    assert ctx.config_path is None
+
+
+def test_infer_dlc_project_from_opened_can_find_project_root(tmp_path: Path):
+    project = tmp_path / "project"
+    dataset = project / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    ctx = paths_mod.infer_dlc_project_from_opened(dataset)
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+# -----------------------------------------------------------------------------
+# infer_dlc_project_from_points_meta
+# -----------------------------------------------------------------------------
+def test_infer_dlc_project_from_points_meta_infers_dataset_and_project(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    pts_meta = SimpleNamespace(
+        project=str(project),
+        root=None,
+        paths=["labeled-data/mouse1/img001.png"],
+    )
+
+    ctx = paths_mod.infer_dlc_project_from_points_meta(pts_meta)
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.dataset_folder == (project / "labeled-data" / "mouse1").resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+def test_infer_dlc_project_from_points_meta_uses_root_as_dataset_fallback(tmp_path: Path):
+    dataset = tmp_path / "project" / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+
+    pts_meta = SimpleNamespace(
+        project=None,
+        root=str(dataset),
+        paths=[],
+    )
+
+    ctx = paths_mod.infer_dlc_project_from_points_meta(pts_meta)
+
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.root_anchor == dataset.resolve()
+
+
+# -----------------------------------------------------------------------------
+# infer_dlc_project_from_image_layer
+# -----------------------------------------------------------------------------
+def test_infer_dlc_project_from_image_layer_uses_metadata_project(tmp_path: Path):
+    project = tmp_path / "project"
+    project.mkdir()
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    layer = SimpleNamespace(
+        metadata={"project": str(project)},
+        source=SimpleNamespace(path=None),
+    )
+
+    ctx = paths_mod.infer_dlc_project_from_image_layer(layer)
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+def test_infer_dlc_project_from_image_layer_falls_back_to_source_path(tmp_path: Path):
+    project = tmp_path / "project"
+    videos = project / "videos"
+    videos.mkdir(parents=True)
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    video = videos / "demo.mp4"
+    video.touch()
+
+    layer = SimpleNamespace(
+        metadata={},
+        source=SimpleNamespace(path=str(video)),
+    )
+
+    ctx = paths_mod.infer_dlc_project_from_image_layer(layer)
+
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+def test_infer_dlc_project_from_image_layer_returns_best_effort_without_config(tmp_path: Path):
+    videos = tmp_path / "videos"
+    videos.mkdir()
+
+    video = videos / "demo.mp4"
+    video.touch()
+
+    layer = SimpleNamespace(
+        metadata={},
+        source=SimpleNamespace(path=str(video)),
+    )
+
+    ctx = paths_mod.infer_dlc_project_from_image_layer(layer)
+
+    assert ctx.project_root is None
+    assert ctx.config_path is None
+    assert ctx.root_anchor == videos.resolve()

--- a/src/napari_deeplabcut/_tests/core/test_remap.py
+++ b/src/napari_deeplabcut/_tests/core/test_remap.py
@@ -2,7 +2,7 @@ import logging
 
 import numpy as np
 
-from napari_deeplabcut.core.paths import PathMatchPolicy
+from napari_deeplabcut.core.project_paths import PathMatchPolicy
 from napari_deeplabcut.core.remap import (
     build_frame_index_map,
     remap_layer_data_by_paths,

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -526,7 +526,7 @@ def test_video_panel_has_extraction_options(viewer, qtbot):
     assert panel.extract_button.text() == "Extract current frame"
     assert panel.crop_button.text() == "Save crop to config"
     assert panel.export_labels_cb.text() == "Also export labels"
-    assert panel.apply_crop_cb.text() == "Apply selected rectangle"
+    assert panel.apply_crop_cb.text() == "Crop to rectangle"
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -539,7 +539,7 @@ def test_extract_single_frame_warns_without_image_layer(viewer, qtbot, monkeypat
     seen = {}
 
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.show_warning",
+        "napari_deeplabcut.ui.cropping.show_warning",
         lambda msg: seen.setdefault("warning", msg),
     )
 

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -513,3 +513,36 @@ def test_widget_map_keypoints_writes_to_config(viewer, qtbot, points, config_pat
         "bp1": "nose",
         "bp2": "upper_jaw",
     }
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_video_panel_has_extraction_options(viewer, qtbot):
+    from napari_deeplabcut._widgets import KeypointControls
+
+    controls = KeypointControls(viewer)
+    qtbot.addWidget(controls)
+
+    panel = controls._video_group
+    assert panel.extract_button.text() == "Extract current frame"
+    assert panel.crop_button.text() == "Save crop to config"
+    assert panel.export_labels_cb.text() == "Also export labels"
+    assert panel.apply_crop_cb.text() == "Apply selected rectangle"
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_extract_single_frame_warns_without_image_layer(viewer, qtbot, monkeypatch):
+    from napari_deeplabcut._widgets import KeypointControls
+
+    controls = KeypointControls(viewer)
+    qtbot.addWidget(controls)
+
+    seen = {}
+
+    monkeypatch.setattr(
+        "napari_deeplabcut._widgets.show_warning",
+        lambda msg: seen.setdefault("warning", msg),
+    )
+
+    controls._extract_single_frame()
+
+    assert "No image/video layer is active." in seen["warning"]

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -232,8 +232,9 @@ def test_find_crop_rectangle_ignores_non_rectangles(monkeypatch):
 # -----------------------------------------------------------------------------
 
 
-def test_plan_frame_extraction_uses_viewer_crop(monkeypatch, tmp_path: Path):
-    monkeypatch.setattr(cropping_mod, "Image", FakeImage)
+def test_plan_frame_extraction_uses_viewer_crop(tmp_path: Path, monkeypatch):
+    from napari.layers import Image
+
     monkeypatch.setattr(
         cropping_mod,
         "find_crop_rectangle",
@@ -243,11 +244,12 @@ def test_plan_frame_extraction_uses_viewer_crop(monkeypatch, tmp_path: Path):
         ),
     )
 
-    image = FakeImage(
-        data=np.zeros((10, 20, 30), dtype=np.uint8),
-        metadata={"root": str(tmp_path)},
+    image = Image(
+        np.zeros((10, 20, 30), dtype=np.uint8),
         name="demo.mp4",
+        metadata={"root": str(tmp_path)},
     )
+
     viewer = SimpleNamespace(
         dims=SimpleNamespace(current_step=(4,), range=[(0, 10, 1), (0, 20, 1), (0, 100, 1)]),
     )
@@ -379,7 +381,7 @@ def test_store_crop_coordinates_saves_legacy_config_coords(monkeypatch, tmp_path
 # -----------------------------------------------------------------------------
 
 
-def test_update_video_panel_context_renders_compact_summary(monkeypatch, tmp_path: Path):
+def test_update_video_panel_context_renders_current_summary(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(cropping_mod, "Image", FakeImage)
     monkeypatch.setattr(cropping_mod, "sync_crop_layer_autorefresh", lambda viewer, panel, refresh_callback: None)
     monkeypatch.setattr(
@@ -409,6 +411,5 @@ def test_update_video_panel_context_renders_compact_summary(monkeypatch, tmp_pat
     cropping_mod.update_video_panel_context(viewer, panel)
 
     assert "Frame 3/5" in panel.text
+    assert f"Output folder: {tmp_path / 'dataset'}" in panel.text
     assert "Crop source: DLC crop layer" in panel.text
-    assert "Viewer: (1, 10, 2, 20)" in panel.text
-    assert "Config: (1, 10, 80, 98)" in panel.text

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -102,7 +102,7 @@ def test_crop_save_plan_rejects_viewer_coords_for_config(tmp_path: Path):
 # -----------------------------------------------------------------------------
 
 
-def test_rectangle_spec_returns_viewer_and_legacy_config_coords(monkeypatch):
+def test_rectangle_spec_returns_viewer_and_DLC_config_coords(monkeypatch):
     monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
 
     # rectangle vertices in [t, y, x]
@@ -130,7 +130,7 @@ def test_rectangle_spec_returns_viewer_and_legacy_config_coords(monkeypatch):
     # raw napari/image-data coords
     assert spec.viewer_crop.values == (20, 60, 10, 40)
 
-    # legacy config coords (y flipped with h=100)
+    #  DLC config coords (y flipped with h=100)
     assert spec.config_crop.values == (20, 60, 60, 90)
 
 
@@ -316,7 +316,7 @@ def test_plan_crop_save_uses_config_crop(monkeypatch, tmp_path: Path):
 # -----------------------------------------------------------------------------
 
 
-def test_store_crop_coordinates_saves_legacy_config_coords(monkeypatch, tmp_path: Path):
+def test_store_crop_coordinates_saves_DLC_config_coords(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
 
     project = tmp_path / "project"
@@ -358,7 +358,8 @@ def test_store_crop_coordinates_saves_legacy_config_coords(monkeypatch, tmp_path
         layers=FakeLayerList([crop_layer, image_layer], active=crop_layer),
         dims=SimpleNamespace(
             current_step=(0,),
-            range=[(0, 10, 1), (0, 20, 1), (0, 100, 1)],
+            # Y extent is 100 (index -2), X extent is 200 (index -1 / old hardcoded index 2)
+            range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)],
         ),
     )
 
@@ -374,6 +375,41 @@ def test_store_crop_coordinates_saves_legacy_config_coords(monkeypatch, tmp_path
 
     cfg = cropping_mod.io.load_config(str(config_path))
     assert cfg["video_sets"][str(video_path)]["crop"] == "20, 60, 60, 90"
+
+
+def test_rectangle_spec_uses_y_axis_extent_for_DLC_config_coords(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    # rectangle vertices in [t, y, x]
+    rect = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 60.0],
+            [0.0, 40.0, 60.0],
+            [0.0, 40.0, 20.0],
+        ],
+        dtype=float,
+    )
+    layer = FakeShapes(
+        data=[rect],
+        shape_type=["rectangle"],
+        metadata={cropping_mod.DLC_CROP_LAYER_META_KEY: True},
+        selected_data={0},
+    )
+
+    # Make Y extent and X extent different so using the wrong axis would fail.
+    # dims.range[-2][1] == 100  (Y)
+    # dims.range[2][1]  == 200  (X)  <-- old buggy code would incorrectly use this
+    viewer = SimpleNamespace(dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]))
+
+    spec = cropping_mod._rectangle_spec(viewer, layer, 0)
+    assert spec is not None
+
+    # raw napari/image-data coords
+    assert spec.viewer_crop.values == (20, 60, 10, 40)
+
+    # DLC config coords must use Y extent = 100, not X extent = 200
+    assert spec.config_crop.values == (20, 60, 60, 90)
 
 
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from napari_deeplabcut.ui import cropping as cropping_mod
@@ -449,3 +450,56 @@ def test_update_video_panel_context_renders_current_summary(monkeypatch, tmp_pat
     assert "Frame 3/5" in panel.text
     assert f"Output folder: {tmp_path / 'dataset'}" in panel.text
     assert "Crop source: DLC crop layer" in panel.text
+
+
+def test_execute_frame_extraction_keeps_new_labels_row_on_duplicate_index(monkeypatch, tmp_path: Path):
+    from napari.layers import Image
+
+    # Avoid writing a real image file through skimage; just create the output file.
+    monkeypatch.setattr(
+        cropping_mod,
+        "_write_image",
+        lambda arr, path: Path(path).write_bytes(b"fake-image"),
+    )
+
+    image = Image(
+        np.zeros((3, 20, 30), dtype=np.uint8),
+        name="demo.mp4",
+        metadata={"root": str(tmp_path)},
+    )
+
+    output_path = tmp_path / "img1.png"
+    labels_path = tmp_path / "machinelabels-iter0.h5"
+
+    # Existing row for the same extracted image path
+    idx = pd.MultiIndex.from_tuples([("tmp", "pytest", "img1.png")])
+    df_prev = pd.DataFrame({"bp1": [111.0]}, index=idx)
+    df_prev.to_hdf(labels_path, key="df_with_missing")
+
+    # New extracted row should overwrite the previous one
+    df_new = pd.DataFrame({"bp1": [222.0]}, index=idx)
+
+    monkeypatch.setattr(
+        cropping_mod,
+        "_build_extracted_frame_labels_df",
+        lambda plan: (df_new, None),
+    )
+
+    plan = cropping_mod.FrameExtractionPlan(
+        image_layer=image,
+        points_layer=object(),
+        frame_index=1,
+        output_root=tmp_path,
+        output_path=output_path,
+        labels_path=labels_path,
+        export_labels=True,
+        viewer_crop=None,
+    )
+
+    written, note = cropping_mod.execute_frame_extraction(plan)
+
+    assert note is None
+    assert labels_path in written
+
+    df_written = pd.read_hdf(labels_path, key="df_with_missing")
+    assert float(df_written.iloc[0]["bp1"]) == 222.0

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -123,7 +123,13 @@ def test_rectangle_spec_returns_viewer_and_DLC_config_coords(monkeypatch):
         selected_data={0},
     )
 
-    viewer = SimpleNamespace(dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]))
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(
+            # Y extent = 100, X extent = 200
+            # This matches the [t, y, x] rectangle coordinates used in the test
+            range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]
+        )
+    )
 
     spec = cropping_mod._rectangle_spec(viewer, layer, 0)
     assert spec is not None
@@ -174,7 +180,7 @@ def test_find_crop_rectangle_prefers_dedicated_crop_layer(monkeypatch):
 
     viewer = SimpleNamespace(
         layers=FakeLayerList([other, dedicated], active=other),
-        dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]),
+        dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]),
     )
 
     spec = cropping_mod.find_crop_rectangle(viewer, prefer_selected=True)
@@ -220,7 +226,7 @@ def test_find_crop_rectangle_ignores_non_rectangles(monkeypatch):
 
     viewer = SimpleNamespace(
         layers=FakeLayerList([poly_layer, rect_layer], active=poly_layer),
-        dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]),
+        dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]),
     )
 
     spec = cropping_mod.find_crop_rectangle(viewer, prefer_selected=True)
@@ -453,7 +459,7 @@ def test_update_video_panel_context_renders_current_summary(monkeypatch, tmp_pat
 
 
 def test_execute_frame_extraction_keeps_new_labels_row_on_duplicate_index(monkeypatch, tmp_path: Path):
-    from napari.layers import Image
+    from napari.layers import Image, Points
 
     # Avoid writing a real image file through skimage; just create the output file.
     monkeypatch.setattr(
@@ -485,9 +491,14 @@ def test_execute_frame_extraction_keeps_new_labels_row_on_duplicate_index(monkey
         lambda plan: (df_new, None),
     )
 
+    points = Points(
+        np.empty((0, 3), dtype=float),
+        name="pts",
+    )
+
     plan = cropping_mod.FrameExtractionPlan(
         image_layer=image,
-        points_layer=object(),
+        points_layer=points,
         frame_index=1,
         output_root=tmp_path,
         output_path=output_path,

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from napari_deeplabcut.ui import cropping as cropping_mod
+
+# -----------------------------------------------------------------------------
+# Small fake layer/viewer helpers (no qtbot, no napari viewer fixture)
+# -----------------------------------------------------------------------------
+
+
+class FakeShapes:
+    def __init__(
+        self,
+        *,
+        data,
+        shape_type,
+        metadata=None,
+        name="shapes",
+        selected_data=None,
+    ):
+        self.data = data
+        self.shape_type = shape_type
+        self.metadata = metadata or {}
+        self.name = name
+        self.selected_data = selected_data or set()
+
+
+class FakeImage:
+    def __init__(self, *, data=None, metadata=None, name="image", source_path=None):
+        self.data = data
+        self.metadata = metadata or {}
+        self.name = name
+        self.source = SimpleNamespace(path=source_path)
+
+
+class FakePoints:
+    def __init__(self, *, data=None, metadata=None, properties=None, name="points"):
+        self.data = data
+        self.metadata = metadata or {}
+        self.properties = properties or {}
+        self.name = name
+
+
+class FakeLayerList(list):
+    def __init__(self, layers=(), active=None):
+        super().__init__(layers)
+        self.selection = SimpleNamespace(active=active)
+
+
+class DummyPanel:
+    def __init__(self):
+        self.text = None
+
+    def set_context_text(self, text: str) -> None:
+        self.text = text
+
+
+# -----------------------------------------------------------------------------
+# Basic schema validation
+# -----------------------------------------------------------------------------
+
+
+def test_viewer_crop_coords_accept_valid_tuple():
+    coords = cropping_mod.ViewerCropCoords(values=(1, 10, 2, 20))
+    assert coords.values == (1, 10, 2, 20)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        (1, 1, 2, 20),  # x2 <= x1
+        (1, 10, 5, 5),  # y2 <= y1
+    ],
+)
+def test_viewer_crop_coords_reject_invalid_tuple(bad):
+    with pytest.raises(ValueError, match="ViewerCropCoords"):
+        cropping_mod.ViewerCropCoords(values=bad)
+
+
+def test_dlc_config_crop_coords_accept_valid_tuple():
+    coords = cropping_mod.DLCConfigCropCoords(values=(5, 15, 6, 30))
+    assert coords.values == (5, 15, 6, 30)
+
+
+def test_crop_save_plan_rejects_viewer_coords_for_config(tmp_path: Path):
+    with pytest.raises(ValueError, match="Refusing to write napari/viewer crop coordinates"):
+        cropping_mod.CropSavePlan(
+            config_path=tmp_path / "config.yaml",
+            project_root=tmp_path,
+            video_key="video.mp4",
+            config_crop=cropping_mod.ViewerCropCoords(values=(1, 10, 2, 20)),
+        )
+
+
+# -----------------------------------------------------------------------------
+# Rectangle resolution / coordinate conventions
+# -----------------------------------------------------------------------------
+
+
+def test_rectangle_spec_returns_viewer_and_legacy_config_coords(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    # rectangle vertices in [t, y, x]
+    rect = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 60.0],
+            [0.0, 40.0, 60.0],
+            [0.0, 40.0, 20.0],
+        ],
+        dtype=float,
+    )
+    layer = FakeShapes(
+        data=[rect],
+        shape_type=["rectangle"],
+        metadata={cropping_mod.DLC_CROP_LAYER_META_KEY: True},
+        selected_data={0},
+    )
+
+    viewer = SimpleNamespace(dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]))
+
+    spec = cropping_mod._rectangle_spec(viewer, layer, 0)
+    assert spec is not None
+
+    # raw napari/image-data coords
+    assert spec.viewer_crop.values == (20, 60, 10, 40)
+
+    # legacy config coords (y flipped with h=100)
+    assert spec.config_crop.values == (20, 60, 60, 90)
+
+
+def test_find_crop_rectangle_prefers_dedicated_crop_layer(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    dedicated_rect = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 60.0],
+            [0.0, 40.0, 60.0],
+            [0.0, 40.0, 20.0],
+        ],
+        dtype=float,
+    )
+    other_rect = np.array(
+        [
+            [0.0, 1.0, 2.0],
+            [0.0, 1.0, 5.0],
+            [0.0, 3.0, 5.0],
+            [0.0, 3.0, 2.0],
+        ],
+        dtype=float,
+    )
+
+    dedicated = FakeShapes(
+        data=[dedicated_rect],
+        shape_type=["rectangle"],
+        metadata={cropping_mod.DLC_CROP_LAYER_META_KEY: True},
+        name=cropping_mod.DLC_CROP_LAYER_NAME,
+        selected_data={0},
+    )
+    other = FakeShapes(
+        data=[other_rect],
+        shape_type=["rectangle"],
+        metadata={},
+        name="other",
+        selected_data={0},
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([other, dedicated], active=other),
+        dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]),
+    )
+
+    spec = cropping_mod.find_crop_rectangle(viewer, prefer_selected=True)
+    assert spec is not None
+    assert spec.viewer_crop.values == (20, 60, 10, 40)
+
+
+def test_find_crop_rectangle_ignores_non_rectangles(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    poly = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 15.0, 25.0],
+            [0.0, 12.0, 30.0],
+        ],
+        dtype=float,
+    )
+    rect = np.array(
+        [
+            [0.0, 5.0, 10.0],
+            [0.0, 5.0, 20.0],
+            [0.0, 15.0, 20.0],
+            [0.0, 15.0, 10.0],
+        ],
+        dtype=float,
+    )
+
+    poly_layer = FakeShapes(
+        data=[poly],
+        shape_type=["polygon"],
+        metadata={},
+        name="poly",
+        selected_data={0},
+    )
+    rect_layer = FakeShapes(
+        data=[rect],
+        shape_type=["rectangle"],
+        metadata={},
+        name="rect",
+        selected_data={0},
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([poly_layer, rect_layer], active=poly_layer),
+        dims=SimpleNamespace(range=[(0, 1, 1), (0, 1, 1), (0, 100, 1)]),
+    )
+
+    spec = cropping_mod.find_crop_rectangle(viewer, prefer_selected=True)
+    assert spec is not None
+    assert spec.viewer_crop.values == (10, 20, 5, 15)
+
+
+# -----------------------------------------------------------------------------
+# Planning logic
+# -----------------------------------------------------------------------------
+
+
+def test_plan_frame_extraction_uses_viewer_crop(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cropping_mod, "Image", FakeImage)
+    monkeypatch.setattr(
+        cropping_mod,
+        "find_crop_rectangle",
+        lambda viewer, prefer_selected=True: cropping_mod.CropRectangleSpec(
+            viewer_crop=cropping_mod.ViewerCropCoords(values=(2, 8, 3, 9)),
+            config_crop=cropping_mod.DLCConfigCropCoords(values=(2, 8, 91, 97)),
+        ),
+    )
+
+    image = FakeImage(
+        data=np.zeros((10, 20, 30), dtype=np.uint8),
+        metadata={"root": str(tmp_path)},
+        name="demo.mp4",
+    )
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(current_step=(4,), range=[(0, 10, 1), (0, 20, 1), (0, 100, 1)]),
+    )
+
+    plan, error = cropping_mod.plan_frame_extraction(
+        viewer,
+        image_layer=image,
+        export_labels=False,
+        apply_crop=True,
+    )
+
+    assert error is None
+    assert plan is not None
+    assert isinstance(plan.viewer_crop, cropping_mod.ViewerCropCoords)
+    assert plan.viewer_crop.values == (2, 8, 3, 9)
+
+
+def test_plan_crop_save_uses_config_crop(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        cropping_mod,
+        "find_crop_rectangle",
+        lambda viewer, prefer_selected=True: cropping_mod.CropRectangleSpec(
+            viewer_crop=cropping_mod.ViewerCropCoords(values=(2, 8, 3, 9)),
+            config_crop=cropping_mod.DLCConfigCropCoords(values=(2, 8, 91, 97)),
+        ),
+    )
+    monkeypatch.setattr(
+        cropping_mod,
+        "infer_dlc_project_from_image_layer",
+        lambda image_layer, prefer_project_root=True: SimpleNamespace(
+            config_path=tmp_path / "config.yaml",
+            project_root=tmp_path,
+            root_anchor=tmp_path,
+        ),
+    )
+
+    image = FakeImage(
+        data=np.zeros((10, 20, 30), dtype=np.uint8),
+        metadata={},
+        name="demo.mp4",
+        source_path=str(tmp_path / "videos" / "demo.mp4"),
+    )
+
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(range=[(0, 10, 1), (0, 20, 1), (0, 100, 1)]),
+        layers=FakeLayerList([], active=None),
+    )
+
+    plan, error = cropping_mod.plan_crop_save(
+        viewer,
+        image_layer=image,
+        explicit_project_path=None,
+        fallback_video_name="demo.mp4",
+    )
+
+    assert error is None
+    assert plan is not None
+    assert isinstance(plan.config_crop, cropping_mod.DLCConfigCropCoords)
+    assert plan.config_crop.values == (2, 8, 91, 97)
+
+
+# -----------------------------------------------------------------------------
+# Saving regression
+# -----------------------------------------------------------------------------
+
+
+def test_store_crop_coordinates_saves_legacy_config_coords(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    config_path = project / "config.yaml"
+    config_path.write_text("video_sets: {}\n", encoding="utf-8")
+
+    video_path = project / "videos" / "demo.mp4"
+    video_path.parent.mkdir()
+    video_path.touch()
+
+    rect = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 60.0],
+            [0.0, 40.0, 60.0],
+            [0.0, 40.0, 20.0],
+        ],
+        dtype=float,
+    )
+
+    crop_layer = FakeShapes(
+        data=[rect],
+        shape_type=["rectangle"],
+        metadata={cropping_mod.DLC_CROP_LAYER_META_KEY: True},
+        name=cropping_mod.DLC_CROP_LAYER_NAME,
+        selected_data={0},
+    )
+
+    image_layer = FakeImage(
+        data=np.zeros((10, 20, 30), dtype=np.uint8),
+        metadata={"root": str(project / "labeled-data" / "demo")},
+        name="demo.mp4",
+        source_path=str(video_path),
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([crop_layer, image_layer], active=crop_layer),
+        dims=SimpleNamespace(
+            current_step=(0,),
+            range=[(0, 10, 1), (0, 20, 1), (0, 100, 1)],
+        ),
+    )
+
+    ok, msg = cropping_mod.store_crop_coordinates(
+        viewer,
+        image_layer=image_layer,
+        explicit_project_path=str(project),
+        fallback_video_name="demo.mp4",
+    )
+
+    assert ok is True
+    assert "Saved crop" in msg
+
+    cfg = cropping_mod.io.load_config(str(config_path))
+    assert cfg["video_sets"][str(video_path)]["crop"] == "20, 60, 60, 90"
+
+
+# -----------------------------------------------------------------------------
+# Context rendering (logic only, no Qt)
+# -----------------------------------------------------------------------------
+
+
+def test_update_video_panel_context_renders_compact_summary(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(cropping_mod, "Image", FakeImage)
+    monkeypatch.setattr(cropping_mod, "sync_crop_layer_autorefresh", lambda viewer, panel, refresh_callback: None)
+    monkeypatch.setattr(
+        cropping_mod,
+        "get_crop_source_summary",
+        lambda viewer: (
+            "DLC crop layer",
+            cropping_mod.CropRectangleSpec(
+                viewer_crop=cropping_mod.ViewerCropCoords(values=(1, 10, 2, 20)),
+                config_crop=cropping_mod.DLCConfigCropCoords(values=(1, 10, 80, 98)),
+            ),
+        ),
+    )
+
+    image = FakeImage(
+        data=np.zeros((5, 20, 30), dtype=np.uint8),
+        metadata={"root": str(tmp_path / "dataset")},
+        name="demo.mp4",
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([image], active=image),
+        dims=SimpleNamespace(current_step=(2,), range=[(0, 5, 1), (0, 20, 1), (0, 100, 1)]),
+    )
+    panel = DummyPanel()
+
+    cropping_mod.update_video_panel_context(viewer, panel)
+
+    assert "Frame 3/5" in panel.text
+    assert "Crop source: DLC crop layer" in panel.text
+    assert "Viewer: (1, 10, 2, 20)" in panel.text
+    assert "Config: (1, 10, 80, 98)" in panel.text

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -16,9 +16,10 @@ from types import MethodType
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from napari.layers import Image, Points, Shapes, Tracks
+from napari.layers import Image, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import get_save_history, update_save_history
+from napari.utils.notifications import show_warning
 from pydantic import ValidationError
 from qtpy.QtCore import QSettings, Qt, QTimer
 from qtpy.QtGui import QAction
@@ -61,10 +62,7 @@ from napari_deeplabcut.core.metadata import (
     sync_points_from_image,
     write_points_meta,
 )
-from napari_deeplabcut.core.project_paths import (
-    PathMatchPolicy,
-    canonicalize_path,
-)
+from napari_deeplabcut.core.project_paths import PathMatchPolicy, canonicalize_path, infer_dlc_project_from_image_layer
 from napari_deeplabcut.core.remap import remap_layer_data_by_paths
 from napari_deeplabcut.core.sidecar import (
     get_default_scorer,
@@ -88,6 +86,10 @@ from napari_deeplabcut.napari_compat import (
 )
 from napari_deeplabcut.napari_compat.points_layer import make_paste_data
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemePanel
+from napari_deeplabcut.ui.cropping import (
+    build_video_action_menu,
+    store_crop_coordinates,
+)
 from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
 from napari_deeplabcut.ui.labels_and_dropdown import (
     DropdownMenu,
@@ -224,7 +226,10 @@ class KeypointControls(QWidget):
         self._layer_to_menu = {}
         self.viewer.layers.selection.events.active.connect(self.on_active_layer_change)
 
-        self._video_group = self._form_video_action_menu()
+        self._video_group = build_video_action_menu(
+            on_extract_frame=self._extract_single_frame,
+            on_store_crop=self._store_crop_coordinates,
+        )
         self.video_widget = self.viewer.window.add_dock_widget(self._video_group, name="video", area="right")
         self.video_widget.setVisible(False)
 
@@ -361,6 +366,20 @@ class KeypointControls(QWidget):
             self.video_widget.setVisible(True)
 
         self._update_image_meta_from_layer(layer)
+
+        if not self._project_path:
+            self._cache_project_path_from_image_layer(layer)
+            if self._project_path is not None:
+                try:
+                    layer.metadata = dict(layer.metadata or {})
+                    layer.metadata.setdefault("project", self._project_path)
+                except Exception:
+                    logger.debug(
+                        "Failed to set project path metadata on image layer %r",
+                        getattr(layer, "name", layer),
+                        exc_info=True,
+                    )
+
         self._sync_points_layers_from_image_meta()
 
         if reorder and index is not None:
@@ -1143,18 +1162,6 @@ class KeypointControls(QWidget):
 
         return next(iter(self._stores.keys()), None)
 
-    def _form_video_action_menu(self):
-        group_box = QGroupBox("Video")
-        layout = QVBoxLayout()
-        extract_button = QPushButton("Extract frame")
-        extract_button.clicked.connect(self._extract_single_frame)
-        layout.addWidget(extract_button)
-        crop_button = QPushButton("Store crop coordinates")
-        crop_button.clicked.connect(self._store_crop_coordinates)
-        layout.addWidget(crop_button)
-        group_box.setLayout(layout)
-        return group_box
-
     def _form_help_buttons(self):
         layout = QVBoxLayout()
         help_buttons_layout = QHBoxLayout()
@@ -1204,30 +1211,56 @@ class KeypointControls(QWidget):
                     df = df[~df.index.duplicated(keep="first")]
                 df.to_hdf(filepath, key="df_with_missing")
 
-    def _store_crop_coordinates(self, *args):
-        if not (project_path := self._project_path):
+    def _cache_project_path_from_image_layer(self, layer: Image) -> None:
+        """Best-effort cache of project path from an image/video layer."""
+        try:
+            ctx = infer_dlc_project_from_image_layer(layer, prefer_project_root=True)
+        except Exception:
+            logger.debug(
+                "Failed to infer DLC project context from image layer %r",
+                getattr(layer, "name", layer),
+                exc_info=True,
+            )
             return
-        for layer in self.viewer.layers:
-            if isinstance(layer, Shapes):
-                try:
-                    ind = layer.shape_type.index("rectangle")
-                except ValueError:
-                    return
-                bbox = layer.data[ind][:, 1:]
-                h = self.viewer.dims.range[2][1]
-                bbox[:, 0] = h - bbox[:, 0]
-                bbox = np.clip(bbox, 0, a_max=None).astype(int)
-                y1, x1 = bbox.min(axis=0)
-                y2, x2 = bbox.max(axis=0)
-                temp = {"crop": ", ".join(map(str, [x1, x2, y1, y2]))}
-                config_path = os.path.join(project_path, "config.yaml")
-                cfg = io.load_config(config_path)
-                video_name = self._image_meta.name
-                if not video_name:
-                    return
-                cfg["video_sets"][os.path.join(project_path, "videos", video_name)] = temp
-                io.write_config(config_path, cfg)
-                break
+
+        project_path = ctx.project_root or ctx.root_anchor
+        if project_path is None:
+            return
+
+        self._project_path = str(project_path)
+        try:
+            layer.metadata = dict(layer.metadata or {})
+            layer.metadata.setdefault("project", self._project_path)
+        except Exception:
+            logger.debug(
+                "Failed to set project path metadata on image layer %r",
+                getattr(layer, "name", layer),
+                exc_info=True,
+            )
+
+    def _store_crop_coordinates(self, *args):
+        image_layer = find_last_layer(self.viewer, Image)
+        if image_layer is None:
+            self.viewer.status = "No image/video layer available for crop export."
+            return
+
+        # Recover best-effort project context if we do not already have one cached.
+        if not self._project_path:
+            self._cache_project_path_from_image_layer(image_layer)
+
+        ok = store_crop_coordinates(
+            self.viewer,
+            image_layer=image_layer,
+            explicit_project_path=self._project_path,
+            fallback_video_name=self._image_meta.name,
+        )
+
+        if ok:
+            self.viewer.status = "Crop coordinates written to config.yaml"
+        else:
+            msg = "Could not determine project/config to write crop coordinates, or crop rectangle was not valid."
+            show_warning(msg)
+            self.viewer.status = msg
 
     def _form_dropdown_menus(self, store):
         menu = KeypointsDropdownMenu(store)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -907,15 +907,7 @@ class KeypointControls(QWidget):
         crop = find_crop_rectangle(self.viewer, prefer_selected=True)
         crop_text = f"Selected crop: {crop}" if crop is not None else "Selected crop: none"
 
-        export_labels = "on" if self._video_group.export_labels_cb.isChecked() else "off"
-        apply_crop = "on" if self._video_group.apply_crop_cb.isChecked() else "off"
-
-        self._video_group.set_context_text(
-            f"{frame_text}\n"
-            f"Output folder: {root_text}\n"
-            f"Export labels: {export_labels} • Apply rectangle crop: {apply_crop}\n"
-            f"{crop_text}"
-        )
+        self._video_group.set_context_text(f"{frame_text}\nOutput folder: {root_text}\n{crop_text}")
 
     def _get_trails_anchor(self, layer: Points | None = None) -> str | None:
         """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -5,21 +5,18 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import os
 from copy import deepcopy
 from datetime import datetime
 from functools import cached_property, partial
-from math import ceil, log10
 from pathlib import Path
 from types import MethodType
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 from napari.layers import Image, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import get_save_history, update_save_history
-from napari.utils.notifications import show_warning
+from napari.utils.notifications import show_info, show_warning
 from pydantic import ValidationError
 from qtpy.QtCore import QSettings, Qt, QTimer
 from qtpy.QtGui import QAction
@@ -41,11 +38,9 @@ from qtpy.QtWidgets import (
 
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut import misc
-from napari_deeplabcut._writer import _write_image
 from napari_deeplabcut.config import settings
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, ImageMetadata, IOProvenance, PointsMetadata
 from napari_deeplabcut.core import keypoints
-from napari_deeplabcut.core.dataframes import guarantee_multiindex_rows
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
 from napari_deeplabcut.core.layers import (
     find_last_layer,
@@ -62,7 +57,7 @@ from napari_deeplabcut.core.metadata import (
     sync_points_from_image,
     write_points_meta,
 )
-from napari_deeplabcut.core.project_paths import PathMatchPolicy, canonicalize_path, infer_dlc_project_from_image_layer
+from napari_deeplabcut.core.project_paths import PathMatchPolicy, infer_dlc_project_from_image_layer
 from napari_deeplabcut.core.remap import remap_layer_data_by_paths
 from napari_deeplabcut.core.sidecar import (
     get_default_scorer,
@@ -88,6 +83,9 @@ from napari_deeplabcut.napari_compat.points_layer import make_paste_data
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemePanel
 from napari_deeplabcut.ui.cropping import (
     build_video_action_menu,
+    execute_frame_extraction,
+    find_crop_rectangle,
+    plan_frame_extraction,
     store_crop_coordinates,
 )
 from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
@@ -232,6 +230,9 @@ class KeypointControls(QWidget):
         )
         self.video_widget = self.viewer.window.add_dock_widget(self._video_group, name="video", area="right")
         self.video_widget.setVisible(False)
+        self._video_group.export_labels_cb.toggled.connect(lambda _checked: self._refresh_video_panel_context())
+        self._video_group.apply_crop_cb.toggled.connect(lambda _checked: self._refresh_video_panel_context())
+        self.viewer.dims.events.current_step.connect(lambda event: self._refresh_video_panel_context())
 
         # form helper display
         self._keypoint_mapping_button = None
@@ -381,6 +382,7 @@ class KeypointControls(QWidget):
                     )
 
         self._sync_points_layers_from_image_meta()
+        self._refresh_video_panel_context()
 
         if reorder and index is not None:
             QTimer.singleShot(10, partial(self._move_image_layer_to_bottom, index))
@@ -877,6 +879,44 @@ class KeypointControls(QWidget):
         except Exception:
             pass
 
+    def _get_active_or_last_layer(self, layer_type):
+        active = self.viewer.layers.selection.active
+        if isinstance(active, layer_type):
+            return active
+        return find_last_layer(self.viewer, layer_type)
+
+    def _refresh_video_panel_context(self) -> None:
+        if not hasattr(self, "_video_group") or self._video_group is None:
+            return
+
+        image_layer = self._get_active_or_last_layer(Image)
+        if image_layer is None:
+            self._video_group.set_context_text("Load a video/image layer to enable extraction and crop tools.")
+            return
+
+        try:
+            n_frames = int(image_layer.data.shape[0])
+            frame_index = int(self.viewer.dims.current_step[0])
+            frame_text = f"Frame {frame_index + 1}/{n_frames}"
+        except Exception:
+            frame_text = "Frame ?/?"
+
+        root_value = (image_layer.metadata or {}).get("root")
+        root_text = str(root_value) if root_value else "unresolved"
+
+        crop = find_crop_rectangle(self.viewer, prefer_selected=True)
+        crop_text = f"Selected crop: {crop}" if crop is not None else "Selected crop: none"
+
+        export_labels = "on" if self._video_group.export_labels_cb.isChecked() else "off"
+        apply_crop = "on" if self._video_group.apply_crop_cb.isChecked() else "off"
+
+        self._video_group.set_context_text(
+            f"{frame_text}\n"
+            f"Output folder: {root_text}\n"
+            f"Export labels: {export_labels} • Apply rectangle crop: {apply_crop}\n"
+            f"{crop_text}"
+        )
+
     def _get_trails_anchor(self, layer: Points | None = None) -> str | None:
         """
         Resolve the folder-scoped sidecar anchor for the trails source layer.
@@ -1181,35 +1221,60 @@ class KeypointControls(QWidget):
         return layout
 
     def _extract_single_frame(self, *args):
-        image_layer = None
-        points_layer = None
-        image_layer = find_last_layer(self.viewer, Image)
-        points_layer = find_last_layer(self.viewer, Points)
-        if image_layer is not None:
-            ind = self.viewer.dims.current_step[0]
-            frame = image_layer.data[ind]
-            n_frames = image_layer.data.shape[0]
-            name = f"img{str(ind).zfill(int(ceil(log10(n_frames))))}.png"
-            output_path = os.path.join(image_layer.metadata["root"], name)
-            _write_image(frame, str(output_path))
+        image_layer = self._get_active_or_last_layer(Image)
+        export_labels = bool(self._video_group.export_labels_cb.isChecked())
+        apply_crop = bool(self._video_group.apply_crop_cb.isChecked())
 
-            # If annotations were loaded, they should be written to a machinefile.h5 file
-            if points_layer is not None:
-                df = io.form_df(
-                    points_layer.data,
-                    layer_metadata=points_layer.metadata,
-                    layer_properties=points_layer.properties,
-                )
-                df = df.iloc[ind : ind + 1]
-                canon = canonicalize_path(output_path, 3)
-                df.index = pd.MultiIndex.from_tuples([tuple(canon.split("/"))])
-                filepath = os.path.join(image_layer.metadata["root"], "machinelabels-iter0.h5")
-                if Path(filepath).is_file():
-                    df_prev = pd.read_hdf(filepath)
-                    guarantee_multiindex_rows(df_prev)
-                    df = pd.concat([df_prev, df])
-                    df = df[~df.index.duplicated(keep="first")]
-                df.to_hdf(filepath, key="df_with_missing")
+        points_layer = self._get_active_or_last_layer(Points) if export_labels else None
+
+        if export_labels and points_layer is not None and not self._validate_header(points_layer):
+            msg = "The selected Points layer is not a valid DLC keypoints layer for label export."
+            show_warning(msg)
+            self.viewer.status = msg
+            return
+
+        plan, error = plan_frame_extraction(
+            self.viewer,
+            image_layer=image_layer,
+            points_layer=points_layer,
+            explicit_output_root=(image_layer.metadata or {}).get("root") if image_layer is not None else None,
+            export_labels=export_labels,
+            apply_crop=apply_crop,
+        )
+
+        if plan is None:
+            msg = error or "Could not plan frame extraction."
+            show_warning(msg)
+            self.viewer.status = msg
+            self._refresh_video_panel_context()
+            return
+
+        if plan.output_path.exists():
+            answer = QMessageBox.question(
+                self,
+                "Overwrite extracted frame?",
+                f"The extracted frame already exists:\n\n{plan.output_path}\n\nDo you want to overwrite it?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if answer != QMessageBox.Yes:
+                self.viewer.status = "Frame extraction cancelled."
+                return
+
+        written_paths, note = execute_frame_extraction(plan)
+
+        msg = f"Extracted frame {plan.frame_index} to {plan.output_path}"
+        if len(written_paths) > 1:
+            msg += f" and updated {written_paths[-1].name}"
+
+        if note:
+            show_warning(note)
+            msg = f"{msg} ({note})"
+        else:
+            show_info(msg)
+
+        self.viewer.status = msg
+        self._refresh_video_panel_context()
 
     def _cache_project_path_from_image_layer(self, layer: Image) -> None:
         """Best-effort cache of project path from an image/video layer."""
@@ -1237,18 +1302,21 @@ class KeypointControls(QWidget):
                 getattr(layer, "name", layer),
                 exc_info=True,
             )
+        self._refresh_video_panel_context()
 
     def _store_crop_coordinates(self, *args):
-        image_layer = find_last_layer(self.viewer, Image)
+        image_layer = self._get_active_or_last_layer(Image)
         if image_layer is None:
-            self.viewer.status = "No image/video layer available for crop export."
+            msg = "No image/video layer is active."
+            show_warning(msg)
+            self.viewer.status = msg
             return
 
         # Recover best-effort project context if we do not already have one cached.
         if not self._project_path:
             self._cache_project_path_from_image_layer(image_layer)
 
-        ok = store_crop_coordinates(
+        ok, msg = store_crop_coordinates(
             self.viewer,
             image_layer=image_layer,
             explicit_project_path=self._project_path,
@@ -1256,11 +1324,13 @@ class KeypointControls(QWidget):
         )
 
         if ok:
-            self.viewer.status = "Crop coordinates written to config.yaml"
+            show_info(msg)
+            self.viewer.status = msg
         else:
-            msg = "Could not determine project/config to write crop coordinates, or crop rectangle was not valid."
             show_warning(msg)
             self.viewer.status = msg
+
+        self._refresh_video_panel_context()
 
     def _form_dropdown_menus(self, store):
         menu = KeypointsDropdownMenu(store)
@@ -1475,6 +1545,7 @@ class KeypointControls(QWidget):
         for layer_ in self.viewer.layers:
             if not isinstance(layer_, Image):
                 self._remap_frame_indices(layer_)
+        self._refresh_video_panel_context()
 
     def on_remove(self, event):
         layer = event.value
@@ -1520,6 +1591,8 @@ class KeypointControls(QWidget):
             self._trails = None
             self._trails_geom_sig = None
             self._trails_style_sig = None
+
+        self._refresh_video_panel_context()
 
     def _ensure_promotion_save_target(self, layer: Points) -> bool:
         """Ensure a prediction/machine source layer has a GT save_target set.
@@ -1757,6 +1830,8 @@ class KeypointControls(QWidget):
                 menu.setHidden(False)
             else:
                 menu.setHidden(True)
+
+        self._refresh_video_panel_context()
 
     def _update_colormap(self, colormap_name: str):
         for layer in self.viewer.layers.selection:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -16,7 +16,6 @@ import numpy as np
 from napari.layers import Image, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import get_save_history, update_save_history
-from napari.utils.notifications import show_info, show_warning
 from pydantic import ValidationError
 from qtpy.QtCore import QSettings, Qt, QTimer
 from qtpy.QtGui import QAction
@@ -43,7 +42,6 @@ from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, Imag
 from napari_deeplabcut.core import keypoints
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
 from napari_deeplabcut.core.layers import (
-    find_last_layer,
     get_first_points_layer,
     get_points_layer_with_tables,
     is_machine_layer,
@@ -57,7 +55,7 @@ from napari_deeplabcut.core.metadata import (
     sync_points_from_image,
     write_points_meta,
 )
-from napari_deeplabcut.core.project_paths import PathMatchPolicy, infer_dlc_project_from_image_layer
+from napari_deeplabcut.core.project_paths import PathMatchPolicy
 from napari_deeplabcut.core.remap import remap_layer_data_by_paths
 from napari_deeplabcut.core.sidecar import (
     get_default_scorer,
@@ -83,10 +81,10 @@ from napari_deeplabcut.napari_compat.points_layer import make_paste_data
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemePanel
 from napari_deeplabcut.ui.cropping import (
     build_video_action_menu,
-    execute_frame_extraction,
-    find_crop_rectangle,
-    plan_frame_extraction,
-    store_crop_coordinates,
+    resolve_project_path_from_image_layer,
+    run_extract_current_frame,
+    run_store_crop_coordinates,
+    update_video_panel_context,
 )
 from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
 from napari_deeplabcut.ui.labels_and_dropdown import (
@@ -879,36 +877,6 @@ class KeypointControls(QWidget):
         except Exception:
             pass
 
-    def _get_active_or_last_layer(self, layer_type):
-        active = self.viewer.layers.selection.active
-        if isinstance(active, layer_type):
-            return active
-        return find_last_layer(self.viewer, layer_type)
-
-    def _refresh_video_panel_context(self) -> None:
-        if not hasattr(self, "_video_group") or self._video_group is None:
-            return
-
-        image_layer = self._get_active_or_last_layer(Image)
-        if image_layer is None:
-            self._video_group.set_context_text("Load a video/image layer to enable extraction and crop tools.")
-            return
-
-        try:
-            n_frames = int(image_layer.data.shape[0])
-            frame_index = int(self.viewer.dims.current_step[0])
-            frame_text = f"Frame {frame_index + 1}/{n_frames}"
-        except Exception:
-            frame_text = "Frame ?/?"
-
-        root_value = (image_layer.metadata or {}).get("root")
-        root_text = str(root_value) if root_value else "unresolved"
-
-        crop = find_crop_rectangle(self.viewer, prefer_selected=True)
-        crop_text = f"Selected crop: {crop}" if crop is not None else "Selected crop: none"
-
-        self._video_group.set_context_text(f"{frame_text}\nOutput folder: {root_text}\n{crop_text}")
-
     def _get_trails_anchor(self, layer: Points | None = None) -> str | None:
         """
         Resolve the folder-scoped sidecar anchor for the trails source layer.
@@ -1212,79 +1180,16 @@ class KeypointControls(QWidget):
         layout.addWidget(self._keypoint_mapping_button)
         return layout
 
-    def _extract_single_frame(self, *args):
-        image_layer = self._get_active_or_last_layer(Image)
-        export_labels = bool(self._video_group.export_labels_cb.isChecked())
-        apply_crop = bool(self._video_group.apply_crop_cb.isChecked())
-
-        points_layer = self._get_active_or_last_layer(Points) if export_labels else None
-
-        if export_labels and points_layer is not None and not self._validate_header(points_layer):
-            msg = "The selected Points layer is not a valid DLC keypoints layer for label export."
-            show_warning(msg)
-            self.viewer.status = msg
-            return
-
-        plan, error = plan_frame_extraction(
-            self.viewer,
-            image_layer=image_layer,
-            points_layer=points_layer,
-            explicit_output_root=(image_layer.metadata or {}).get("root") if image_layer is not None else None,
-            export_labels=export_labels,
-            apply_crop=apply_crop,
-        )
-
-        if plan is None:
-            msg = error or "Could not plan frame extraction."
-            show_warning(msg)
-            self.viewer.status = msg
-            self._refresh_video_panel_context()
-            return
-
-        if plan.output_path.exists():
-            answer = QMessageBox.question(
-                self,
-                "Overwrite extracted frame?",
-                f"The extracted frame already exists:\n\n{plan.output_path}\n\nDo you want to overwrite it?",
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
-            )
-            if answer != QMessageBox.Yes:
-                self.viewer.status = "Frame extraction cancelled."
-                return
-
-        written_paths, note = execute_frame_extraction(plan)
-
-        msg = f"Extracted frame {plan.frame_index} to {plan.output_path}"
-        if len(written_paths) > 1:
-            msg += f" and updated {written_paths[-1].name}"
-
-        if note:
-            show_warning(note)
-            msg = f"{msg} ({note})"
-        else:
-            show_info(msg)
-
-        self.viewer.status = msg
-        self._refresh_video_panel_context()
+    def _refresh_video_panel_context(self) -> None:
+        update_video_panel_context(self.viewer, self._video_group)
 
     def _cache_project_path_from_image_layer(self, layer: Image) -> None:
         """Best-effort cache of project path from an image/video layer."""
-        try:
-            ctx = infer_dlc_project_from_image_layer(layer, prefer_project_root=True)
-        except Exception:
-            logger.debug(
-                "Failed to infer DLC project context from image layer %r",
-                getattr(layer, "name", layer),
-                exc_info=True,
-            )
-            return
-
-        project_path = ctx.project_root or ctx.root_anchor
+        project_path = resolve_project_path_from_image_layer(layer)
         if project_path is None:
             return
 
-        self._project_path = str(project_path)
+        self._project_path = project_path
         try:
             layer.metadata = dict(layer.metadata or {})
             layer.metadata.setdefault("project", self._project_path)
@@ -1294,34 +1199,28 @@ class KeypointControls(QWidget):
                 getattr(layer, "name", layer),
                 exc_info=True,
             )
+
+        self._refresh_video_panel_context()
+
+    def _extract_single_frame(self, *args):
+        ok, msg = run_extract_current_frame(
+            self.viewer,
+            self._video_group,
+            validate_points_layer=self._validate_header,
+        )
+        self.viewer.status = msg
         self._refresh_video_panel_context()
 
     def _store_crop_coordinates(self, *args):
-        image_layer = self._get_active_or_last_layer(Image)
-        if image_layer is None:
-            msg = "No image/video layer is active."
-            show_warning(msg)
-            self.viewer.status = msg
-            return
-
-        # Recover best-effort project context if we do not already have one cached.
-        if not self._project_path:
-            self._cache_project_path_from_image_layer(image_layer)
-
-        ok, msg = store_crop_coordinates(
+        ok, msg, project_path = run_store_crop_coordinates(
             self.viewer,
-            image_layer=image_layer,
+            self._video_group,
             explicit_project_path=self._project_path,
             fallback_video_name=self._image_meta.name,
         )
-
-        if ok:
-            show_info(msg)
-            self.viewer.status = msg
-        else:
-            show_warning(msg)
-            self.viewer.status = msg
-
+        if project_path is not None:
+            self._project_path = project_path
+        self.viewer.status = msg
         self._refresh_video_panel_context()
 
     def _form_dropdown_menus(self, store):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -61,7 +61,7 @@ from napari_deeplabcut.core.metadata import (
     sync_points_from_image,
     write_points_meta,
 )
-from napari_deeplabcut.core.paths import (
+from napari_deeplabcut.core.project_paths import (
     PathMatchPolicy,
     canonicalize_path,
 )

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -233,6 +233,7 @@ class KeypointControls(QWidget):
         self._video_group.apply_crop_cb.toggled.connect(self._on_apply_crop_toggled)
         self.viewer.dims.events.current_step.connect(lambda event: self._refresh_video_panel_context())
         self.viewer.layers.selection.events.active.connect(lambda event: self._refresh_video_panel_context())
+        QTimer.singleShot(0, self._refresh_video_panel_context)
 
         # form helper display
         self._keypoint_mapping_button = None

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -81,6 +81,7 @@ from napari_deeplabcut.napari_compat.points_layer import make_paste_data
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemePanel
 from napari_deeplabcut.ui.cropping import (
     build_video_action_menu,
+    handle_apply_crop_toggled,
     resolve_project_path_from_image_layer,
     run_extract_current_frame,
     run_store_crop_coordinates,
@@ -229,8 +230,9 @@ class KeypointControls(QWidget):
         self.video_widget = self.viewer.window.add_dock_widget(self._video_group, name="video", area="right")
         self.video_widget.setVisible(False)
         self._video_group.export_labels_cb.toggled.connect(lambda _checked: self._refresh_video_panel_context())
-        self._video_group.apply_crop_cb.toggled.connect(lambda _checked: self._refresh_video_panel_context())
+        self._video_group.apply_crop_cb.toggled.connect(self._on_apply_crop_toggled)
         self.viewer.dims.events.current_step.connect(lambda event: self._refresh_video_panel_context())
+        self.viewer.layers.selection.events.active.connect(lambda event: self._refresh_video_panel_context())
 
         # form helper display
         self._keypoint_mapping_button = None
@@ -1209,6 +1211,10 @@ class KeypointControls(QWidget):
             validate_points_layer=self._validate_header,
         )
         self.viewer.status = msg
+        self._refresh_video_panel_context()
+
+    def _on_apply_crop_toggled(self, checked) -> None:
+        handle_apply_crop_toggled(self.viewer, self._video_group, bool(checked))
         self._refresh_video_panel_context()
 
     def _store_crop_coordinates(self, *args):

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -30,8 +30,6 @@ class MetadataKind(str, Enum):
 # -----------------------------------------------------------------------------
 # Project structure models
 # -----------------------------------------------------------------------------
-
-
 class DLCProjectContext(BaseModel):
     """
     Best-effort DLC project/location context inferred from available hints.
@@ -87,14 +85,11 @@ class DLCProjectContext(BaseModel):
         if root_anchor is None:
             root_anchor = project_root or dataset_folder
 
-        return self.model_copy(
-            update={
-                "root_anchor": root_anchor,
-                "project_root": project_root,
-                "config_path": config_path,
-                "dataset_folder": dataset_folder,
-            }
-        )
+        object.__setattr__(self, "root_anchor", root_anchor)
+        object.__setattr__(self, "project_root", project_root)
+        object.__setattr__(self, "config_path", config_path)
+        object.__setattr__(self, "dataset_folder", dataset_folder)
+        return self
 
 
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
+from pathlib import Path
 from typing import Any
 
 import numpy as np
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 def unsorted_unique(array: Sequence) -> np.ndarray:
@@ -24,6 +25,76 @@ class MetadataKind(str, Enum):
 
     IMAGE = "image"
     POINTS = "points"
+
+
+# -----------------------------------------------------------------------------
+# Project structure models
+# -----------------------------------------------------------------------------
+
+
+class DLCProjectContext(BaseModel):
+    """
+    Best-effort DLC project/location context inferred from available hints.
+
+    All fields are optional because users may open partial project fragments
+    (e.g. only a video, only a labeled-data folder, only annotations).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    root_anchor: Path | None = Field(
+        default=None,
+        description="Base folder anchor used for project-relative resolution when no stronger hint exists.",
+    )
+    project_root: Path | None = Field(
+        default=None,
+        description="Folder containing config.yaml, if inferable.",
+    )
+    config_path: Path | None = Field(
+        default=None,
+        description="Resolved path to DLC config.yaml, if inferable.",
+    )
+    dataset_folder: Path | None = Field(
+        default=None,
+        description="Resolved labeled-data/<dataset> folder, if inferable.",
+    )
+
+    @model_validator(mode="after")
+    def _normalize_and_validate(self) -> DLCProjectContext:
+        def _norm(p: Path | None) -> Path | None:
+            if p is None:
+                return None
+            try:
+                return p.expanduser().resolve()
+            except Exception:
+                return p
+
+        root_anchor = _norm(self.root_anchor)
+        project_root = _norm(self.project_root)
+        config_path = _norm(self.config_path)
+        dataset_folder = _norm(self.dataset_folder)
+
+        # If config_path is present, project_root should default to its parent
+        if config_path is not None and project_root is None:
+            project_root = config_path.parent
+
+        # If project_root exists and config_path is missing, infer config path conventionally
+        if project_root is not None and config_path is None:
+            candidate = project_root / "config.yaml"
+            config_path = candidate
+
+        # If root_anchor is missing, prefer project_root, otherwise dataset_folder
+        if root_anchor is None:
+            root_anchor = project_root or dataset_folder
+
+        return self.model_copy(
+            update={
+                "root_anchor": root_anchor,
+                "project_root": project_root,
+                "config_path": config_path,
+                "dataset_folder": dataset_folder,
+            }
+        )
 
 
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -79,7 +79,8 @@ class DLCProjectContext(BaseModel):
         # If project_root exists and config_path is missing, infer config path conventionally
         if project_root is not None and config_path is None:
             candidate = project_root / "config.yaml"
-            config_path = candidate
+            if candidate.exists():
+                config_path = candidate
 
         # If root_anchor is missing, prefer project_root, otherwise dataset_folder
         if root_anchor is None:

--- a/src/napari_deeplabcut/core/conflicts.py
+++ b/src/napari_deeplabcut/core/conflicts.py
@@ -100,7 +100,7 @@ def compute_overwrite_report_for_points_save(
     # Same GT fallback logic as write_hdf(...)
     if not out_path:
         project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
-        dataset_dir = project_ctx.dataset_folder or project_ctx.root_anchor
+        dataset_dir = project_ctx.dataset_folder
 
         if dataset_dir is not None:
             dataset_dir.mkdir(parents=True, exist_ok=True)

--- a/src/napari_deeplabcut/core/conflicts.py
+++ b/src/napari_deeplabcut/core/conflicts.py
@@ -156,3 +156,53 @@ def compute_overwrite_report_for_points_save(
     )
 
     return report if report.has_conflicts else None
+
+
+def compute_overwrite_report_for_extracted_labels_row(
+    destination_path: str | Path,
+    df_new: pd.DataFrame,
+    *,
+    layer_name: str | None = None,
+) -> OverwriteConflictReport | None:
+    """
+    Compute an overwrite-conflict report for a single extracted-frame labels row
+    being merged into an existing machinelabels-iter0.h5 file.
+
+    Parameters
+    ----------
+    destination_path:
+        Existing or prospective machinelabels file.
+    df_new:
+        A one-row DLC-style dataframe for the extracted frame, indexed by the
+        canonical image path tuple.
+    layer_name:
+        Optional display name for the source layer in the dialog.
+
+    Returns
+    -------
+    OverwriteConflictReport | None
+        Report if overwrites would occur, otherwise None.
+    """
+    from napari_deeplabcut.core.dataframes import (
+        build_overwrite_conflict_report,
+        keypoint_conflicts,
+    )
+
+    out = Path(destination_path)
+    if not out.exists():
+        return None
+
+    try:
+        df_old = pd.read_hdf(out, key="df_with_missing")
+    except (KeyError, ValueError):
+        df_old = pd.read_hdf(out)
+
+    key_conflict = keypoint_conflicts(df_old, df_new)
+
+    report = build_overwrite_conflict_report(
+        key_conflict,
+        layer_name=layer_name or "Extracted frame labels",
+        destination_path=str(out),
+    )
+
+    return report if report.has_conflicts else None

--- a/src/napari_deeplabcut/core/conflicts.py
+++ b/src/napari_deeplabcut/core/conflicts.py
@@ -10,8 +10,8 @@ from napari_deeplabcut.core import schemas as dlc_schemas
 from napari_deeplabcut.core.dataframes import set_df_scorer
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
 from napari_deeplabcut.core.metadata import parse_points_metadata
+from napari_deeplabcut.core.project_paths import infer_dlc_project_from_points_meta
 from napari_deeplabcut.core.provenance import (
-    infer_dataset_folder_from_points_meta,
     resolve_output_path_from_metadata,
 )
 
@@ -99,7 +99,8 @@ def compute_overwrite_report_for_points_save(
 
     # Same GT fallback logic as write_hdf(...)
     if not out_path:
-        dataset_dir = infer_dataset_folder_from_points_meta(pts_meta)
+        project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
+        dataset_dir = project_ctx.dataset_folder or project_ctx.root_anchor
 
         if dataset_dir is not None:
             dataset_dir.mkdir(parents=True, exist_ok=True)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -355,8 +355,8 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
         # Prefer dataset folder if inferable (DLC convention)
         project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
         dataset_dir = None
-        if project_ctx is not None:
-            dataset_dir = project_ctx.dataset_folder or project_ctx.root_anchor
+        if project_ctx is not None and project_ctx.dataset_folder is not None:
+            dataset_dir = project_ctx.dataset_folder
 
         # If dataset_dir exists or can be created, use it; else fall back to pts_meta.root
         if dataset_dir is not None:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -45,8 +45,8 @@ from napari_deeplabcut.core.dataframes import (
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
 from napari_deeplabcut.core.layers import populate_keypoint_layer_properties
 from napari_deeplabcut.core.metadata import attach_source_and_io, parse_points_metadata
-from napari_deeplabcut.core.project_paths import canonicalize_path
-from napari_deeplabcut.core.provenance import infer_dataset_folder_from_points_meta, resolve_output_path_from_metadata
+from napari_deeplabcut.core.project_paths import canonicalize_path, infer_dlc_project_from_points_meta
+from napari_deeplabcut.core.provenance import resolve_output_path_from_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -353,7 +353,10 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
             raise MissingProvenanceError("Cannot resolve provenance output path for MACHINE source.")
 
         # Prefer dataset folder if inferable (DLC convention)
-        dataset_dir = infer_dataset_folder_from_points_meta(pts_meta)
+        project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
+        dataset_dir = None
+        if project_ctx is not None:
+            dataset_dir = project_ctx.dataset_folder or project_ctx.root_anchor
 
         # If dataset_dir exists or can be created, use it; else fall back to pts_meta.root
         if dataset_dir is not None:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -45,7 +45,7 @@ from napari_deeplabcut.core.dataframes import (
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
 from napari_deeplabcut.core.layers import populate_keypoint_layer_properties
 from napari_deeplabcut.core.metadata import attach_source_and_io, parse_points_metadata
-from napari_deeplabcut.core.paths import canonicalize_path
+from napari_deeplabcut.core.project_paths import canonicalize_path
 from napari_deeplabcut.core.provenance import infer_dataset_folder_from_points_meta, resolve_output_path_from_metadata
 
 logger = logging.getLogger(__name__)

--- a/src/napari_deeplabcut/core/metadata.py
+++ b/src/napari_deeplabcut/core/metadata.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ValidationError
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, ImageMetadata, IOProvenance, PointsMetadata
 from napari_deeplabcut.core.discovery import infer_annotation_kind_for_file
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
-from napari_deeplabcut.core.paths import canonicalize_path
+from napari_deeplabcut.core.project_paths import canonicalize_path
 
 logger = logging.getLogger(__name__)
 

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
-from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+
+from napari_deeplabcut.config.models import DLCProjectContext
 
 logger = logging.getLogger(__name__)
 
@@ -30,8 +31,6 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 # Canonicalization
 # -----------------------------------------------------------------------------
-
-
 def canonicalize_path(p: str | Path, n: int = 3) -> str:
     """
     Return canonical POSIX path built from the last n path components.
@@ -202,21 +201,150 @@ def should_force_dlc_reader(paths: str | Path | Iterable[str | Path]) -> bool:
 # -----------------------------------------------------------------------------
 # Root-anchor inference utilities
 # -----------------------------------------------------------------------------
+def normalize_anchor_candidate(value: str | Path | None) -> Path | None:
+    """Return a normalized directory anchor from a file/folder candidate."""
+    if value is None:
+        return None
+
+    try:
+        p = Path(value).expanduser().resolve()
+    except Exception:
+        try:
+            p = Path(value)
+        except Exception:
+            return None
+
+    if p.is_file():
+        return p.parent
+    return p
 
 
-@dataclass(frozen=True)
-class DLCPathContext:
+def infer_dlc_project(
+    *,
+    anchor_candidates: list[str | Path] | tuple[str | Path, ...] = (),
+    dataset_candidates: list[str | Path] | tuple[str | Path, ...] = (),
+    explicit_root: str | Path | None = None,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
     """
-    Best-effort DLC location context inferred from user-opened content.
+    Infer a best-effort DLC project context from generic path-like hints.
 
-    Fields are optional because users may open partial project fragments
-    (e.g. only a video, only a labeled-data folder, or only annotations).
+    Parameters
+    ----------
+    anchor_candidates:
+        Ordered candidates that may indicate a project anchor, project root,
+        file parent, source directory, etc.
+    dataset_candidates:
+        Ordered candidates that may already point at a labeled-data dataset folder.
+    explicit_root:
+        Strongest hint. If provided, used first.
+    prefer_project_root:
+        If True, root_anchor prefers the folder containing config.yaml.
+        Otherwise it prefers the first valid anchor candidate.
     """
+    anchors: list[Path] = []
 
-    root_anchor: Path | None = None
-    project_root: Path | None = None
-    config_path: Path | None = None
-    dataset_folder: Path | None = None
+    if explicit_root is not None:
+        a = normalize_anchor_candidate(explicit_root)
+        if a is not None:
+            anchors.append(a)
+
+    for cand in anchor_candidates:
+        a = normalize_anchor_candidate(cand)
+        if a is not None and a not in anchors:
+            anchors.append(a)
+
+    dataset_folder = None
+    for cand in dataset_candidates:
+        d = normalize_anchor_candidate(cand)
+        if d is not None:
+            dataset_folder = d
+            break
+
+    # First try to find config from anchors
+    for anchor in anchors:
+        cfg = find_nearest_config(anchor, max_levels=max_levels)
+        if cfg is not None:
+            project_root = cfg.parent
+            root_anchor = project_root if prefer_project_root else anchor
+            return DLCProjectContext(
+                root_anchor=root_anchor,
+                project_root=project_root,
+                config_path=cfg,
+                dataset_folder=dataset_folder,
+            )
+
+    # No config found: still return best-effort context
+    root_anchor = anchors[0] if anchors else dataset_folder
+    return DLCProjectContext(
+        root_anchor=root_anchor,
+        project_root=None,
+        config_path=None,
+        dataset_folder=dataset_folder,
+    )
+
+
+def infer_labeled_data_folder_from_paths(
+    paths: list[str | Path] | tuple[str | Path, ...],
+    *,
+    project_root: str | Path | None = None,
+    fallback_root: str | Path | None = None,
+) -> Path | None:
+    """
+    Infer a DLC labeled-data/<dataset> folder from path hints.
+
+    Accepts canonicalized or partially relative paths such as:
+      labeled-data/test/img000.png
+    """
+    # If fallback_root already looks like a labeled-data dataset folder, use it
+    for root_like in (fallback_root,):
+        anchor = normalize_anchor_candidate(root_like)
+        if anchor is not None:
+            lowered = [part.lower() for part in anchor.parts]
+            if "labeled-data" in lowered and anchor.name.lower() != "labeled-data":
+                return anchor
+
+    dataset_name = None
+    for s in paths:
+        try:
+            text = str(s).replace("\\", "/")
+        except Exception:
+            continue
+        parts = [p for p in text.split("/") if p]
+        lowered = [p.lower() for p in parts]
+        try:
+            idx = lowered.index("labeled-data")
+        except ValueError:
+            continue
+        if idx + 1 < len(parts):
+            dataset_name = parts[idx + 1]
+            break
+
+    if not dataset_name:
+        return None
+
+    proj = normalize_anchor_candidate(project_root)
+    if proj is not None:
+        return proj / "labeled-data" / dataset_name
+
+    return None
+
+
+def infer_dlc_project_from_opened(
+    opened: str | Path,
+    *,
+    explicit_root: str | Path | None = None,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
+    return infer_dlc_project(
+        anchor_candidates=[opened],
+        dataset_candidates=[],
+        explicit_root=explicit_root,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
 
 
 def infer_root_anchor(
@@ -261,27 +389,22 @@ def infer_root_anchor(
 
 
 def find_nearest_config(
-    start: str | Path,
+    start: str | Path | None,
     *,
     max_levels: int = 5,
 ) -> Path | None:
-    """Walk upward from start to find the nearest config.yaml."""
-    try:
-        p = Path(start)
-    except Exception:
+    """
+    Walk upward from start to find the nearest config.yaml.
+    """
+    anchor = normalize_anchor_candidate(start)
+    if anchor is None:
         return None
 
-    if p.is_file():
-        p = p.parent
-
-    cur = p
+    cur = anchor
     for _ in range(max_levels + 1):
         cfg = cur / "config.yaml"
-        if is_config_yaml(cfg):
-            try:
-                return cfg.expanduser().resolve()
-            except Exception:
-                return cfg
+        if cfg.is_file() and cfg.name.lower() == "config.yaml":
+            return cfg
         if cur.parent == cur:
             break
         cur = cur.parent

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -15,7 +15,7 @@ Therefore the root anchor must be inferable from what the user opened:
   root, but must remain configurable and must not be required.
 """
 
-# src/napari_deeplabcut/core/paths.py
+# src/napari_deeplabcut/core/project_paths.py
 from __future__ import annotations
 
 import logging

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -23,7 +23,7 @@ from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
 
-from napari_deeplabcut.config.models import DLCProjectContext
+from napari_deeplabcut.config.models import DLCProjectContext, PointsMetadata
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +201,41 @@ def should_force_dlc_reader(paths: str | Path | Iterable[str | Path]) -> bool:
 # -----------------------------------------------------------------------------
 # Root-anchor inference utilities
 # -----------------------------------------------------------------------------
+def _collect_anchor_candidates(
+    *values: str | Path | None,
+) -> list[Path]:
+    anchors: list[Path] = []
+    for value in values:
+        anchor = normalize_anchor_candidate(value)
+        if anchor is not None and anchor not in anchors:
+            anchors.append(anchor)
+    return anchors
+
+
+def _is_labeled_data_dataset_folder(path: Path | None) -> bool:
+    if path is None:
+        return False
+    lowered = [part.lower() for part in path.parts]
+    return "labeled-data" in lowered and path.name.lower() != "labeled-data"
+
+
+def _extract_dataset_name_from_paths(paths: Iterable[str | Path]) -> str | None:
+    for value in paths:
+        try:
+            text = str(value).replace("\\", "/")
+        except Exception:
+            continue
+        parts = [p for p in text.split("/") if p]
+        lowered = [p.lower() for p in parts]
+        try:
+            idx = lowered.index("labeled-data")
+        except ValueError:
+            continue
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    return None
+
+
 def normalize_anchor_candidate(value: str | Path | None) -> Path | None:
     """Return a normalized directory anchor from a file/folder candidate."""
     if value is None:
@@ -243,17 +278,7 @@ def infer_dlc_project(
         If True, root_anchor prefers the folder containing config.yaml.
         Otherwise it prefers the first valid anchor candidate.
     """
-    anchors: list[Path] = []
-
-    if explicit_root is not None:
-        a = normalize_anchor_candidate(explicit_root)
-        if a is not None:
-            anchors.append(a)
-
-    for cand in anchor_candidates:
-        a = normalize_anchor_candidate(cand)
-        if a is not None and a not in anchors:
-            anchors.append(a)
+    anchors = _collect_anchor_candidates(explicit_root, *anchor_candidates)
 
     dataset_folder = None
     for cand in dataset_candidates:
@@ -262,7 +287,6 @@ def infer_dlc_project(
             dataset_folder = d
             break
 
-    # First try to find config from anchors
     for anchor in anchors:
         cfg = find_nearest_config(anchor, max_levels=max_levels)
         if cfg is not None:
@@ -275,10 +299,8 @@ def infer_dlc_project(
                 dataset_folder=dataset_folder,
             )
 
-    # No config found: still return best-effort context
-    root_anchor = anchors[0] if anchors else dataset_folder
     return DLCProjectContext(
-        root_anchor=root_anchor,
+        root_anchor=anchors[0] if anchors else dataset_folder,
         project_root=None,
         config_path=None,
         dataset_folder=dataset_folder,
@@ -286,106 +308,27 @@ def infer_dlc_project(
 
 
 def infer_labeled_data_folder_from_paths(
-    paths: list[str | Path] | tuple[str | Path, ...],
+    paths: Iterable[str | Path],
     *,
     project_root: str | Path | None = None,
     fallback_root: str | Path | None = None,
 ) -> Path | None:
     """
     Infer a DLC labeled-data/<dataset> folder from path hints.
-
-    Accepts canonicalized or partially relative paths such as:
-      labeled-data/test/img000.png
     """
-    # If fallback_root already looks like a labeled-data dataset folder, use it
-    for root_like in (fallback_root,):
-        anchor = normalize_anchor_candidate(root_like)
-        if anchor is not None:
-            lowered = [part.lower() for part in anchor.parts]
-            if "labeled-data" in lowered and anchor.name.lower() != "labeled-data":
-                return anchor
+    fallback = normalize_anchor_candidate(fallback_root)
+    if _is_labeled_data_dataset_folder(fallback):
+        return fallback
 
-    dataset_name = None
-    for s in paths:
-        try:
-            text = str(s).replace("\\", "/")
-        except Exception:
-            continue
-        parts = [p for p in text.split("/") if p]
-        lowered = [p.lower() for p in parts]
-        try:
-            idx = lowered.index("labeled-data")
-        except ValueError:
-            continue
-        if idx + 1 < len(parts):
-            dataset_name = parts[idx + 1]
-            break
-
+    dataset_name = _extract_dataset_name_from_paths(paths)
     if not dataset_name:
         return None
 
     proj = normalize_anchor_candidate(project_root)
-    if proj is not None:
-        return proj / "labeled-data" / dataset_name
-
-    return None
-
-
-def infer_dlc_project_from_opened(
-    opened: str | Path,
-    *,
-    explicit_root: str | Path | None = None,
-    prefer_project_root: bool = True,
-    max_levels: int = 5,
-) -> DLCProjectContext:
-    return infer_dlc_project(
-        anchor_candidates=[opened],
-        dataset_candidates=[],
-        explicit_root=explicit_root,
-        prefer_project_root=prefer_project_root,
-        max_levels=max_levels,
-    )
-
-
-def infer_root_anchor(
-    opened: str | Path,
-    *,
-    explicit_root: str | Path | None = None,
-) -> str | None:
-    """Infer a best-effort root anchor given a user-opened path.
-
-    Parameters
-    ----------
-    opened:
-        Path that the user opened (file or directory).
-    explicit_root:
-        If provided, this wins and is returned as-is.
-
-    Returns
-    -------
-    str | None
-        A directory path to use as anchor, or None if inference fails.
-
-    Notes
-    -----
-    This is intentionally conservative and does not search globally.
-    """
-    if explicit_root:
-        return str(Path(explicit_root))
-
-    try:
-        p = Path(opened)
-    except Exception:
+    if proj is None:
         return None
 
-    if p.is_dir():
-        return str(p)
-
-    if p.is_file():
-        return str(p.parent)
-
-    # If path does not exist (e.g., virtual/remote), give up.
-    return None
+    return proj / "labeled-data" / dataset_name
 
 
 def find_nearest_config(
@@ -412,68 +355,104 @@ def find_nearest_config(
     return None
 
 
-def find_nearest_project_root(
-    start: str | Path,
-    *,
-    max_levels: int = 5,
-) -> str | None:
-    """Walk parents upwards to find a folder containing config.yaml.
-
-    This is used as an *optional* enhancement. The result should be treated as
-    a candidate anchor, not as a required project root.
-
-    Parameters
-    ----------
-    start:
-        Starting file or directory.
-    max_levels:
-        Maximum number of parent levels to inspect.
-
-    Returns
-    -------
-    str | None
-        Directory containing config.yaml if found, else None.
-    """
-    cfg = find_nearest_config(start, max_levels=max_levels)
-    return str(cfg.parent) if cfg else None
-
-
-def choose_anchor_candidate(
-    *,
+# -----------------------------------------------------------------------------
+# Source-specific adapters
+# -----------------------------------------------------------------------------
+def infer_dlc_project_from_opened(
     opened: str | Path,
+    *,
     explicit_root: str | Path | None = None,
-    prefer_project_root: bool = False,
-) -> str | None:
-    """Choose a root anchor candidate.
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
+    return infer_dlc_project(
+        anchor_candidates=[opened],
+        explicit_root=explicit_root,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
 
-    Strategy
-    --------
-    1) If explicit_root provided -> use it.
-    2) Infer anchor from opened path (file parent or directory).
-    3) If prefer_project_root is True and a nearby config.yaml exists ->
-       return the nearest project root.
 
-    This does *not* validate existence of expected DLC files; callers may.
+def infer_dlc_project_from_points_meta(
+    pts_meta: PointsMetadata,
+    *,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
     """
-    if explicit_root:
-        return str(Path(explicit_root))
+    Infer DLC dataset folder (…/labeled-data/<dataset>) from PointsMetadata.
 
-    anchor = infer_root_anchor(opened)
-    if not anchor:
-        return None
+    Uses:
+      - pts_meta.project (config parent) as project root
+      - pts_meta.paths (canonicalized relpaths like labeled-data/test/img000.png)
+      - pts_meta.root as a fallback hint
 
-    if prefer_project_root:
-        pr = find_nearest_project_root(anchor)
-        if pr:
-            return pr
-
-    return anchor
+    Args:
+        pts_meta: PointsMetadata object containing project-related metadata.
+        prefer_project_root: If True, root_anchor prefers the folder containing config.yaml.
+        max_levels: Maximum number of levels to search upward for config.yaml.
 
 
-def anchor_contains_dlc_artifacts(anchor: str | Path) -> bool:
-    """Return True if the anchor folder appears to contain DLC artifacts."""
+    Returns a DLCProjectContext object representing the inferred project context.
+    """
+    project = getattr(pts_meta, "project", None)
+    root = getattr(pts_meta, "root", None)
+    paths = getattr(pts_meta, "paths", None) or []
+
+    dataset_folder = infer_labeled_data_folder_from_paths(
+        paths,
+        project_root=project,
+        fallback_root=root,
+    )
+
+    return infer_dlc_project(
+        anchor_candidates=[project, root, dataset_folder],
+        dataset_candidates=[dataset_folder],
+        explicit_root=None,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
+
+
+def infer_dlc_project_from_image_layer(
+    layer,
+    *,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
+    """Best-effort inference of the DLC project context from an Image/video layer using its source metadata.
+
+    Uses:
+      - layer.metadata.project as project root
+      - layer.metadata.root as a fallback hint
+      - layer.source.path as a fallback hint
+
+    Returns a DLCProjectContext object representing the inferred project context.
+    """
+    md = getattr(layer, "metadata", {}) or {}
+
+    candidates: list[str | Path] = []
+
+    project = md.get("project")
+    if isinstance(project, str) and project:
+        candidates.append(project)
+
+    root = md.get("root")
+    if isinstance(root, str) and root:
+        candidates.append(root)
+
     try:
-        return has_dlc_datafiles(anchor)
+        src = getattr(getattr(layer, "source", None), "path", None)
     except Exception:
-        logger.debug("Failed to check DLC artifacts for %r", anchor, exc_info=True)
-        return False
+        src = None
+
+    if src:
+        candidates.append(src)
+
+    return infer_dlc_project(
+        anchor_candidates=candidates,
+        dataset_candidates=[],
+        explicit_root=None,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -249,8 +249,17 @@ def normalize_anchor_candidate(value: str | Path | None) -> Path | None:
         except Exception:
             return None
 
+    # If this is an existing file, anchor on its parent directory.
     if p.is_file():
         return p.parent
+
+    # For non-existent paths, heuristically treat file-like paths (with a suffix)
+    # as files so that their parent directory is used as the anchor. This avoids
+    # searching for config files under a non-existent "<file>/config.yaml".
+    if not p.exists() and p.suffix:
+        return p.parent
+
+    # Existing directories (or suffix-less paths) are used as-is.
     return p
 
 

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
@@ -203,6 +204,21 @@ def should_force_dlc_reader(paths: str | Path | Iterable[str | Path]) -> bool:
 # -----------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class DLCPathContext:
+    """
+    Best-effort DLC location context inferred from user-opened content.
+
+    Fields are optional because users may open partial project fragments
+    (e.g. only a video, only a labeled-data folder, or only annotations).
+    """
+
+    root_anchor: Path | None = None
+    project_root: Path | None = None
+    config_path: Path | None = None
+    dataset_folder: Path | None = None
+
+
 def infer_root_anchor(
     opened: str | Path,
     *,
@@ -244,6 +260,35 @@ def infer_root_anchor(
     return None
 
 
+def find_nearest_config(
+    start: str | Path,
+    *,
+    max_levels: int = 5,
+) -> Path | None:
+    """Walk upward from start to find the nearest config.yaml."""
+    try:
+        p = Path(start)
+    except Exception:
+        return None
+
+    if p.is_file():
+        p = p.parent
+
+    cur = p
+    for _ in range(max_levels + 1):
+        cfg = cur / "config.yaml"
+        if is_config_yaml(cfg):
+            try:
+                return cfg.expanduser().resolve()
+            except Exception:
+                return cfg
+        if cur.parent == cur:
+            break
+        cur = cur.parent
+
+    return None
+
+
 def find_nearest_project_root(
     start: str | Path,
     *,
@@ -266,24 +311,8 @@ def find_nearest_project_root(
     str | None
         Directory containing config.yaml if found, else None.
     """
-    try:
-        p = Path(start)
-    except Exception:
-        return None
-
-    if p.is_file():
-        p = p.parent
-
-    cur = p
-    for _ in range(max_levels + 1):
-        cfg = cur / "config.yaml"
-        if is_config_yaml(cfg):
-            return str(cur)
-        if cur.parent == cur:
-            break
-        cur = cur.parent
-
-    return None
+    cfg = find_nearest_config(start, max_levels=max_levels)
+    return str(cfg.parent) if cfg else None
 
 
 def choose_anchor_candidate(

--- a/src/napari_deeplabcut/core/provenance.py
+++ b/src/napari_deeplabcut/core/provenance.py
@@ -6,91 +6,11 @@ from pathlib import Path, PurePosixPath
 
 from pydantic import ValidationError
 
-from napari_deeplabcut.config.models import AnnotationKind, DLCProjectContext, IOProvenance, PointsMetadata
+from napari_deeplabcut.config.models import AnnotationKind, IOProvenance
 from napari_deeplabcut.core.errors import MissingProvenanceError, UnresolvablePathError
 from napari_deeplabcut.core.metadata import parse_points_metadata
-from napari_deeplabcut.core.project_paths import infer_dlc_project, infer_labeled_data_folder_from_paths
 
 logger = logging.getLogger(__name__)
-
-
-def infer_dlc_project_from_points_meta(
-    pts_meta: PointsMetadata,
-    *,
-    prefer_project_root: bool = True,
-    max_levels: int = 5,
-) -> DLCProjectContext:
-    """
-    Infer DLC dataset folder (…/labeled-data/<dataset>) from PointsMetadata.
-
-    Uses:
-      - pts_meta.project (config parent) as project root
-      - pts_meta.paths (canonicalized relpaths like labeled-data/test/img000.png)
-      - pts_meta.root as a fallback hint
-
-    Returns a DLCProjectContext object representing the inferred project context.
-    """
-    project = getattr(pts_meta, "project", None)
-    root = getattr(pts_meta, "root", None)
-    paths = getattr(pts_meta, "paths", None) or []
-
-    dataset_folder = infer_labeled_data_folder_from_paths(
-        paths,
-        project_root=project,
-        fallback_root=root,
-    )
-
-    return infer_dlc_project(
-        anchor_candidates=[project, root, dataset_folder],
-        dataset_candidates=[dataset_folder],
-        explicit_root=None,
-        prefer_project_root=prefer_project_root,
-        max_levels=max_levels,
-    )
-
-
-def infer_dlc_project_from_image_layer(
-    layer,
-    *,
-    prefer_project_root: bool = True,
-    max_levels: int = 5,
-) -> DLCProjectContext:
-    """Best-effort inference of the DLC project context from an Image/video layer using its source metadata.
-
-    Uses:
-      - layer.metadata.project as project root
-      - layer.metadata.root as a fallback hint
-      - layer.source.path as a fallback hint
-
-    Returns a DLCProjectContext object representing the inferred project context.
-    """
-    md = getattr(layer, "metadata", {}) or {}
-
-    candidates: list[str | Path] = []
-
-    project = md.get("project")
-    if isinstance(project, str) and project:
-        candidates.append(project)
-
-    root = md.get("root")
-    if isinstance(root, str) and root:
-        candidates.append(root)
-
-    try:
-        src = getattr(getattr(layer, "source", None), "path", None)
-    except Exception:
-        src = None
-
-    if src:
-        candidates.append(src)
-
-    return infer_dlc_project(
-        anchor_candidates=candidates,
-        dataset_candidates=[],
-        explicit_root=None,
-        prefer_project_root=prefer_project_root,
-        max_levels=max_levels,
-    )
 
 
 def resolve_output_path_from_metadata(metadata: dict) -> tuple[str | None, str | None, AnnotationKind | None]:

--- a/src/napari_deeplabcut/core/provenance.py
+++ b/src/napari_deeplabcut/core/provenance.py
@@ -6,14 +6,20 @@ from pathlib import Path, PurePosixPath
 
 from pydantic import ValidationError
 
-from napari_deeplabcut.config.models import AnnotationKind, IOProvenance, PointsMetadata
+from napari_deeplabcut.config.models import AnnotationKind, DLCProjectContext, IOProvenance, PointsMetadata
 from napari_deeplabcut.core.errors import MissingProvenanceError, UnresolvablePathError
 from napari_deeplabcut.core.metadata import parse_points_metadata
+from napari_deeplabcut.core.project_paths import infer_dlc_project, infer_labeled_data_folder_from_paths
 
 logger = logging.getLogger(__name__)
 
 
-def infer_dataset_folder_from_points_meta(pts_meta: PointsMetadata) -> Path | None:
+def infer_dlc_project_from_points_meta(
+    pts_meta: PointsMetadata,
+    *,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
     """
     Infer DLC dataset folder (…/labeled-data/<dataset>) from PointsMetadata.
 
@@ -22,48 +28,69 @@ def infer_dataset_folder_from_points_meta(pts_meta: PointsMetadata) -> Path | No
       - pts_meta.paths (canonicalized relpaths like labeled-data/test/img000.png)
       - pts_meta.root as a fallback hint
 
-    Returns a Path to dataset folder or None if not inferable.
+    Returns a DLCProjectContext object representing the inferred project context.
     """
     project = getattr(pts_meta, "project", None)
-    paths = getattr(pts_meta, "paths", None) or []
     root = getattr(pts_meta, "root", None)
+    paths = getattr(pts_meta, "paths", None) or []
 
-    # If root itself is already dataset folder, use it
+    dataset_folder = infer_labeled_data_folder_from_paths(
+        paths,
+        project_root=project,
+        fallback_root=root,
+    )
+
+    return infer_dlc_project(
+        anchor_candidates=[project, root, dataset_folder],
+        dataset_candidates=[dataset_folder],
+        explicit_root=None,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
+
+
+def infer_dlc_project_from_image_layer(
+    layer,
+    *,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
+    """Best-effort inference of the DLC project context from an Image/video layer using its source metadata.
+
+    Uses:
+      - layer.metadata.project as project root
+      - layer.metadata.root as a fallback hint
+      - layer.source.path as a fallback hint
+
+    Returns a DLCProjectContext object representing the inferred project context.
+    """
+    md = getattr(layer, "metadata", {}) or {}
+
+    candidates: list[str | Path] = []
+
+    project = md.get("project")
+    if isinstance(project, str) and project:
+        candidates.append(project)
+
+    root = md.get("root")
+    if isinstance(root, str) and root:
+        candidates.append(root)
+
     try:
-        if root:
-            rp = Path(root).expanduser().resolve()
-            if "labeled-data" in [p.lower() for p in rp.parts] and rp.name.lower() != "labeled-data":
-                return rp
+        src = getattr(getattr(layer, "source", None), "path", None)
     except Exception:
-        pass
+        src = None
 
-    # Infer from paths like "labeled-data/<dataset>/img000.png"
-    dataset_name = None
-    for s in paths:
-        if not isinstance(s, str):
-            continue
-        parts = s.replace("\\", "/").split("/")
-        try:
-            i = [p.lower() for p in parts].index("labeled-data")
-            if i + 1 < len(parts):
-                dataset_name = parts[i + 1]
-                break
-        except ValueError:
-            continue
+    if src:
+        candidates.append(src)
 
-    if not dataset_name:
-        return None
-
-    # Need a project root anchor to build full dataset path
-    if not project:
-        return None
-
-    try:
-        proj = Path(project).expanduser().resolve()
-    except Exception:
-        proj = Path(project)
-
-    return proj / "labeled-data" / dataset_name
+    return infer_dlc_project(
+        anchor_candidates=candidates,
+        dataset_candidates=[],
+        explicit_root=None,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
 
 
 def resolve_output_path_from_metadata(metadata: dict) -> tuple[str | None, str | None, AnnotationKind | None]:
@@ -157,29 +184,6 @@ def normalize_provenance(io: IOProvenance | None) -> IOProvenance | None:
         src = src.replace("\\\\", "/").replace("\\", "/")
 
     return io.model_copy(update={"source_relpath_posix": src})
-
-
-# def build_io_provenance_dict(
-#     *,
-#     project_root: str | Path,
-#     source_relpath_posix: str,
-#     kind: AnnotationKind | None,
-#     dataset_key: str,
-#     **extra: Any,
-# ) -> dict[str, Any]:
-#     """
-#     Build a provenance dict for storage in napari layer.metadata.
-
-#     Important: uses mode="python" so AnnotationKind stays an enum at runtime.
-#     """
-#     io = IOProvenance(
-#         project_root=str(project_root),
-#         source_relpath_posix=source_relpath_posix,
-#         kind=kind,
-#         dataset_key=dataset_key,
-#         **extra,
-#     )
-#     return io.model_dump(mode="python", exclude_none=True)
 
 
 def resolve_provenance_path(

--- a/src/napari_deeplabcut/core/remap.py
+++ b/src/napari_deeplabcut/core/remap.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 
-from napari_deeplabcut.core.paths import PathMatchPolicy, canonicalize_path, find_matching_depth
+from napari_deeplabcut.core.project_paths import PathMatchPolicy, canonicalize_path, find_matching_depth
 
 logger = logging.getLogger(__name__)
 

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -11,7 +11,7 @@ from typing import Protocol
 import numpy as np
 from natsort import natsorted
 
-from napari_deeplabcut.core.paths import canonicalize_path
+from napari_deeplabcut.core.project_paths import canonicalize_path
 from napari_deeplabcut.utils.deprecations import DeprecationMode, deprecated
 
 logger = logging.getLogger(__name__)

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -112,10 +112,6 @@ class CropSavePlan(_CropModel):
         return v
 
 
-def _format_crop(coords: ViewerCropCoords | DLCConfigCropCoords | None) -> str:
-    return str(coords.values) if coords is not None else "none"
-
-
 class VideoActionPanel(QGroupBox):
     """Small video tools panel with lightweight user-facing context."""
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -797,7 +797,12 @@ def execute_crop_save(plan: CropSavePlan) -> str:
     """
     cfg = io.load_config(str(plan.config_path))
     video_sets = cfg.setdefault("video_sets", {})
-    existing = dict(video_sets.get(plan.video_key, {}))
+
+    existing = video_sets.get(plan.video_key)
+    if not isinstance(existing, dict):
+        existing = {}
+        video_sets[plan.video_key] = existing
+
     existing["crop"] = ", ".join(map(str, plan.config_crop.values))
     video_sets[plan.video_key] = existing
     io.write_config(str(plan.config_path), cfg)

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -321,7 +321,7 @@ def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_nam
 
     if src:
         try:
-            return str(Path(src).expanduser().resolve())
+            return str(Path(src).expanduser())
         except Exception:
             return str(Path(src))
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -51,7 +51,7 @@ class ViewerCropCoords(_CropModel):
 
 class DLCConfigCropCoords(_CropModel):
     """
-    Rectangle coordinates in the legacy DLC-compatible config.yaml convention.
+    Rectangle coordinates in the DLC-compatible config.yaml convention.
     Used only for writing cfg['video_sets'][...]['crop'].
     """
 
@@ -351,6 +351,49 @@ def _selected_rectangle_indices(layer: Shapes) -> list[int]:
     return [idx for idx in selected if _is_rectangle_shape(layer, idx)]
 
 
+def _dlc_config_y_extent(viewer) -> int | None:
+    """
+    Return the Y-axis extent used for DLC config crop conversion.
+
+    Prefer the displayed Y axis in napari dims (second-to-last displayed axis),
+    because rectangle coordinates are interpreted from the last two columns as
+    [y, x]. Fall back to an active/last Image layer shape if needed.
+    """
+    try:
+        dims_range = getattr(getattr(viewer, "dims", None), "range", None)
+        if dims_range is not None and len(dims_range) >= 2:
+            return int(dims_range[-2][1])
+    except Exception:
+        pass
+
+    try:
+        active = getattr(getattr(viewer, "layers", None), "selection", None)
+        active = getattr(active, "active", None)
+        if isinstance(active, Image):
+            data = getattr(active, "data", None)
+            if data is not None and hasattr(data, "shape") and len(data.shape) >= 2:
+                # For (t, y, x) -> y is -2
+                # For (t, y, x, c) -> y is -3
+                if len(data.shape) >= 4:
+                    return int(data.shape[-3])
+                return int(data.shape[-2])
+    except Exception:
+        pass
+
+    try:
+        for layer in reversed(viewer.layers):
+            if isinstance(layer, Image):
+                data = getattr(layer, "data", None)
+                if data is not None and hasattr(data, "shape") and len(data.shape) >= 2:
+                    if len(data.shape) >= 4:
+                        return int(data.shape[-3])
+                    return int(data.shape[-2])
+    except Exception:
+        pass
+
+    return None
+
+
 def _rectangle_spec(viewer, layer: Shapes, rect_index: int) -> CropRectangleSpec | None:
     """
     Resolve both coordinate conventions from the same rectangle:
@@ -358,7 +401,7 @@ def _rectangle_spec(viewer, layer: Shapes, rect_index: int) -> CropRectangleSpec
     - viewer_crop:
         raw napari/image-data coordinates used for extraction
     - config_crop:
-        legacy backwards-compatible coordinates written to config.yaml
+        DLC-compatible coordinates written to config.yaml
     """
     try:
         data = np.asarray(layer.data[rect_index], dtype=float)
@@ -393,19 +436,20 @@ def _rectangle_spec(viewer, layer: Shapes, rect_index: int) -> CropRectangleSpec
     viewer_crop = ViewerCropCoords(values=(vx1, vx2, vy1, vy2))
 
     # -----------------------------------------
-    # 2) legacy DLC-compatible config.yaml crop
+    # 2) DLC-compatible config.yaml crop
     # -----------------------------------------
-    try:
-        h = viewer.dims.range[2][1]
-    except Exception:
+    h = _dlc_config_y_extent(viewer)
+    if h is None:
         return None
 
-    legacy_y = h - y_vals
-    legacy = np.column_stack([legacy_y, x_vals])
-    legacy = np.clip(legacy, 0, a_max=None).astype(int)
+    # Flip the coordinates to the DLC convention where Y is inverted
+    # and comes first, then clip to non-negative integers.
+    dlc_y = h - y_vals
+    dlc_crop = np.column_stack([dlc_y, x_vals])
+    dlc_crop = np.clip(dlc_crop, 0, a_max=None).astype(int)
 
-    y1_cfg, x1_cfg = legacy.min(axis=0)
-    y2_cfg, x2_cfg = legacy.max(axis=0)
+    y1_cfg, x1_cfg = dlc_crop.min(axis=0)
+    y2_cfg, x2_cfg = dlc_crop.max(axis=0)
 
     if x2_cfg <= x1_cfg or y2_cfg <= y1_cfg:
         return None

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from napari.layers import Image, Points, Shapes
-from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QPushButton, QVBoxLayout
+from napari.utils.notifications import show_info, show_warning
+from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QMessageBox, QPushButton, QVBoxLayout
 
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut._writer import _write_image
@@ -423,3 +424,162 @@ def store_crop_coordinates(
 
     msg = execute_crop_save(plan)
     return True, msg
+
+
+# ---------------------------------
+# UI helpers
+# ---------------------------------
+def get_active_or_last_layer(viewer, layer_type):
+    """Prefer the active layer when it matches `layer_type`, else fall back to the last layer of that type."""
+    active = viewer.layers.selection.active
+    if isinstance(active, layer_type):
+        return active
+
+    for layer in reversed(viewer.layers):
+        if isinstance(layer, layer_type):
+            return layer
+    return None
+
+
+def resolve_project_path_from_image_layer(layer: Image) -> str | None:
+    """Best-effort project path string from DLC project context."""
+    try:
+        ctx = infer_dlc_project_from_image_layer(layer, prefer_project_root=True)
+    except Exception:
+        return None
+
+    project_path = ctx.project_root or ctx.root_anchor
+    return str(project_path) if project_path is not None else None
+
+
+def update_video_panel_context(viewer, panel) -> None:
+    """Refresh lightweight user-facing context shown in the video action panel."""
+    if panel is None:
+        return
+
+    image_layer = get_active_or_last_layer(viewer, Image)
+    if image_layer is None:
+        panel.set_context_text("Load a video/image layer to enable extraction and crop tools.")
+        return
+
+    try:
+        n_frames = int(image_layer.data.shape[0])
+        frame_index = int(viewer.dims.current_step[0])
+        frame_text = f"Frame {frame_index + 1}/{n_frames}"
+    except Exception:
+        frame_text = "Frame ?/?"
+
+    root_value = (image_layer.metadata or {}).get("root")
+    root_text = str(root_value) if root_value else "unresolved"
+
+    crop = find_crop_rectangle(viewer, prefer_selected=True)
+    crop_text = f"Selected crop: {crop}" if crop is not None else "Selected crop: none"
+
+    panel.set_context_text(f"{frame_text}\nOutput folder: {root_text}\n{crop_text}")
+
+
+def run_extract_current_frame(
+    viewer,
+    panel,
+    *,
+    validate_points_layer=None,
+) -> tuple[bool, str]:
+    """
+    End-to-end frame extraction workflow for the video panel.
+
+    Returns
+    -------
+    (ok, message)
+        ok: whether the extraction completed
+        message: user-facing status text
+    """
+    image_layer = get_active_or_last_layer(viewer, Image)
+    export_labels = bool(getattr(panel, "export_labels_cb", None) and panel.export_labels_cb.isChecked())
+    apply_crop = bool(getattr(panel, "apply_crop_cb", None) and panel.apply_crop_cb.isChecked())
+
+    points_layer = get_active_or_last_layer(viewer, Points) if export_labels else None
+
+    if export_labels and points_layer is not None and callable(validate_points_layer):
+        if not validate_points_layer(points_layer):
+            msg = "The selected Points layer is not a valid DLC keypoints layer for label export."
+            show_warning(msg)
+            return False, msg
+
+    plan, error = plan_frame_extraction(
+        viewer,
+        image_layer=image_layer,
+        points_layer=points_layer,
+        explicit_output_root=(image_layer.metadata or {}).get("root") if image_layer is not None else None,
+        export_labels=export_labels,
+        apply_crop=apply_crop,
+    )
+
+    if plan is None:
+        msg = error or "Could not plan frame extraction."
+        show_warning(msg)
+        return False, msg
+
+    if plan.output_path.exists():
+        answer = QMessageBox.question(
+            panel,
+            "Overwrite extracted frame?",
+            f"The extracted frame already exists:\n\n{plan.output_path}\n\nDo you want to overwrite it?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        if answer != QMessageBox.Yes:
+            return False, "Frame extraction cancelled."
+
+    written_paths, note = execute_frame_extraction(plan)
+
+    msg = f"Extracted frame {plan.frame_index} to {plan.output_path}"
+    if len(written_paths) > 1:
+        msg += f" and updated {written_paths[-1].name}"
+
+    if note:
+        show_warning(note)
+        msg = f"{msg} ({note})"
+    else:
+        show_info(msg)
+
+    return True, msg
+
+
+def run_store_crop_coordinates(
+    viewer,
+    panel,
+    *,
+    explicit_project_path: str | None = None,
+    fallback_video_name: str | None = None,
+) -> tuple[bool, str, str | None]:
+    """
+    End-to-end crop-save workflow for the video panel.
+
+    Returns
+    -------
+    (ok, message, project_path)
+        ok: whether crop save succeeded
+        message: user-facing status text
+        project_path: resolved best-effort project path (if any)
+    """
+    image_layer = get_active_or_last_layer(viewer, Image)
+    if image_layer is None:
+        msg = "No image/video layer is active."
+        show_warning(msg)
+        return False, msg, explicit_project_path
+
+    resolved_project_path = explicit_project_path or resolve_project_path_from_image_layer(image_layer)
+
+    ok, msg = store_crop_coordinates(
+        viewer,
+        image_layer=image_layer,
+        explicit_project_path=resolved_project_path,
+        fallback_video_name=fallback_video_name,
+    )
+
+    if ok:
+        show_info(msg)
+    else:
+        show_warning(msg)
+
+    return ok, msg, resolved_project_path

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -362,9 +362,20 @@ def _dlc_config_y_extent(viewer) -> int | None:
     [y, x]. Fall back to an active/last Image layer shape if needed.
     """
     try:
-        dims_range = getattr(getattr(viewer, "dims", None), "range", None)
-        if dims_range is not None and len(dims_range) >= 2:
-            return int(dims_range[-2][1])
+        dims = getattr(viewer, "dims", None)
+        if dims is not None:
+            dims_range = getattr(dims, "range", None)
+            displayed = getattr(dims, "displayed", None)
+
+            # Preferred: use the second-to-last displayed axis as Y and get its extent.
+            if displayed is not None and hasattr(displayed, "__len__") and len(displayed) >= 2 and dims_range is not None:
+                y_axis = displayed[-2]
+                if isinstance(y_axis, int) and 0 <= y_axis < len(dims_range):
+                    return int(dims_range[y_axis][1])
+
+            # Fallback: legacy behavior using the second-to-last range entry directly.
+            if dims_range is not None and len(dims_range) >= 2:
+                return int(dims_range[-2][1])
     except Exception:
         pass
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -1,0 +1,148 @@
+# src/napari_deeplabcut/ui/cropping.py
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+from napari.layers import Image, Shapes
+from qtpy.QtWidgets import QGroupBox, QPushButton, QVBoxLayout
+
+import napari_deeplabcut.core.io as io
+from napari_deeplabcut.core.project_paths import infer_dlc_project, infer_dlc_project_from_image_layer
+
+
+def build_video_action_menu(*, on_extract_frame, on_store_crop) -> QGroupBox:
+    """Create the small 'Video' action panel used by KeypointControls."""
+    group_box = QGroupBox("Video")
+    layout = QVBoxLayout()
+
+    extract_button = QPushButton("Extract frame")
+    extract_button.clicked.connect(on_extract_frame)
+    layout.addWidget(extract_button)
+
+    crop_button = QPushButton("Store crop coordinates")
+    crop_button.clicked.connect(on_store_crop)
+    layout.addWidget(crop_button)
+
+    group_box.setLayout(layout)
+    return group_box
+
+
+def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_name: str | None = None) -> str | None:
+    """
+    Determine the key used under cfg['video_sets'].
+
+    Prefer the actual loaded video source path if available, otherwise fall back
+    to <project>/videos/<video_name>.
+    """
+    try:
+        src = getattr(getattr(image_layer, "source", None), "path", None)
+    except Exception:
+        src = None
+
+    if src:
+        try:
+            return str(Path(src).expanduser().resolve())
+        except Exception:
+            return str(Path(src))
+
+    video_name = fallback_video_name or getattr(image_layer, "name", None)
+    if not video_name:
+        return None
+
+    return os.path.join(project_path, "videos", video_name)
+
+
+def _find_latest_rectangle_crop(viewer) -> tuple[int, int, int, int] | None:
+    """
+    Return (x1, x2, y1, y2) from the latest rectangle in a Shapes layer.
+
+    This preserves the current coordinate convention used by _widgets.py.
+    """
+    shape_layers = [layer for layer in viewer.layers if isinstance(layer, Shapes)]
+    if not shape_layers:
+        return None
+
+    for layer in reversed(shape_layers):
+        try:
+            rect_indices = [i for i, shape in enumerate(layer.shape_type) if shape == "rectangle"]
+        except Exception:
+            continue
+
+        if not rect_indices:
+            continue
+
+        ind = rect_indices[-1]
+        try:
+            bbox = np.asarray(layer.data[ind])[:, 1:].copy()
+        except Exception:
+            continue
+
+        if bbox.ndim != 2 or bbox.shape[1] != 2:
+            continue
+
+        try:
+            # Preserve the existing convention from _widgets.py
+            h = viewer.dims.range[2][1]
+        except Exception:
+            return None
+
+        bbox[:, 0] = h - bbox[:, 0]
+        bbox = np.clip(bbox, 0, a_max=None).astype(int)
+
+        y1, x1 = bbox.min(axis=0)
+        y2, x2 = bbox.max(axis=0)
+        return int(x1), int(x2), int(y1), int(y2)
+
+    return None
+
+
+def store_crop_coordinates(
+    viewer,
+    *,
+    image_layer: Image,
+    explicit_project_path: str | None = None,
+    fallback_video_name: str | None = None,
+) -> bool:
+    """
+    Persist crop coordinates into the project's config.yaml.
+
+    Returns
+    -------
+    bool
+        True if the crop was written, False otherwise.
+    """
+    if image_layer is None:
+        return False
+
+    if explicit_project_path:
+        ctx = infer_dlc_project(
+            explicit_root=explicit_project_path,
+            anchor_candidates=[getattr(getattr(image_layer, "source", None), "path", None)],
+            prefer_project_root=True,
+        )
+    else:
+        ctx = infer_dlc_project_from_image_layer(image_layer, prefer_project_root=True)
+
+    config_path = ctx.config_path
+    project_root = ctx.project_root or ctx.root_anchor
+
+    if config_path is None or project_root is None:
+        return False
+
+    crop = _find_latest_rectangle_crop(viewer)
+    if crop is None:
+        return False
+
+    video_key = _resolve_video_key(image_layer, str(project_root), fallback_video_name=fallback_video_name)
+    if not video_key:
+        return False
+
+    cfg = io.load_config(str(config_path))
+    video_sets = cfg.setdefault("video_sets", {})
+    existing = dict(video_sets.get(video_key, {}))
+    existing["crop"] = ", ".join(map(str, crop))
+    video_sets[video_key] = existing
+    io.write_config(str(config_path), cfg)
+    return True

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -644,7 +644,7 @@ def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str
 def plan_crop_save(
     viewer,
     *,
-    image_layer: Image,
+    image_layer: Image | None,
     explicit_project_path: str | None = None,
     fallback_video_name: str | None = None,
 ) -> tuple[CropSavePlan | None, str | None]:

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -2,31 +2,90 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-from napari.layers import Image, Shapes
-from qtpy.QtWidgets import QGroupBox, QPushButton, QVBoxLayout
+import pandas as pd
+from napari.layers import Image, Points, Shapes
+from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QPushButton, QVBoxLayout
 
 import napari_deeplabcut.core.io as io
-from napari_deeplabcut.core.project_paths import infer_dlc_project, infer_dlc_project_from_image_layer
+from napari_deeplabcut._writer import _write_image
+from napari_deeplabcut.core.dataframes import guarantee_multiindex_rows
+from napari_deeplabcut.core.project_paths import (
+    canonicalize_path,
+    infer_dlc_project,
+    infer_dlc_project_from_image_layer,
+)
 
 
-def build_video_action_menu(*, on_extract_frame, on_store_crop) -> QGroupBox:
-    """Create the small 'Video' action panel used by KeypointControls."""
-    group_box = QGroupBox("Video")
-    layout = QVBoxLayout()
+@dataclass(frozen=True)
+class FrameExtractionPlan:
+    image_layer: Image
+    points_layer: Points | None
+    frame_index: int
+    output_root: Path
+    output_path: Path
+    labels_path: Path | None
+    export_labels: bool
+    crop: tuple[int, int, int, int] | None
 
-    extract_button = QPushButton("Extract frame")
-    extract_button.clicked.connect(on_extract_frame)
-    layout.addWidget(extract_button)
 
-    crop_button = QPushButton("Store crop coordinates")
-    crop_button.clicked.connect(on_store_crop)
-    layout.addWidget(crop_button)
+@dataclass(frozen=True)
+class CropSavePlan:
+    config_path: Path
+    project_root: Path
+    video_key: str
+    crop: tuple[int, int, int, int]
 
-    group_box.setLayout(layout)
-    return group_box
+
+class VideoActionPanel(QGroupBox):
+    """Small video tools panel with lightweight user-facing context."""
+
+    def __init__(self, *, on_extract_frame, on_store_crop):
+        super().__init__("Video")
+
+        layout = QVBoxLayout(self)
+
+        self.extract_button = QPushButton("Extract current frame")
+        self.extract_button.clicked.connect(on_extract_frame)
+        layout.addWidget(self.extract_button)
+
+        self.export_labels_cb = QCheckBox("Also export labels")
+        self.export_labels_cb.setToolTip(
+            "Write the current frame labels to machinelabels-iter0.h5 if a DLC points layer is available."
+        )
+        layout.addWidget(self.export_labels_cb)
+
+        self.apply_crop_cb = QCheckBox("Apply selected rectangle")
+        self.apply_crop_cb.setToolTip("Crop the extracted frame to the selected rectangle before writing it.")
+        layout.addWidget(self.apply_crop_cb)
+
+        self.crop_button = QPushButton("Save crop to config")
+        self.crop_button.clicked.connect(on_store_crop)
+        layout.addWidget(self.crop_button)
+
+        self.help_label = QLabel(
+            "Extract the current frame from the active video/image layer. "
+            "Optionally export labels and/or apply the selected crop rectangle."
+        )
+        self.help_label.setWordWrap(True)
+        layout.addWidget(self.help_label)
+
+        self.context_label = QLabel("")
+        self.context_label.setWordWrap(True)
+        layout.addWidget(self.context_label)
+
+    def set_context_text(self, text: str) -> None:
+        self.context_label.setText(text or "")
+
+
+def build_video_action_menu(*, on_extract_frame, on_store_crop) -> VideoActionPanel:
+    return VideoActionPanel(
+        on_extract_frame=on_extract_frame,
+        on_store_crop=on_store_crop,
+    )
 
 
 def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_name: str | None = None) -> str | None:
@@ -54,67 +113,241 @@ def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_nam
     return os.path.join(project_path, "videos", video_name)
 
 
-def _find_latest_rectangle_crop(viewer) -> tuple[int, int, int, int] | None:
-    """
-    Return (x1, x2, y1, y2) from the latest rectangle in a Shapes layer.
+def _rectangle_to_crop_tuple(viewer, layer: Shapes, rect_index: int) -> tuple[int, int, int, int] | None:
+    try:
+        bbox = np.asarray(layer.data[rect_index])[:, 1:].copy()
+    except Exception:
+        return None
 
-    This preserves the current coordinate convention used by _widgets.py.
+    if bbox.ndim != 2 or bbox.shape[1] != 2:
+        return None
+
+    try:
+        # Preserve the existing convention from _widgets.py
+        h = viewer.dims.range[2][1]
+    except Exception:
+        return None
+
+    bbox[:, 0] = h - bbox[:, 0]
+    bbox = np.clip(bbox, 0, a_max=None).astype(int)
+
+    y1, x1 = bbox.min(axis=0)
+    y2, x2 = bbox.max(axis=0)
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    return int(x1), int(x2), int(y1), int(y2)
+
+
+def _selected_rectangle_indices(layer: Shapes) -> list[int]:
+    try:
+        selected = list(getattr(layer, "selected_data", set()) or set())
+    except Exception:
+        return []
+
+    out: list[int] = []
+    for idx in selected:
+        try:
+            if layer.shape_type[idx] == "rectangle":
+                out.append(idx)
+        except Exception:
+            continue
+    return out
+
+
+def find_crop_rectangle(viewer, *, prefer_selected: bool = True) -> tuple[int, int, int, int] | None:
+    """
+    Resolve the crop rectangle in a deterministic order:
+
+    1) selected rectangle in active Shapes layer
+    2) selected rectangle in any Shapes layer
+    3) latest rectangle in active Shapes layer
+    4) latest rectangle globally
     """
     shape_layers = [layer for layer in viewer.layers if isinstance(layer, Shapes)]
     if not shape_layers:
         return None
 
+    active = viewer.layers.selection.active
+
+    # 1) selected rectangle in active Shapes layer
+    if prefer_selected and isinstance(active, Shapes):
+        for idx in _selected_rectangle_indices(active):
+            crop = _rectangle_to_crop_tuple(viewer, active, idx)
+            if crop is not None:
+                return crop
+
+    # 2) selected rectangle in any Shapes layer
+    if prefer_selected:
+        for layer in shape_layers:
+            for idx in _selected_rectangle_indices(layer):
+                crop = _rectangle_to_crop_tuple(viewer, layer, idx)
+                if crop is not None:
+                    return crop
+
+    # 3) latest rectangle in active Shapes layer
+    if isinstance(active, Shapes):
+        try:
+            rect_indices = [i for i, shape in enumerate(active.shape_type) if shape == "rectangle"]
+        except Exception:
+            rect_indices = []
+        for idx in reversed(rect_indices):
+            crop = _rectangle_to_crop_tuple(viewer, active, idx)
+            if crop is not None:
+                return crop
+
+    # 4) latest rectangle globally
     for layer in reversed(shape_layers):
         try:
             rect_indices = [i for i, shape in enumerate(layer.shape_type) if shape == "rectangle"]
         except Exception:
-            continue
-
-        if not rect_indices:
-            continue
-
-        ind = rect_indices[-1]
-        try:
-            bbox = np.asarray(layer.data[ind])[:, 1:].copy()
-        except Exception:
-            continue
-
-        if bbox.ndim != 2 or bbox.shape[1] != 2:
-            continue
-
-        try:
-            # Preserve the existing convention from _widgets.py
-            h = viewer.dims.range[2][1]
-        except Exception:
-            return None
-
-        bbox[:, 0] = h - bbox[:, 0]
-        bbox = np.clip(bbox, 0, a_max=None).astype(int)
-
-        y1, x1 = bbox.min(axis=0)
-        y2, x2 = bbox.max(axis=0)
-        return int(x1), int(x2), int(y1), int(y2)
+            rect_indices = []
+        for idx in reversed(rect_indices):
+            crop = _rectangle_to_crop_tuple(viewer, layer, idx)
+            if crop is not None:
+                return crop
 
     return None
 
 
-def store_crop_coordinates(
+def _frame_digits(n_frames: int) -> int:
+    return max(1, len(str(max(n_frames - 1, 0))))
+
+
+def plan_frame_extraction(
+    viewer,
+    *,
+    image_layer: Image | None,
+    points_layer: Points | None = None,
+    explicit_output_root: str | Path | None = None,
+    export_labels: bool = False,
+    apply_crop: bool = False,
+) -> tuple[FrameExtractionPlan | None, str | None]:
+    """
+    Validate and plan a single-frame extraction before doing any I/O.
+    """
+    if image_layer is None:
+        return None, "No image/video layer is active."
+
+    data = getattr(image_layer, "data", None)
+    if data is None or not hasattr(data, "shape") or len(data.shape) < 3:
+        return None, "Active image layer does not look like a video/image stack."
+
+    try:
+        frame_index = int(viewer.dims.current_step[0])
+    except Exception:
+        return None, "Could not determine the current frame index."
+
+    n_frames = int(data.shape[0])
+    if frame_index < 0 or frame_index >= n_frames:
+        return None, f"Current frame index {frame_index} is out of bounds for a stack of length {n_frames}."
+
+    root_value = explicit_output_root or (image_layer.metadata or {}).get("root")
+    if not root_value:
+        return None, "Could not determine the output folder for extracted frames."
+
+    try:
+        output_root = Path(root_value).expanduser().resolve()
+    except Exception:
+        output_root = Path(root_value)
+
+    crop = None
+    if apply_crop:
+        crop = find_crop_rectangle(viewer, prefer_selected=True)
+        if crop is None:
+            return None, "Apply selected rectangle is enabled, but no valid rectangle is selected."
+
+    frame_name = f"img{str(frame_index).zfill(_frame_digits(n_frames))}.png"
+    output_path = output_root / frame_name
+
+    labels_path = None
+    if export_labels:
+        if points_layer is None:
+            return None, "Also export labels is enabled, but no Points layer is available."
+        labels_path = output_root / "machinelabels-iter0.h5"
+
+    return (
+        FrameExtractionPlan(
+            image_layer=image_layer,
+            points_layer=points_layer,
+            frame_index=frame_index,
+            output_root=output_root,
+            output_path=output_path,
+            labels_path=labels_path,
+            export_labels=export_labels,
+            crop=crop,
+        ),
+        None,
+    )
+
+
+def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str | None]:
+    """
+    Execute a previously validated extraction plan.
+
+    Returns
+    -------
+    (written_paths, note)
+        written_paths: all files written
+        note: optional non-fatal note (e.g. labels skipped)
+    """
+    frame = np.asarray(plan.image_layer.data[plan.frame_index])
+
+    if plan.crop is not None:
+        x1, x2, y1, y2 = plan.crop
+        frame = frame[y1:y2, x1:x2]
+
+    plan.output_root.mkdir(parents=True, exist_ok=True)
+    _write_image(frame, str(plan.output_path))
+
+    written = [plan.output_path]
+    note = None
+
+    if plan.export_labels and plan.points_layer is not None and plan.labels_path is not None:
+        df = io.form_df(
+            plan.points_layer.data,
+            layer_metadata=plan.points_layer.metadata,
+            layer_properties=plan.points_layer.properties,
+        )
+
+        if plan.frame_index >= len(df):
+            note = "Frame image was extracted, "
+            "but labels were skipped because the points layer did not contain the current frame."
+            return written, note
+
+        df = df.iloc[plan.frame_index : plan.frame_index + 1]
+
+        canon = canonicalize_path(plan.output_path, 3)
+        df.index = pd.MultiIndex.from_tuples([tuple(canon.split("/"))])
+
+        if plan.labels_path.is_file():
+            try:
+                df_prev = pd.read_hdf(plan.labels_path, key="df_with_missing")
+            except Exception:
+                df_prev = pd.read_hdf(plan.labels_path)
+            guarantee_multiindex_rows(df_prev)
+            df = pd.concat([df_prev, df])
+            df = df[~df.index.duplicated(keep="first")]
+
+        df.to_hdf(plan.labels_path, key="df_with_missing")
+        written.append(plan.labels_path)
+
+    return written, note
+
+
+def plan_crop_save(
     viewer,
     *,
     image_layer: Image,
     explicit_project_path: str | None = None,
     fallback_video_name: str | None = None,
-) -> bool:
+) -> tuple[CropSavePlan | None, str | None]:
     """
-    Persist crop coordinates into the project's config.yaml.
-
-    Returns
-    -------
-    bool
-        True if the crop was written, False otherwise.
+    Validate and plan a crop save to config.yaml before doing any I/O.
     """
     if image_layer is None:
-        return False
+        return None, "No image/video layer is active."
 
     if explicit_project_path:
         ctx = infer_dlc_project(
@@ -129,20 +362,64 @@ def store_crop_coordinates(
     project_root = ctx.project_root or ctx.root_anchor
 
     if config_path is None or project_root is None:
-        return False
+        return None, "Could not determine a DLC config.yaml for this video."
 
-    crop = _find_latest_rectangle_crop(viewer)
+    crop = find_crop_rectangle(viewer, prefer_selected=True)
     if crop is None:
-        return False
+        return None, "Select or draw a valid rectangle before saving a crop."
 
     video_key = _resolve_video_key(image_layer, str(project_root), fallback_video_name=fallback_video_name)
     if not video_key:
-        return False
+        return None, "Could not resolve the current video key for config.yaml."
 
-    cfg = io.load_config(str(config_path))
+    return (
+        CropSavePlan(
+            config_path=Path(config_path),
+            project_root=Path(project_root),
+            video_key=video_key,
+            crop=crop,
+        ),
+        None,
+    )
+
+
+def execute_crop_save(plan: CropSavePlan) -> str:
+    """
+    Persist crop coordinates into the project's config.yaml.
+
+    Returns
+    -------
+    str
+        Success message suitable for user-facing notifications.
+    """
+    cfg = io.load_config(str(plan.config_path))
     video_sets = cfg.setdefault("video_sets", {})
-    existing = dict(video_sets.get(video_key, {}))
-    existing["crop"] = ", ".join(map(str, crop))
-    video_sets[video_key] = existing
-    io.write_config(str(config_path), cfg)
-    return True
+    existing = dict(video_sets.get(plan.video_key, {}))
+    existing["crop"] = ", ".join(map(str, plan.crop))
+    video_sets[plan.video_key] = existing
+    io.write_config(str(plan.config_path), cfg)
+
+    return f"Saved crop {plan.crop} to {plan.config_path.name} for video key {plan.video_key}"
+
+
+def store_crop_coordinates(
+    viewer,
+    *,
+    image_layer: Image,
+    explicit_project_path: str | None = None,
+    fallback_video_name: str | None = None,
+) -> tuple[bool, str]:
+    """
+    Compatibility wrapper used by the widget layer.
+    """
+    plan, error = plan_crop_save(
+        viewer,
+        image_layer=image_layer,
+        explicit_project_path=explicit_project_path,
+        fallback_video_name=fallback_video_name,
+    )
+    if plan is None:
+        return False, (error or "Could not save crop coordinates.")
+
+    msg = execute_crop_save(plan)
+    return True, msg

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 from math import ceil, floor
 from pathlib import Path
 
@@ -10,6 +9,7 @@ import numpy as np
 import pandas as pd
 from napari.layers import Image, Points, Shapes
 from napari.utils.notifications import show_info, show_warning
+from pydantic import BaseModel, ConfigDict, field_validator
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QMessageBox, QPushButton, QVBoxLayout
 
@@ -26,8 +26,49 @@ DLC_CROP_LAYER_NAME = "DLC crop"
 DLC_CROP_LAYER_META_KEY = "_dlc_crop_layer"
 
 
-@dataclass(frozen=True)
-class FrameExtractionPlan:
+class _CropModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+
+class ViewerCropCoords(_CropModel):
+    """
+    Rectangle coordinates in napari/image-data space.
+    Used only for numpy slicing during extraction.
+    """
+
+    values: tuple[int, int, int, int]
+
+    @field_validator("values")
+    @classmethod
+    def _validate_values(cls, v: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+        if len(v) != 4:
+            raise ValueError(f"ViewerCropCoords must be a 4-tuple (x1, x2, y1, y2). Got: {v!r}")
+        x1, x2, y1, y2 = v
+        if x2 <= x1 or y2 <= y1:
+            raise ValueError(f"ViewerCropCoords must satisfy x2>x1 and y2>y1. Got: {v!r}")
+        return v
+
+
+class DLCConfigCropCoords(_CropModel):
+    """
+    Rectangle coordinates in the legacy DLC-compatible config.yaml convention.
+    Used only for writing cfg['video_sets'][...]['crop'].
+    """
+
+    values: tuple[int, int, int, int]
+
+    @field_validator("values")
+    @classmethod
+    def _validate_values(cls, v: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+        if len(v) != 4:
+            raise ValueError(f"DLCConfigCropCoords must be a 4-tuple (x1, x2, y1, y2). Got: {v!r}")
+        x1, x2, y1, y2 = v
+        if x2 <= x1 or y2 <= y1:
+            raise ValueError(f"DLCConfigCropCoords must satisfy x2>x1 and y2>y1. Got: {v!r}")
+        return v
+
+
+class FrameExtractionPlan(_CropModel):
     image_layer: Image
     points_layer: Points | None
     frame_index: int
@@ -35,15 +76,44 @@ class FrameExtractionPlan:
     output_path: Path
     labels_path: Path | None
     export_labels: bool
-    crop: tuple[int, int, int, int] | None
+    viewer_crop: ViewerCropCoords | None = None
+
+    @field_validator("frame_index")
+    @classmethod
+    def _validate_frame_index(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(f"frame_index must be >= 0. Got: {v}")
+        return v
 
 
-@dataclass(frozen=True)
-class CropSavePlan:
+class CropRectangleSpec(_CropModel):
+    """
+    A single resolved rectangle with two explicit coordinate conventions.
+    """
+
+    viewer_crop: ViewerCropCoords
+    config_crop: DLCConfigCropCoords
+
+
+class CropSavePlan(_CropModel):
     config_path: Path
     project_root: Path
     video_key: str
-    crop: tuple[int, int, int, int]
+    config_crop: DLCConfigCropCoords
+
+    @field_validator("config_crop", mode="before")
+    @classmethod
+    def _reject_viewer_coords_for_config(cls, v):
+        if isinstance(v, ViewerCropCoords):
+            raise ValueError(
+                "Refusing to write napari/viewer crop coordinates to DLC config.yaml. "
+                "Use CropRectangleSpec.config_crop or plan_crop_save(...), not viewer_crop."
+            )
+        return v
+
+
+def _format_crop(coords: ViewerCropCoords | DLCConfigCropCoords | None) -> str:
+    return str(coords.values) if coords is not None else "none"
 
 
 class VideoActionPanel(QGroupBox):
@@ -66,9 +136,8 @@ class VideoActionPanel(QGroupBox):
 
         self.apply_crop_cb = QCheckBox("Crop to rectangle")
         self.apply_crop_cb.setToolTip(
-            "When enabled, you can draw a rectangle to specify a crop region for frame extraction. "
-            "The dedicated 'DLC crop' layer is preferred, "
-            "but any rectangle from a Shapes layer will be considered."
+            "Use a rectangle crop for extraction. Viewer coords are used for extraction; "
+            "DLC config coords are saved separately."
         )
         layout.addWidget(self.apply_crop_cb)
 
@@ -76,17 +145,9 @@ class VideoActionPanel(QGroupBox):
         self.crop_button.clicked.connect(on_store_crop)
         layout.addWidget(self.crop_button)
 
-        self.help_label = QLabel(
-            "Extract the current frame from the active video/image layer. "
-            "Optionally export labels and/or apply a rectangle crop. "
-            "When crop is enabled, the dedicated 'DLC crop' layer is preferred, "
-            "but any rectangle from a Shapes layer will be considered."
-        )
-        self.help_label.setWordWrap(True)
-        layout.addWidget(self.help_label)
-
         self.context_label = QLabel("")
         self.context_label.setWordWrap(True)
+        self.context_label.setStyleSheet("color: palette(mid);")
         layout.addWidget(self.context_label)
 
     def set_context_text(self, text: str) -> None:
@@ -291,12 +352,14 @@ def _selected_rectangle_indices(layer: Shapes) -> list[int]:
     return [idx for idx in selected if _is_rectangle_shape(layer, idx)]
 
 
-def _rectangle_bounds(layer: Shapes, rect_index: int) -> tuple[int, int, int, int] | None:
+def _rectangle_spec(viewer, layer: Shapes, rect_index: int) -> CropRectangleSpec | None:
     """
-    Return raw rectangle bounds as (x1, x2, y1, y2) in image/data coordinates.
+    Resolve both coordinate conventions from the same rectangle:
 
-    For video rectangles, napari Shapes data is expected to contain [t, y, x] per vertex.
-    We therefore use the last two columns as [y, x] consistently.
+    - viewer_crop:
+        raw napari/image-data coordinates used for extraction
+    - config_crop:
+        legacy backwards-compatible coordinates written to config.yaml
     """
     try:
         data = np.asarray(layer.data[rect_index], dtype=float)
@@ -306,7 +369,7 @@ def _rectangle_bounds(layer: Shapes, rect_index: int) -> tuple[int, int, int, in
     if data.ndim != 2 or data.shape[1] < 2:
         return None
 
-    # Use the last two coordinate columns as [y, x] so this works for both 2D and 3D shapes.
+    # Use the last two columns consistently as [y, x]
     yx = data[:, -2:]
     if yx.ndim != 2 or yx.shape[1] != 2:
         return None
@@ -317,24 +380,53 @@ def _rectangle_bounds(layer: Shapes, rect_index: int) -> tuple[int, int, int, in
     if len(x_vals) == 0 or len(y_vals) == 0:
         return None
 
-    x1 = max(0, int(floor(np.min(x_vals))))
-    x2 = max(0, int(ceil(np.max(x_vals))))
-    y1 = max(0, int(floor(np.min(y_vals))))
-    y2 = max(0, int(ceil(np.max(y_vals))))
+    # ----------------------------
+    # 1) napari/image-data coords
+    # ----------------------------
+    vx1 = max(0, int(floor(np.min(x_vals))))
+    vx2 = max(0, int(ceil(np.max(x_vals))))
+    vy1 = max(0, int(floor(np.min(y_vals))))
+    vy2 = max(0, int(ceil(np.max(y_vals))))
 
-    if x2 <= x1 or y2 <= y1:
+    if vx2 <= vx1 or vy2 <= vy1:
         return None
 
-    return x1, x2, y1, y2
+    viewer_crop = ViewerCropCoords(values=(vx1, vx2, vy1, vy2))
+
+    # -----------------------------------------
+    # 2) legacy DLC-compatible config.yaml crop
+    # -----------------------------------------
+    try:
+        h = viewer.dims.range[2][1]
+    except Exception:
+        return None
+
+    legacy_y = h - y_vals
+    legacy = np.column_stack([legacy_y, x_vals])
+    legacy = np.clip(legacy, 0, a_max=None).astype(int)
+
+    y1_cfg, x1_cfg = legacy.min(axis=0)
+    y2_cfg, x2_cfg = legacy.max(axis=0)
+
+    if x2_cfg <= x1_cfg or y2_cfg <= y1_cfg:
+        return None
+
+    config_crop = DLCConfigCropCoords(values=(int(x1_cfg), int(x2_cfg), int(y1_cfg), int(y2_cfg)))
+
+    return CropRectangleSpec(
+        viewer_crop=viewer_crop,
+        config_crop=config_crop,
+    )
 
 
 def _find_rectangle_in_layer(
+    viewer,
     layer: Shapes,
     *,
     prefer_selected: bool = True,
-) -> tuple[int, int, int, int] | None:
+) -> CropRectangleSpec | None:
     """
-    Resolve a rectangle from a specific Shapes layer.
+    Resolve a rectangle spec from a specific Shapes layer.
 
     Preference:
     1) selected rectangle(s)
@@ -342,71 +434,75 @@ def _find_rectangle_in_layer(
     """
     if prefer_selected:
         for idx in _selected_rectangle_indices(layer):
-            rect = _rectangle_bounds(layer, idx)
-            if rect is not None:
-                return rect
+            spec = _rectangle_spec(viewer, layer, idx)
+            if spec is not None:
+                return spec
 
     for idx in reversed(_rectangle_indices(layer)):
-        rect = _rectangle_bounds(layer, idx)
-        if rect is not None:
-            return rect
+        spec = _rectangle_spec(viewer, layer, idx)
+        if spec is not None:
+            return spec
 
     return None
 
 
-def find_crop_rectangle(viewer, *, prefer_selected: bool = True) -> tuple[int, int, int, int] | None:
+def find_crop_rectangle(viewer, *, prefer_selected: bool = True) -> CropRectangleSpec | None:
     """
-    Resolve the crop rectangle in a deterministic order:
+    Resolve the crop rectangle spec in a deterministic order:
 
     1) dedicated DLC crop layer (source of truth) if it exists and contains a rectangle
     2) active Shapes layer
     3) next available Shapes layer(s)
+
+    Returns
+    -------
+    CropRectangleSpec | None
+        Contains both:
+        - viewer_crop: for extraction
+        - config_crop: for config.yaml saving
     """
     crop_layer = get_dlc_crop_layer(viewer)
     if crop_layer is not None:
-        rect = _find_rectangle_in_layer(crop_layer, prefer_selected=prefer_selected)
-        if rect is not None:
-            return rect
+        spec = _find_rectangle_in_layer(viewer, crop_layer, prefer_selected=prefer_selected)
+        if spec is not None:
+            return spec
 
     active = viewer.layers.selection.active
     if isinstance(active, Shapes) and not is_dlc_crop_layer(active):
-        rect = _find_rectangle_in_layer(active, prefer_selected=prefer_selected)
-        if rect is not None:
-            return rect
+        spec = _find_rectangle_in_layer(viewer, active, prefer_selected=prefer_selected)
+        if spec is not None:
+            return spec
 
     for layer in viewer.layers:
         if isinstance(layer, Shapes) and not is_dlc_crop_layer(layer):
-            rect = _find_rectangle_in_layer(layer, prefer_selected=prefer_selected)
-            if rect is not None:
-                return rect
+            spec = _find_rectangle_in_layer(viewer, layer, prefer_selected=prefer_selected)
+            if spec is not None:
+                return spec
 
     return None
 
 
-def get_crop_source_summary(viewer) -> tuple[str, tuple[int, int, int, int] | None]:
+def get_crop_source_summary(viewer) -> tuple[str, CropRectangleSpec | None]:
     """
-    Return a human-friendly crop source label plus the resolved crop tuple.
-
-    The coordinates returned are the actual raw rectangle bounds:
-    (x1, x2, y1, y2)
+    Return a human-friendly crop source label plus the resolved rectangle spec.
     """
     crop_layer = get_dlc_crop_layer(viewer)
     if crop_layer is not None:
-        rect = _find_rectangle_in_layer(crop_layer, prefer_selected=True)
-        if rect is not None:
-            return f"{DLC_CROP_LAYER_NAME} layer", rect
+        spec = _find_rectangle_in_layer(viewer, crop_layer, prefer_selected=True)
+        if spec is not None:
+            return f"{DLC_CROP_LAYER_NAME} layer", spec
 
     active = viewer.layers.selection.active
     if isinstance(active, Shapes) and not is_dlc_crop_layer(active):
-        rect = _find_rectangle_in_layer(active, prefer_selected=True)
-        if rect is not None:
-            return f"active Shapes layer ({active.name})", rect
+        spec = _find_rectangle_in_layer(viewer, active, prefer_selected=True)
+        if spec is not None:
+            return f"active Shapes layer ({active.name})", spec
 
     for layer in viewer.layers:
         if isinstance(layer, Shapes) and not is_dlc_crop_layer(layer):
-            rect = _find_rectangle_in_layer(layer, prefer_selected=True)
-            if rect is not None:
-                return f"Shapes layer ({layer.name})", rect
+            spec = _find_rectangle_in_layer(viewer, layer, prefer_selected=True)
+            if spec is not None:
+                return f"Shapes layer ({layer.name})", spec
 
     return "none", None
 
@@ -454,12 +550,13 @@ def plan_frame_extraction(
 
     crop = None
     if apply_crop:
-        crop = find_crop_rectangle(viewer, prefer_selected=True)
-        if crop is None:
+        crop_spec = find_crop_rectangle(viewer, prefer_selected=True)
+        if crop_spec is None:
             return None, (
-                "Apply selected rectangle is enabled, but no valid rectangle was found. "
+                "Crop to rectangle is enabled, but no valid rectangle was found. "
                 "Use the dedicated DLC crop layer or select a rectangle in a Shapes layer."
             )
+        crop = crop_spec.viewer_crop
 
     frame_name = f"img{str(frame_index).zfill(_frame_digits(n_frames))}.png"
     output_path = output_root / frame_name
@@ -479,7 +576,7 @@ def plan_frame_extraction(
             output_path=output_path,
             labels_path=labels_path,
             export_labels=export_labels,
-            crop=crop,
+            viewer_crop=crop,
         ),
         None,
     )
@@ -497,8 +594,8 @@ def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str
     """
     frame = np.asarray(plan.image_layer.data[plan.frame_index])
 
-    if plan.crop is not None:
-        x1, x2, y1, y2 = plan.crop
+    if plan.viewer_crop is not None:
+        x1, x2, y1, y2 = plan.viewer_crop.values
         frame = frame[y1:y2, x1:x2]
 
     plan.output_root.mkdir(parents=True, exist_ok=True)
@@ -569,12 +666,13 @@ def plan_crop_save(
     if config_path is None or project_root is None:
         return None, "Could not determine a DLC config.yaml for this video."
 
-    crop = find_crop_rectangle(viewer, prefer_selected=True)
-    if crop is None:
+    crop_spec = find_crop_rectangle(viewer, prefer_selected=True)
+    if crop_spec is None:
         return None, (
             "No valid rectangle was found for crop saving. "
             "Use the dedicated DLC crop layer or select a rectangle in a Shapes layer."
         )
+    crop = crop_spec.config_crop
 
     video_key = _resolve_video_key(image_layer, str(project_root), fallback_video_name=fallback_video_name)
     if not video_key:
@@ -585,7 +683,7 @@ def plan_crop_save(
             config_path=Path(config_path),
             project_root=Path(project_root),
             video_key=video_key,
-            crop=crop,
+            config_crop=crop,
         ),
         None,
     )
@@ -603,11 +701,11 @@ def execute_crop_save(plan: CropSavePlan) -> str:
     cfg = io.load_config(str(plan.config_path))
     video_sets = cfg.setdefault("video_sets", {})
     existing = dict(video_sets.get(plan.video_key, {}))
-    existing["crop"] = ", ".join(map(str, plan.crop))
+    existing["crop"] = ", ".join(map(str, plan.config_crop.values))
     video_sets[plan.video_key] = existing
     io.write_config(str(plan.config_path), cfg)
 
-    return f"Saved crop {plan.crop} to {plan.config_path.name} for video key {plan.video_key}"
+    return f"Saved crop {plan.config_crop.values} to {plan.config_path.name} for video key {plan.video_key}"
 
 
 def store_crop_coordinates(
@@ -685,11 +783,20 @@ def update_video_panel_context(viewer, panel) -> None:
     root_value = (image_layer.metadata or {}).get("root")
     root_text = str(root_value) if root_value else "unresolved"
 
-    crop_source, crop = get_crop_source_summary(viewer)
-    crop_text = f"{crop}" if crop is not None else "none"
+    crop_source, crop_spec = get_crop_source_summary(viewer)
+
+    viewer_crop_text = "none"
+    config_crop_text = "none"
+    if crop_spec is not None:
+        viewer_crop_text = str(crop_spec.viewer_crop.values)
+        config_crop_text = str(crop_spec.config_crop.values)
 
     panel.set_context_text(
-        f"{frame_text}\nOutput folder: {root_text}\nCrop source: {crop_source}\nCrop (x1, x2, y1, y2): {crop_text}"
+        f"{frame_text}\n"
+        f"Output folder: {root_text}\n"
+        f"Crop source: {crop_source}\n"
+        f"napari/viewer crop (used for extraction): {viewer_crop_text}\n"
+        f"DLC config crop (saved to config.yaml): {config_crop_text}"
     )
 
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -368,7 +368,12 @@ def _dlc_config_y_extent(viewer) -> int | None:
             displayed = getattr(dims, "displayed", None)
 
             # Preferred: use the second-to-last displayed axis as Y and get its extent.
-            if displayed is not None and hasattr(displayed, "__len__") and len(displayed) >= 2 and dims_range is not None:
+            if (
+                displayed is not None
+                and hasattr(displayed, "__len__")
+                and len(displayed) >= 2
+                and dims_range is not None
+            ):
                 y_axis = displayed[-2]
                 if isinstance(y_axis, int) and 0 <= y_axis < len(dims_range):
                     return int(dims_range[y_axis][1])

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -15,12 +15,14 @@ from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QMessageBox, QPushButto
 
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut._writer import _write_image
+from napari_deeplabcut.core.conflicts import compute_overwrite_report_for_extracted_labels_row
 from napari_deeplabcut.core.dataframes import guarantee_multiindex_rows
 from napari_deeplabcut.core.project_paths import (
     canonicalize_path,
     infer_dlc_project,
     infer_dlc_project_from_image_layer,
 )
+from napari_deeplabcut.ui.dialogs import maybe_confirm_overwrite
 
 DLC_CROP_LAYER_NAME = "DLC crop"
 DLC_CROP_LAYER_META_KEY = "_dlc_crop_layer"
@@ -625,6 +627,66 @@ def plan_frame_extraction(
     )
 
 
+def _build_extracted_frame_labels_df(plan: FrameExtractionPlan) -> tuple[pd.DataFrame | None, str | None]:
+    """
+    Build the one-row labels dataframe corresponding to the extracted frame.
+
+    Returns
+    -------
+    (df, note)
+        df: one-row dataframe ready to merge into machinelabels-iter0.h5
+        note: optional non-fatal message if labels cannot be built for this frame
+    """
+    if plan.points_layer is None or plan.labels_path is None:
+        return None, None
+
+    df = io.form_df(
+        plan.points_layer.data,
+        layer_metadata=plan.points_layer.metadata,
+        layer_properties=plan.points_layer.properties,
+    )
+
+    if plan.frame_index >= len(df):
+        return None, (
+            "Frame image was extracted, "
+            "but labels were skipped because the points layer did not contain the current frame."
+        )
+
+    df = df.iloc[plan.frame_index : plan.frame_index + 1]
+
+    canon = canonicalize_path(plan.output_path, 3)
+    df.index = pd.MultiIndex.from_tuples([tuple(canon.split("/"))])
+
+    return df, None
+
+
+def compute_extracted_labels_overwrite_report(
+    plan: FrameExtractionPlan,
+) -> tuple[object | None, str | None]:
+    """
+    Compute overwrite report for the extracted-frame labels merge.
+
+    Returns
+    -------
+    (report, note)
+        report: OverwriteConflictReport or None
+        note: optional non-fatal note if labels cannot be built for this frame
+    """
+    if not plan.export_labels or plan.points_layer is None or plan.labels_path is None:
+        return None, None
+
+    df_new, note = _build_extracted_frame_labels_df(plan)
+    if df_new is None:
+        return None, note
+
+    report = compute_overwrite_report_for_extracted_labels_row(
+        plan.labels_path,
+        df_new,
+        layer_name=getattr(plan.points_layer, "name", None),
+    )
+    return report, note
+
+
 def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str | None]:
     """
     Execute a previously validated extraction plan.
@@ -648,34 +710,26 @@ def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str
     note = None
 
     if plan.export_labels and plan.points_layer is not None and plan.labels_path is not None:
-        df = io.form_df(
-            plan.points_layer.data,
-            layer_metadata=plan.points_layer.metadata,
-            layer_properties=plan.points_layer.properties,
-        )
-
-        if plan.frame_index >= len(df):
-            note = (
-                "Frame image was extracted, "
-                "but labels were skipped because the points layer did not contain the current frame."
-            )
+        df_new, note = _build_extracted_frame_labels_df(plan)
+        if df_new is None:
             return written, note
-
-        df = df.iloc[plan.frame_index : plan.frame_index + 1]
-
-        canon = canonicalize_path(plan.output_path, 3)
-        df.index = pd.MultiIndex.from_tuples([tuple(canon.split("/"))])
 
         if plan.labels_path.is_file():
             try:
                 df_prev = pd.read_hdf(plan.labels_path, key="df_with_missing")
             except Exception:
                 df_prev = pd.read_hdf(plan.labels_path)
-            guarantee_multiindex_rows(df_prev)
-            df = pd.concat([df_prev, df])
-            df = df[~df.index.duplicated(keep="first")]
 
-        df.to_hdf(plan.labels_path, key="df_with_missing")
+            guarantee_multiindex_rows(df_prev)
+            df_merged = pd.concat([df_prev, df_new])
+
+            # IMPORTANT:
+            # Keep the newly exported row when the frame already exists.
+            df_merged = df_merged[~df_merged.index.duplicated(keep="last")]
+        else:
+            df_merged = df_new
+
+        df_merged.to_hdf(plan.labels_path, key="df_with_missing")
         written.append(plan.labels_path)
 
     return written, note
@@ -887,6 +941,7 @@ def run_extract_current_frame(
         show_warning(msg)
         return False, msg
 
+    # 1) Image overwrite confirmation
     if plan.output_path.exists():
         answer = QMessageBox.question(
             panel,
@@ -898,15 +953,34 @@ def run_extract_current_frame(
         if answer != QMessageBox.Yes:
             return False, "Frame extraction cancelled."
 
-    written_paths, note = execute_frame_extraction(plan)
+    # 2) Labels overwrite preflight using the shared conflict dialog infrastructure
+    report = None
+    note = None
+    if plan.export_labels and plan.points_layer is not None and plan.labels_path is not None:
+        report, note = compute_extracted_labels_overwrite_report(plan)
+
+        if note is not None:
+            # non-fatal: image can still be extracted even if labels are missing for this frame
+            pass
+
+        if report is not None:
+            if not maybe_confirm_overwrite(
+                parent=panel,
+                report=report,
+            ):
+                return False, "Frame extraction cancelled."
+
+    written_paths, exec_note = execute_frame_extraction(plan)
+
+    final_note = exec_note or note
 
     msg = f"Extracted frame {plan.frame_index} to {plan.output_path}"
     if len(written_paths) > 1:
         msg += f" and updated {written_paths[-1].name}"
 
-    if note:
-        show_warning(note)
-        msg = f"{msg} ({note})"
+    if final_note:
+        show_warning(final_note)
+        msg = f"{msg} ({final_note})"
     else:
         show_info(msg)
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from math import ceil, floor
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from napari.layers import Image, Points, Shapes
 from napari.utils.notifications import show_info, show_warning
+from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QCheckBox, QGroupBox, QLabel, QMessageBox, QPushButton, QVBoxLayout
 
 import napari_deeplabcut.core.io as io
@@ -19,6 +21,9 @@ from napari_deeplabcut.core.project_paths import (
     infer_dlc_project,
     infer_dlc_project_from_image_layer,
 )
+
+DLC_CROP_LAYER_NAME = "DLC crop"
+DLC_CROP_LAYER_META_KEY = "_dlc_crop_layer"
 
 
 @dataclass(frozen=True)
@@ -59,8 +64,12 @@ class VideoActionPanel(QGroupBox):
         )
         layout.addWidget(self.export_labels_cb)
 
-        self.apply_crop_cb = QCheckBox("Apply selected rectangle")
-        self.apply_crop_cb.setToolTip("Crop the extracted frame to the selected rectangle before writing it.")
+        self.apply_crop_cb = QCheckBox("Crop to rectangle")
+        self.apply_crop_cb.setToolTip(
+            "When enabled, you can draw a rectangle to specify a crop region for frame extraction. "
+            "The dedicated 'DLC crop' layer is preferred, "
+            "but any rectangle from a Shapes layer will be considered."
+        )
         layout.addWidget(self.apply_crop_cb)
 
         self.crop_button = QPushButton("Save crop to config")
@@ -69,7 +78,9 @@ class VideoActionPanel(QGroupBox):
 
         self.help_label = QLabel(
             "Extract the current frame from the active video/image layer. "
-            "Optionally export labels and/or apply the selected crop rectangle."
+            "Optionally export labels and/or apply a rectangle crop. "
+            "When crop is enabled, the dedicated 'DLC crop' layer is preferred, "
+            "but any rectangle from a Shapes layer will be considered."
         )
         self.help_label.setWordWrap(True)
         layout.addWidget(self.help_label)
@@ -87,6 +98,149 @@ def build_video_action_menu(*, on_extract_frame, on_store_crop) -> VideoActionPa
         on_extract_frame=on_extract_frame,
         on_store_crop=on_store_crop,
     )
+
+
+def is_dlc_crop_layer(layer) -> bool:
+    return isinstance(layer, Shapes) and bool((layer.metadata or {}).get(DLC_CROP_LAYER_META_KEY, False))
+
+
+def get_dlc_crop_layer(viewer) -> Shapes | None:
+    for layer in viewer.layers:
+        if is_dlc_crop_layer(layer):
+            return layer
+    return None
+
+
+def ensure_dlc_crop_layer(viewer) -> Shapes:
+    """
+    Ensure a dedicated crop Shapes layer exists and is ready for rectangle drawing.
+    """
+    existing = get_dlc_crop_layer(viewer)
+    if existing is not None:
+        existing.visible = True
+        try:
+            viewer.layers.selection.active = existing
+        except Exception:
+            pass
+        try:
+            existing.mode = "add_rectangle"
+        except Exception:
+            pass
+        return existing
+
+    layer = viewer.add_shapes(
+        name=DLC_CROP_LAYER_NAME,
+        metadata={DLC_CROP_LAYER_META_KEY: True},
+    )
+    try:
+        layer.mode = "add_rectangle"
+    except Exception:
+        pass
+
+    try:
+        viewer.layers.selection.active = layer
+    except Exception:
+        pass
+
+    return layer
+
+
+def handle_apply_crop_toggled(viewer, panel, checked: bool) -> None:
+    """
+    When crop application is enabled, create/select the dedicated crop layer and
+    make it the preferred source of truth for crop rectangles.
+
+    Auto-refresh wiring is synchronized by update_video_panel_context(...),
+    so this function only needs to ensure the layer exists when enabled.
+    """
+    if checked:
+        ensure_dlc_crop_layer(viewer)
+
+    update_video_panel_context(viewer, panel)
+
+
+# ---------------------------------
+# Dedicated crop-layer auto-refresh
+# ---------------------------------
+
+
+def _ensure_crop_refresh_timer(panel, refresh_callback) -> QTimer:
+    """
+    Create (once) a lightweight debounce timer stored on the panel.
+
+    We debounce crop refreshes because Shapes data can emit repeatedly while
+    the user drags/resizes a rectangle.
+    """
+    timer = getattr(panel, "_dlc_crop_refresh_timer", None)
+    if timer is not None:
+        return timer
+
+    timer = QTimer(panel)
+    timer.setSingleShot(True)
+    timer.setInterval(30)  # small debounce; coalesces drag/resize bursts
+    timer.timeout.connect(refresh_callback)
+    panel._dlc_crop_refresh_timer = timer
+    return timer
+
+
+def _schedule_crop_refresh(panel, refresh_callback) -> None:
+    timer = _ensure_crop_refresh_timer(panel, refresh_callback)
+    timer.start()
+
+
+def sync_crop_layer_autorefresh(viewer, panel, refresh_callback) -> None:
+    """
+    Keep a debounced data-change listener attached only to the dedicated DLC crop layer.
+
+    This is intentionally a no-op in all other contexts:
+    - no dedicated crop layer -> nothing connected
+    - same layer already connected -> nothing changes
+    - crop layer removed/replaced -> disconnect old, connect new
+    """
+    current_layer = get_dlc_crop_layer(viewer)
+
+    prev_layer = getattr(panel, "_dlc_crop_refresh_layer", None)
+    prev_handler = getattr(panel, "_dlc_crop_refresh_handler", None)
+
+    # Fast no-op path: already synced to the current dedicated crop layer
+    if current_layer is not None and prev_layer is current_layer and prev_handler is not None:
+        return
+
+    # Disconnect previous listener if present
+    if prev_layer is not None and prev_handler is not None:
+        try:
+            prev_layer.events.data.disconnect(prev_handler)
+        except Exception:
+            pass
+
+    panel._dlc_crop_refresh_layer = None
+    panel._dlc_crop_refresh_handler = None
+
+    timer = getattr(panel, "_dlc_crop_refresh_timer", None)
+    if current_layer is None and timer is not None:
+        try:
+            timer.stop()
+        except Exception:
+            pass
+
+    if current_layer is None:
+        return
+
+    def _on_crop_layer_change(event=None):
+        _schedule_crop_refresh(panel, refresh_callback)
+
+    try:
+        current_layer.events.data.connect(_on_crop_layer_change)
+    except Exception:
+        return
+
+    try:
+        current_layer.events.selected_data.connect(_on_crop_layer_change)
+    except Exception:
+        pass
+
+    panel._dlc_crop_refresh_layer = current_layer
+    panel._dlc_crop_refresh_handler = _on_crop_layer_change
 
 
 def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_name: str | None = None) -> str | None:
@@ -114,31 +268,18 @@ def _resolve_video_key(image_layer: Image, project_path: str, fallback_video_nam
     return os.path.join(project_path, "videos", video_name)
 
 
-def _rectangle_to_crop_tuple(viewer, layer: Shapes, rect_index: int) -> tuple[int, int, int, int] | None:
+def _is_rectangle_shape(layer: Shapes, index: int) -> bool:
     try:
-        bbox = np.asarray(layer.data[rect_index])[:, 1:].copy()
+        return layer.shape_type[index] == "rectangle"
     except Exception:
-        return None
+        return False
 
-    if bbox.ndim != 2 or bbox.shape[1] != 2:
-        return None
 
+def _rectangle_indices(layer: Shapes) -> list[int]:
     try:
-        # Preserve the existing convention from _widgets.py
-        h = viewer.dims.range[2][1]
+        return [i for i, _shape in enumerate(layer.shape_type) if _is_rectangle_shape(layer, i)]
     except Exception:
-        return None
-
-    bbox[:, 0] = h - bbox[:, 0]
-    bbox = np.clip(bbox, 0, a_max=None).astype(int)
-
-    y1, x1 = bbox.min(axis=0)
-    y2, x2 = bbox.max(axis=0)
-
-    if x2 <= x1 or y2 <= y1:
-        return None
-
-    return int(x1), int(x2), int(y1), int(y2)
+        return []
 
 
 def _selected_rectangle_indices(layer: Shapes) -> list[int]:
@@ -147,69 +288,127 @@ def _selected_rectangle_indices(layer: Shapes) -> list[int]:
     except Exception:
         return []
 
-    out: list[int] = []
-    for idx in selected:
-        try:
-            if layer.shape_type[idx] == "rectangle":
-                out.append(idx)
-        except Exception:
-            continue
-    return out
+    return [idx for idx in selected if _is_rectangle_shape(layer, idx)]
+
+
+def _rectangle_bounds(layer: Shapes, rect_index: int) -> tuple[int, int, int, int] | None:
+    """
+    Return raw rectangle bounds as (x1, x2, y1, y2) in image/data coordinates.
+
+    For video rectangles, napari Shapes data is expected to contain [t, y, x] per vertex.
+    We therefore use the last two columns as [y, x] consistently.
+    """
+    try:
+        data = np.asarray(layer.data[rect_index], dtype=float)
+    except Exception:
+        return None
+
+    if data.ndim != 2 or data.shape[1] < 2:
+        return None
+
+    # Use the last two coordinate columns as [y, x] so this works for both 2D and 3D shapes.
+    yx = data[:, -2:]
+    if yx.ndim != 2 or yx.shape[1] != 2:
+        return None
+
+    y_vals = yx[:, 0]
+    x_vals = yx[:, 1]
+
+    if len(x_vals) == 0 or len(y_vals) == 0:
+        return None
+
+    x1 = max(0, int(floor(np.min(x_vals))))
+    x2 = max(0, int(ceil(np.max(x_vals))))
+    y1 = max(0, int(floor(np.min(y_vals))))
+    y2 = max(0, int(ceil(np.max(y_vals))))
+
+    if x2 <= x1 or y2 <= y1:
+        return None
+
+    return x1, x2, y1, y2
+
+
+def _find_rectangle_in_layer(
+    layer: Shapes,
+    *,
+    prefer_selected: bool = True,
+) -> tuple[int, int, int, int] | None:
+    """
+    Resolve a rectangle from a specific Shapes layer.
+
+    Preference:
+    1) selected rectangle(s)
+    2) latest rectangle in that layer
+    """
+    if prefer_selected:
+        for idx in _selected_rectangle_indices(layer):
+            rect = _rectangle_bounds(layer, idx)
+            if rect is not None:
+                return rect
+
+    for idx in reversed(_rectangle_indices(layer)):
+        rect = _rectangle_bounds(layer, idx)
+        if rect is not None:
+            return rect
+
+    return None
 
 
 def find_crop_rectangle(viewer, *, prefer_selected: bool = True) -> tuple[int, int, int, int] | None:
     """
     Resolve the crop rectangle in a deterministic order:
 
-    1) selected rectangle in active Shapes layer
-    2) selected rectangle in any Shapes layer
-    3) latest rectangle in active Shapes layer
-    4) latest rectangle globally
+    1) dedicated DLC crop layer (source of truth) if it exists and contains a rectangle
+    2) active Shapes layer
+    3) next available Shapes layer(s)
     """
-    shape_layers = [layer for layer in viewer.layers if isinstance(layer, Shapes)]
-    if not shape_layers:
-        return None
+    crop_layer = get_dlc_crop_layer(viewer)
+    if crop_layer is not None:
+        rect = _find_rectangle_in_layer(crop_layer, prefer_selected=prefer_selected)
+        if rect is not None:
+            return rect
 
     active = viewer.layers.selection.active
+    if isinstance(active, Shapes) and not is_dlc_crop_layer(active):
+        rect = _find_rectangle_in_layer(active, prefer_selected=prefer_selected)
+        if rect is not None:
+            return rect
 
-    # 1) selected rectangle in active Shapes layer
-    if prefer_selected and isinstance(active, Shapes):
-        for idx in _selected_rectangle_indices(active):
-            crop = _rectangle_to_crop_tuple(viewer, active, idx)
-            if crop is not None:
-                return crop
-
-    # 2) selected rectangle in any Shapes layer
-    if prefer_selected:
-        for layer in shape_layers:
-            for idx in _selected_rectangle_indices(layer):
-                crop = _rectangle_to_crop_tuple(viewer, layer, idx)
-                if crop is not None:
-                    return crop
-
-    # 3) latest rectangle in active Shapes layer
-    if isinstance(active, Shapes):
-        try:
-            rect_indices = [i for i, shape in enumerate(active.shape_type) if shape == "rectangle"]
-        except Exception:
-            rect_indices = []
-        for idx in reversed(rect_indices):
-            crop = _rectangle_to_crop_tuple(viewer, active, idx)
-            if crop is not None:
-                return crop
-
-    # 4) latest rectangle globally
-    for layer in reversed(shape_layers):
-        try:
-            rect_indices = [i for i, shape in enumerate(layer.shape_type) if shape == "rectangle"]
-        except Exception:
-            rect_indices = []
-        for idx in reversed(rect_indices):
-            crop = _rectangle_to_crop_tuple(viewer, layer, idx)
-            if crop is not None:
-                return crop
+    for layer in viewer.layers:
+        if isinstance(layer, Shapes) and not is_dlc_crop_layer(layer):
+            rect = _find_rectangle_in_layer(layer, prefer_selected=prefer_selected)
+            if rect is not None:
+                return rect
 
     return None
+
+
+def get_crop_source_summary(viewer) -> tuple[str, tuple[int, int, int, int] | None]:
+    """
+    Return a human-friendly crop source label plus the resolved crop tuple.
+
+    The coordinates returned are the actual raw rectangle bounds:
+    (x1, x2, y1, y2)
+    """
+    crop_layer = get_dlc_crop_layer(viewer)
+    if crop_layer is not None:
+        rect = _find_rectangle_in_layer(crop_layer, prefer_selected=True)
+        if rect is not None:
+            return f"{DLC_CROP_LAYER_NAME} layer", rect
+
+    active = viewer.layers.selection.active
+    if isinstance(active, Shapes) and not is_dlc_crop_layer(active):
+        rect = _find_rectangle_in_layer(active, prefer_selected=True)
+        if rect is not None:
+            return f"active Shapes layer ({active.name})", rect
+
+    for layer in viewer.layers:
+        if isinstance(layer, Shapes) and not is_dlc_crop_layer(layer):
+            rect = _find_rectangle_in_layer(layer, prefer_selected=True)
+            if rect is not None:
+                return f"Shapes layer ({layer.name})", rect
+
+    return "none", None
 
 
 def _frame_digits(n_frames: int) -> int:
@@ -257,7 +456,10 @@ def plan_frame_extraction(
     if apply_crop:
         crop = find_crop_rectangle(viewer, prefer_selected=True)
         if crop is None:
-            return None, "Apply selected rectangle is enabled, but no valid rectangle is selected."
+            return None, (
+                "Apply selected rectangle is enabled, but no valid rectangle was found. "
+                "Use the dedicated DLC crop layer or select a rectangle in a Shapes layer."
+            )
 
     frame_name = f"img{str(frame_index).zfill(_frame_digits(n_frames))}.png"
     output_path = output_root / frame_name
@@ -313,8 +515,10 @@ def execute_frame_extraction(plan: FrameExtractionPlan) -> tuple[list[Path], str
         )
 
         if plan.frame_index >= len(df):
-            note = "Frame image was extracted, "
-            "but labels were skipped because the points layer did not contain the current frame."
+            note = (
+                "Frame image was extracted, "
+                "but labels were skipped because the points layer did not contain the current frame."
+            )
             return written, note
 
         df = df.iloc[plan.frame_index : plan.frame_index + 1]
@@ -367,7 +571,10 @@ def plan_crop_save(
 
     crop = find_crop_rectangle(viewer, prefer_selected=True)
     if crop is None:
-        return None, "Select or draw a valid rectangle before saving a crop."
+        return None, (
+            "No valid rectangle was found for crop saving. "
+            "Use the dedicated DLC crop layer or select a rectangle in a Shapes layer."
+        )
 
     video_key = _resolve_video_key(image_layer, str(project_root), fallback_video_name=fallback_video_name)
     if not video_key:
@@ -457,6 +664,12 @@ def update_video_panel_context(viewer, panel) -> None:
     if panel is None:
         return
 
+    sync_crop_layer_autorefresh(
+        viewer,
+        panel,
+        refresh_callback=lambda: update_video_panel_context(viewer, panel),
+    )
+
     image_layer = get_active_or_last_layer(viewer, Image)
     if image_layer is None:
         panel.set_context_text("Load a video/image layer to enable extraction and crop tools.")
@@ -472,10 +685,12 @@ def update_video_panel_context(viewer, panel) -> None:
     root_value = (image_layer.metadata or {}).get("root")
     root_text = str(root_value) if root_value else "unresolved"
 
-    crop = find_crop_rectangle(viewer, prefer_selected=True)
-    crop_text = f"Selected crop: {crop}" if crop is not None else "Selected crop: none"
+    crop_source, crop = get_crop_source_summary(viewer)
+    crop_text = f"{crop}" if crop is not None else "none"
 
-    panel.set_context_text(f"{frame_text}\nOutput folder: {root_text}\n{crop_text}")
+    panel.set_context_text(
+        f"{frame_text}\nOutput folder: {root_text}\nCrop source: {crop_source}\nCrop (x1, x2, y1, y2): {crop_text}"
+    )
 
 
 def run_extract_current_frame(

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -145,9 +145,8 @@ class VideoActionPanel(QGroupBox):
         self.crop_button.clicked.connect(on_store_crop)
         layout.addWidget(self.crop_button)
 
-        self.context_label = QLabel("")
+        self.context_label = QLabel("No crop or video context yet.")
         self.context_label.setWordWrap(True)
-        self.context_label.setStyleSheet("color: palette(mid);")
         layout.addWidget(self.context_label)
 
     def set_context_text(self, text: str) -> None:
@@ -271,6 +270,10 @@ def sync_crop_layer_autorefresh(viewer, panel, refresh_callback) -> None:
     if prev_layer is not None and prev_handler is not None:
         try:
             prev_layer.events.data.disconnect(prev_handler)
+        except Exception:
+            pass
+        try:
+            prev_layer.events.selected_data.disconnect(prev_handler)
         except Exception:
             pass
 
@@ -770,7 +773,7 @@ def update_video_panel_context(viewer, panel) -> None:
 
     image_layer = get_active_or_last_layer(viewer, Image)
     if image_layer is None:
-        panel.set_context_text("Load a video/image layer to enable extraction and crop tools.")
+        panel.set_context_text("No active video/image layer.")
         return
 
     try:
@@ -785,18 +788,21 @@ def update_video_panel_context(viewer, panel) -> None:
 
     crop_source, crop_spec = get_crop_source_summary(viewer)
 
-    viewer_crop_text = "none"
-    config_crop_text = "none"
-    if crop_spec is not None:
-        viewer_crop_text = str(crop_spec.viewer_crop.values)
-        config_crop_text = str(crop_spec.config_crop.values)
+    if crop_spec is None:
+        panel.set_context_text(
+            f"{frame_text}\nOutput folder: {root_text}\nCrop source: {crop_source}\nNo valid rectangle selected yet."
+        )
+        return
+
+    viewer_crop_text = str(crop_spec.viewer_crop.values)
+    config_crop_text = str(crop_spec.config_crop.values)
 
     panel.set_context_text(
         f"{frame_text}\n"
         f"Output folder: {root_text}\n"
         f"Crop source: {crop_source}\n"
-        f"napari/viewer crop (used for extraction): {viewer_crop_text}\n"
-        f"DLC config crop (saved to config.yaml): {config_crop_text}"
+        f"Viewer crop: {viewer_crop_text}\n"
+        f"Config crop: {config_crop_text}"
     )
 
 


### PR DESCRIPTION
## Summary
This PR consolidates DLC path/project inference into a new core.project_paths module and updates IO/save routing to use a typed DLCProjectContext. It also introduces a dedicated ui.cropping module to handle video frame extraction and crop-to-config workflows with clearer UI, better validation, and regression tests.

### What changed

- Replaced legacy core.paths usage with core.project_paths
- Added DLCProjectContext for best-effort project/config/dataset resolution
- Updated save/conflict routing to infer dataset/project context consistently
- Moved video extraction + crop logic out of _widgets.py into ui.cropping
- Added a dedicated “Video” panel with:
  - Extract current frame
  - Also export labels
  - Crop to rectangle
  - Save crop to config
- Added dedicated crop layer support (DLC crop) and crop context display
- Preserved backwards-compatible DLC crop config coordinates while keeping napari/viewer crop coordinates explicit for extraction
- Expanded tests for:
  - project-path inference
  - overwrite/conflict GT fallback
  - video panel controls
  - crop coordinate regression / UI crop logic



### Why

This PR reduces duplicated path logic, makes save routing more predictable, and improves the UX around manual frame extraction/cropping by validating actions before writing files and surfacing clearer context in the UI.

### Compatibility notes

Crop saving remains backwards-compatible with the previous DLC config coordinate convention.
Extraction and config-saving now use distinct, explicit coordinate semantics:
- viewer crop → frame extraction
- config crop → config.yaml

### Testing

Added/updated unit tests for project_paths, conflict routing, widget video actions, and crop logic/regression.
Existing tests updated to use DLCProjectContext-based project inference.