### PR TITLE
Plugin refactor [4-III]:: Centralize keybinds config, improve shortcuts window

### DIFF
--- a/src/napari_deeplabcut/_tests/config/test_keybinds.py
+++ b/src/napari_deeplabcut/_tests/config/test_keybinds.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+import napari_deeplabcut.config.keybinds as keybinds
+
+
+class DummyLayer:
+    def __init__(self):
+        self.bound = []
+
+    def bind_key(self, key, callback, overwrite=False):
+        self.bound.append(
+            {
+                "key": key,
+                "callback": callback,
+                "overwrite": overwrite,
+            }
+        )
+
+
+def test_iter_shortcuts_returns_registry():
+    shortcuts = tuple(keybinds.iter_shortcuts())
+    assert shortcuts == keybinds.SHORTCUTS
+    assert shortcuts, "SHORTCUTS should not be empty"
+
+
+def test_shortcuts_registry_points_layer_entries_have_callbacks():
+    for spec in keybinds.SHORTCUTS:
+        assert spec.keys
+        assert spec.description
+        assert spec.group
+        assert spec.scope in {"points-layer", "global-points"}
+
+        if spec.scope == "points-layer":
+            assert spec.get_callback is not None
+            assert spec.action is not None
+
+
+def test_shortcuts_registry_has_no_duplicate_keys_within_scope():
+    seen = set()
+
+    for spec in keybinds.SHORTCUTS:
+        for key in spec.keys:
+            item = (spec.scope, key)
+            assert item not in seen, f"Duplicate shortcut declared for scope/key: {item}"
+            seen.add(item)
+
+
+def test_bind_each_key_binds_all_keys():
+    layer = DummyLayer()
+
+    def callback():
+        return None
+
+    keybinds._bind_each_key(layer, ("A", "B"), callback, overwrite=True)
+
+    assert layer.bound == [
+        {"key": "A", "callback": callback, "overwrite": True},
+        {"key": "B", "callback": callback, "overwrite": True},
+    ]
+
+
+def test_install_points_layer_keybindings_binds_registry_declared_shortcuts():
+    layer = DummyLayer()
+
+    controls = SimpleNamespace(
+        cycle_through_label_modes=object(),
+        cycle_through_color_modes=object(),
+    )
+    store = SimpleNamespace(
+        next_keypoint=object(),
+        prev_keypoint=object(),
+        _find_first_unlabeled_frame=object(),
+    )
+
+    keybinds.install_points_layer_keybindings(layer, controls, store)
+
+    expected = []
+    ctx = keybinds.BindingContext(controls=controls, store=store)
+
+    for spec in keybinds.SHORTCUTS:
+        if spec.scope != "points-layer":
+            continue
+        callback = spec.get_callback(ctx)
+        for key in spec.keys:
+            expected.append(
+                {
+                    "key": key,
+                    "callback": callback,
+                    "overwrite": spec.overwrite,
+                }
+            )
+
+    assert layer.bound == expected
+
+
+def test_callback_resolvers_return_expected_methods():
+    controls = SimpleNamespace(
+        cycle_through_label_modes=object(),
+        cycle_through_color_modes=object(),
+    )
+    store = SimpleNamespace(
+        next_keypoint=object(),
+        prev_keypoint=object(),
+        _find_first_unlabeled_frame=object(),
+    )
+    ctx = keybinds.BindingContext(controls=controls, store=store)
+
+    assert keybinds._cycle_label_mode(ctx) is controls.cycle_through_label_modes
+    assert keybinds._cycle_color_mode(ctx) is controls.cycle_through_color_modes
+    assert keybinds._next_keypoint(ctx) is store.next_keypoint
+    assert keybinds._prev_keypoint(ctx) is store.prev_keypoint
+    assert keybinds._jump_unlabeled_frame(ctx) is store._find_first_unlabeled_frame
+
+
+def test_toggle_edge_color_toggles_between_0_and_2():
+    layer = SimpleNamespace(border_width=np.array([0, 2, 0, 2]))
+
+    keybinds.toggle_edge_color(layer)
+    np.testing.assert_array_equal(layer.border_width, np.array([2, 0, 2, 0]))
+
+    keybinds.toggle_edge_color(layer)
+    np.testing.assert_array_equal(layer.border_width, np.array([0, 2, 0, 2]))
+
+
+def test_install_global_points_keybindings_installs_once(monkeypatch):
+    calls = []
+
+    class DummyPoints:
+        @staticmethod
+        def bind_key(key):
+            calls.append(("bind_key", key))
+
+            def decorator(callback):
+                calls.append(("decorated", key, callback))
+                return callback
+
+            return decorator
+
+    monkeypatch.setattr(keybinds, "Points", DummyPoints)
+    monkeypatch.setattr(keybinds, "_global_points_bindings_installed", False)
+
+    keybinds.install_global_points_keybindings()
+    first_calls = list(calls)
+
+    keybinds.install_global_points_keybindings()
+    second_calls = list(calls)
+
+    assert first_calls, "Expected at least one global binding registration"
+    assert second_calls == first_calls, "Second install should be a no-op"
+
+
+def test_global_shortcuts_are_not_missing_install_support():
+    """
+    Help ensure all global shortcuts have corresponding installation code
+    by asserting that all global actions are accounted for.
+    """
+    global_actions = {spec.action for spec in keybinds.SHORTCUTS if spec.scope == "global-points"}
+    assert global_actions == {keybinds.ShortcutAction.TOGGLE_EDGE_COLOR}

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -7,13 +7,14 @@ import numpy as np
 import pytest
 import yaml
 from napari.layers import Image
-from qtpy.QtSvgWidgets import QSvgWidget
+from qtpy.QtWidgets import QScrollArea
 from vispy import keys
 
 from napari_deeplabcut import _widgets
 from napari_deeplabcut.core import io, keypoints
 from napari_deeplabcut.core.io import populate_keypoint_layer_properties
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemeDisplay
+from napari_deeplabcut.ui.dialogs import ShortcutRow
 from napari_deeplabcut.ui.labels_and_dropdown import KeypointsDropdownMenu, LabelPair
 from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
 
@@ -385,15 +386,9 @@ def test_display_shortcuts_dialog(viewer, qtbot):
 
     # Verify it is visible
     assert dlg.isVisible()
-
-    # Ensure the SVG widget is present
-    found_svg = False
-    for child in dlg.children():
-        if isinstance(child, QSvgWidget):
-            found_svg = True
-            break
-
-    assert found_svg, "Shortcuts dialog should contain a QSvgWidget with the shortcuts image."
+    assert dlg.windowTitle() == "Keyboard shortcuts"
+    assert dlg.findChildren(QScrollArea)
+    assert dlg.findChildren(ShortcutRow)
 
 
 # NOTE SuperAnimal keypoints functionality and testing may need an overhaul in the future:

--- a/src/napari_deeplabcut/_tests/ui/test_dialogs.py
+++ b/src/napari_deeplabcut/_tests/ui/test_dialogs.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import numpy as np
+from napari.layers import Image, Points
 from qtpy.QtCore import QPoint, Qt
-from qtpy.QtSvgWidgets import QSvgWidget
-from qtpy.QtWidgets import QDialog, QLabel, QPlainTextEdit, QPushButton
+from qtpy.QtWidgets import QDialog, QLabel, QPlainTextEdit, QPushButton, QScrollArea
 
+from napari_deeplabcut.config.keybinds import iter_shortcuts
 from napari_deeplabcut.ui.dialogs import (
     OverwriteConflictsDialog,
+    ShortcutRow,
     Shortcuts,
     Tutorial,
     maybe_confirm_overwrite,
@@ -18,18 +21,120 @@ from napari_deeplabcut.ui.dialogs import (
 # -----------------------------------------------------------------------------
 
 
-def test_shortcuts_dialog_smoke(dialog_parent, qtbot):
+class _DummyEmitter:
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):
+        self._callbacks.append(callback)
+
+    def disconnect(self, callback):
+        self._callbacks.remove(callback)
+
+    def emit(self, event=None):
+        for callback in list(self._callbacks):
+            callback(event)
+
+
+class _DummyViewer:
+    def __init__(self, *, active=None):
+        self.layers = SimpleNamespace(
+            selection=SimpleNamespace(
+                active=active,
+                events=SimpleNamespace(active=_DummyEmitter()),
+            )
+        )
+
+
+def _points_layer(name: str = "points"):
+    return Points(np.empty((0, 2)), name=name)
+
+
+def _image_layer(name: str = "image"):
+    return Image(np.zeros((8, 8)), name=name)
+
+
+def test_shortcuts_dialog_without_viewer_renders_registry(dialog_parent, qtbot):
     dlg = Shortcuts(dialog_parent)
     qtbot.addWidget(dlg)
 
     assert dlg.parent() is dialog_parent
-    assert dlg.windowTitle() == "Shortcuts"
-    assert dlg.layout() is not None
-    assert dlg.layout().count() == 1
+    assert dlg.windowTitle() == "Keyboard shortcuts"
+    assert dlg.testAttribute(Qt.WA_DeleteOnClose)
 
-    svg_widgets = dlg.findChildren(QSvgWidget)
-    assert len(svg_widgets) == 1
-    assert svg_widgets[0].styleSheet() == "background-color: white;"
+    scroll_areas = dlg.findChildren(QScrollArea)
+    assert len(scroll_areas) == 1
+
+    rows = dlg.findChildren(ShortcutRow)
+    assert len(rows) == len(tuple(iter_shortcuts()))
+
+    assert (
+        dlg.context_banner.text()
+        == "Showing all known shortcuts. Availability cannot be determined without a viewer context."
+    )
+
+
+def test_shortcuts_dialog_marks_points_shortcuts_unavailable_for_non_points_layer(dialog_parent, qtbot):
+    viewer = _DummyViewer(active=_image_layer("raw image"))
+    dlg = Shortcuts(dialog_parent, viewer=viewer)
+    qtbot.addWidget(dlg)
+
+    assert "No active <b>Points</b> layer" in dlg.context_banner.text()
+
+    rows = dlg.findChildren(ShortcutRow)
+    points_rows = [row for row in rows if row.spec.scope == "points-layer"]
+    global_rows = [row for row in rows if row.spec.scope == "global-points"]
+
+    assert points_rows, "expected at least one points-layer shortcut row"
+    assert global_rows, "expected at least one global-points shortcut row"
+
+    for row in points_rows:
+        assert row.graphicsEffect().opacity() == 0.45
+        assert "No active Points layer." in row.toolTip()
+
+    for row in global_rows:
+        assert row.graphicsEffect().opacity() == 1.0
+        assert "No active Points layer." not in row.toolTip()
+
+
+def test_shortcuts_dialog_updates_when_active_layer_changes_and_escapes_layer_name(dialog_parent, qtbot):
+    viewer = _DummyViewer(active=_image_layer("raw image"))
+    dlg = Shortcuts(dialog_parent, viewer=viewer)
+    qtbot.addWidget(dlg)
+
+    # Start with a non-Points layer: points shortcuts are dimmed.
+    row = next(row for row in dlg.findChildren(ShortcutRow) if row.spec.scope == "points-layer")
+    assert row.graphicsEffect().opacity() == 0.45
+    assert "No active Points layer." in row.toolTip()
+
+    # Switch to a Points layer with characters that must be escaped in rich text.
+    viewer.layers.selection.active = _points_layer("a <bizarre> & layer")
+    viewer.layers.selection.events.active.emit()
+
+    banner = dlg.context_banner.text()
+    assert "Active Points layer:" in banner
+    assert "&lt;bizarre&gt;" in banner
+    assert "&amp; layer" in banner
+    assert "a <bizarre> & layer" not in banner  # raw rich-text-breaking text should not appear
+
+    assert row.graphicsEffect().opacity() == 1.0
+    assert "No active Points layer." not in row.toolTip()
+
+
+def test_shortcuts_dialog_disconnects_from_viewer_on_close(dialog_parent, qtbot):
+    viewer = _DummyViewer(active=_image_layer("raw image"))
+    emitter = viewer.layers.selection.events.active
+
+    dlg = Shortcuts(dialog_parent, viewer=viewer)
+    qtbot.addWidget(dlg)
+
+    assert len(emitter._callbacks) == 1
+
+    dlg.show()
+    dlg.close()
+    qtbot.wait(0)
+
+    assert emitter._callbacks == []
 
 
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -752,7 +752,7 @@ class KeypointControls(QWidget):
         Tutorial(self.viewer.window._qt_window.current()).show()
 
     def display_shortcuts(self):
-        Shortcuts(self.viewer.window._qt_window.current()).show()
+        Shortcuts(self.viewer.window._qt_window.current(), viewer=self.viewer).show()
 
     def _move_image_layer_to_bottom(self, index):
         if (ind := index) != 0:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -38,6 +38,10 @@ from qtpy.QtWidgets import (
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut import misc
 from napari_deeplabcut.config import settings
+from napari_deeplabcut.config.keybinds import (
+    install_global_points_keybindings,
+    install_points_layer_keybindings,
+)
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, ImageMetadata, IOProvenance, PointsMetadata
 from napari_deeplabcut.core import keypoints
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
@@ -330,6 +334,8 @@ class KeypointControls(QWidget):
         display_shortcuts_action = QAction("&Shortcuts", self)
         display_shortcuts_action.triggered.connect(self.display_shortcuts)
         self.viewer.window.help_menu.addAction(display_shortcuts_action)
+        # Install global keybinds
+        install_global_points_keybindings()
 
         # Hide some unused viewer buttons
         # NOTE (future) do we truly want to disable these ? Tracking util may need to create new points layers
@@ -503,10 +509,6 @@ class KeypointControls(QWidget):
         store._get_label_mode = lambda: self._label_mode
         layer.text.visible = False
 
-        # key bindings
-        layer.bind_key("M", self.cycle_through_label_modes)
-        layer.bind_key("F", self.cycle_through_color_modes)
-
         paste_func = make_paste_data(self, store=store)
         install_paste_patch(layer, paste_func=paste_func)
 
@@ -517,12 +519,8 @@ class KeypointControls(QWidget):
         layer.events.add(query_next_frame=Event)
         layer.events.query_next_frame.connect(store._advance_step)
 
-        # navigation keys
-        # FIXME: @C-Achard 2026-03-11 Move this to dedicated config file
-        layer.bind_key("Shift-Right", store._find_first_unlabeled_frame)
-        layer.bind_key("Shift-Left", store._find_first_unlabeled_frame)
-        layer.bind_key("Down", store.next_keypoint, overwrite=True)
-        layer.bind_key("Up", store.prev_keypoint, overwrite=True)
+        # Install keybinds
+        install_points_layer_keybindings(layer, self, store)
 
         if len(self._stores) == 1 and self._is_multianimal(layer):
             # set internal mode without triggering recolor storms
@@ -1816,9 +1814,3 @@ class KeypointControls(QWidget):
                 return True
 
         return False
-
-
-@Points.bind_key("E")
-def toggle_edge_color(layer):
-    # Trick to toggle between 0 and 2
-    layer.border_width = np.bitwise_xor(layer.border_width, 2)

--- a/src/napari_deeplabcut/config/keybinds.py
+++ b/src/napari_deeplabcut/config/keybinds.py
@@ -3,6 +3,7 @@
 # src/napari_deeplabcut/config/keybinds.py
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 import numpy as np
@@ -13,93 +14,86 @@ _global_points_bindings_installed = False
 
 @dataclass(frozen=True)
 class ShortcutSpec:
-    key: str
+    keys: tuple[str, ...]
     description: str
-    scope: str  # e.g. "points-layer", "global-points"
+    group: str
+    scope: str
     overwrite: bool = False
+    when: str | None = None  # optional UI note, e.g. "Multi-animal layers only"
 
 
 # ---- Single source of truth for displayed shortcuts ----
-CYCLE_LABEL_MODE = ShortcutSpec(
-    key="M",
-    description="Change labeling mode",
-    scope="points-layer",
+
+SHORTCUTS: tuple[ShortcutSpec, ...] = (
+    ShortcutSpec(
+        keys=("M",),
+        description="Change labeling mode",
+        group="Annotation",
+        scope="points-layer",
+    ),
+    ShortcutSpec(
+        keys=("F",),
+        description="Change color mode",
+        group="Display",
+        scope="points-layer",
+        when="Only cycles beyond bodypart mode for multi-animal layers",
+    ),
+    ShortcutSpec(
+        keys=("Down",),
+        description="Select next keypoint",
+        group="Navigation",
+        scope="points-layer",
+        overwrite=True,
+    ),
+    ShortcutSpec(
+        keys=("Up",),
+        description="Select previous keypoint",
+        group="Navigation",
+        scope="points-layer",
+        overwrite=True,
+    ),
+    ShortcutSpec(
+        keys=("Shift-Right", "Shift-Left"),
+        description="Jump to first unlabeled frame",
+        group="Navigation",
+        scope="points-layer",
+    ),
+    ShortcutSpec(
+        keys=("E",),
+        description="Toggle point edge color",
+        group="Display",
+        scope="global-points",
+    ),
 )
 
-CYCLE_COLOR_MODE = ShortcutSpec(
-    key="F",
-    description="Change color mode",
-    scope="points-layer",
-)
 
-NEXT_KEYPOINT = ShortcutSpec(
-    key="Down",
-    description="Select next keypoint",
-    scope="points-layer",
-    overwrite=True,
-)
+def iter_shortcuts() -> Iterable[ShortcutSpec]:
+    return SHORTCUTS
 
-PREV_KEYPOINT = ShortcutSpec(
-    key="Up",
-    description="Select previous keypoint",
-    scope="points-layer",
-    overwrite=True,
-)
 
-NEXT_UNLABELED_RIGHT = ShortcutSpec(
-    key="Shift-Right",
-    description="Jump to first unlabeled frame",
-    scope="points-layer",
-)
-
-NEXT_UNLABELED_LEFT = ShortcutSpec(
-    key="Shift-Left",
-    description="Jump to first unlabeled frame",
-    scope="points-layer",
-)
-
-TOGGLE_EDGE_COLOR = ShortcutSpec(
-    key="E",
-    description="Toggle point edge color",
-    scope="global-points",
-)
+def _bind_each_key(layer: Points, keys: tuple[str, ...], callback, *, overwrite: bool = False) -> None:
+    for key in keys:
+        layer.bind_key(key, callback, overwrite=overwrite)
 
 
 def install_points_layer_keybindings(layer: Points, controls, store) -> None:
-    """Bind per-layer keybindings for a DLC-managed Points layer."""
-    layer.bind_key(CYCLE_LABEL_MODE.key, controls.cycle_through_label_modes)
-    layer.bind_key(CYCLE_COLOR_MODE.key, controls.cycle_through_color_modes)
-
-    layer.bind_key(NEXT_UNLABELED_RIGHT.key, store._find_first_unlabeled_frame)
-    layer.bind_key(NEXT_UNLABELED_LEFT.key, store._find_first_unlabeled_frame)
-
-    layer.bind_key(NEXT_KEYPOINT.key, store.next_keypoint, overwrite=NEXT_KEYPOINT.overwrite)
-    layer.bind_key(PREV_KEYPOINT.key, store.prev_keypoint, overwrite=PREV_KEYPOINT.overwrite)
+    _bind_each_key(layer, ("M",), controls.cycle_through_label_modes)
+    _bind_each_key(layer, ("F",), controls.cycle_through_color_modes)
+    _bind_each_key(layer, ("Shift-Right", "Shift-Left"), store._find_first_unlabeled_frame)
+    _bind_each_key(layer, ("Down",), store.next_keypoint, overwrite=True)
+    _bind_each_key(layer, ("Up",), store.prev_keypoint, overwrite=True)
 
 
 def toggle_edge_color(layer):
-    """Toggle point border width between 0 and 2."""
     layer.border_width = np.bitwise_xor(layer.border_width, 2)
 
 
 def install_global_points_keybindings() -> None:
-    """Install Points-class-wide keybindings exactly once."""
     global _global_points_bindings_installed
     if _global_points_bindings_installed:
         return
 
-    Points.bind_key(TOGGLE_EDGE_COLOR.key)(toggle_edge_color)
+    for key in ("E",):
+        Points.bind_key(key)(toggle_edge_color)
+
     _global_points_bindings_installed = True
-
-
-def iter_shortcuts():
-    """Return all known shortcuts for help / docs UI."""
-    return [
-        CYCLE_LABEL_MODE,
-        CYCLE_COLOR_MODE,
-        NEXT_KEYPOINT,
-        PREV_KEYPOINT,
-        NEXT_UNLABELED_RIGHT,
-        NEXT_UNLABELED_LEFT,
-        TOGGLE_EDGE_COLOR,
-    ]

--- a/src/napari_deeplabcut/config/keybinds.py
+++ b/src/napari_deeplabcut/config/keybinds.py
@@ -1,2 +1,105 @@
 """Future file for centralizing keybinds."""
+
 # src/napari_deeplabcut/config/keybinds.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from napari.layers import Points
+
+_global_points_bindings_installed = False
+
+
+@dataclass(frozen=True)
+class ShortcutSpec:
+    key: str
+    description: str
+    scope: str  # e.g. "points-layer", "global-points"
+    overwrite: bool = False
+
+
+# ---- Single source of truth for displayed shortcuts ----
+CYCLE_LABEL_MODE = ShortcutSpec(
+    key="M",
+    description="Change labeling mode",
+    scope="points-layer",
+)
+
+CYCLE_COLOR_MODE = ShortcutSpec(
+    key="F",
+    description="Change color mode",
+    scope="points-layer",
+)
+
+NEXT_KEYPOINT = ShortcutSpec(
+    key="Down",
+    description="Select next keypoint",
+    scope="points-layer",
+    overwrite=True,
+)
+
+PREV_KEYPOINT = ShortcutSpec(
+    key="Up",
+    description="Select previous keypoint",
+    scope="points-layer",
+    overwrite=True,
+)
+
+NEXT_UNLABELED_RIGHT = ShortcutSpec(
+    key="Shift-Right",
+    description="Jump to first unlabeled frame",
+    scope="points-layer",
+)
+
+NEXT_UNLABELED_LEFT = ShortcutSpec(
+    key="Shift-Left",
+    description="Jump to first unlabeled frame",
+    scope="points-layer",
+)
+
+TOGGLE_EDGE_COLOR = ShortcutSpec(
+    key="E",
+    description="Toggle point edge color",
+    scope="global-points",
+)
+
+
+def install_points_layer_keybindings(layer: Points, controls, store) -> None:
+    """Bind per-layer keybindings for a DLC-managed Points layer."""
+    layer.bind_key(CYCLE_LABEL_MODE.key, controls.cycle_through_label_modes)
+    layer.bind_key(CYCLE_COLOR_MODE.key, controls.cycle_through_color_modes)
+
+    layer.bind_key(NEXT_UNLABELED_RIGHT.key, store._find_first_unlabeled_frame)
+    layer.bind_key(NEXT_UNLABELED_LEFT.key, store._find_first_unlabeled_frame)
+
+    layer.bind_key(NEXT_KEYPOINT.key, store.next_keypoint, overwrite=NEXT_KEYPOINT.overwrite)
+    layer.bind_key(PREV_KEYPOINT.key, store.prev_keypoint, overwrite=PREV_KEYPOINT.overwrite)
+
+
+def toggle_edge_color(layer):
+    """Toggle point border width between 0 and 2."""
+    layer.border_width = np.bitwise_xor(layer.border_width, 2)
+
+
+def install_global_points_keybindings() -> None:
+    """Install Points-class-wide keybindings exactly once."""
+    global _global_points_bindings_installed
+    if _global_points_bindings_installed:
+        return
+
+    Points.bind_key(TOGGLE_EDGE_COLOR.key)(toggle_edge_color)
+    _global_points_bindings_installed = True
+
+
+def iter_shortcuts():
+    """Return all known shortcuts for help / docs UI."""
+    return [
+        CYCLE_LABEL_MODE,
+        CYCLE_COLOR_MODE,
+        NEXT_KEYPOINT,
+        PREV_KEYPOINT,
+        NEXT_UNLABELED_RIGHT,
+        NEXT_UNLABELED_LEFT,
+        TOGGLE_EDGE_COLOR,
+    ]

--- a/src/napari_deeplabcut/config/keybinds.py
+++ b/src/napari_deeplabcut/config/keybinds.py
@@ -3,8 +3,9 @@
 # src/napari_deeplabcut/config/keybinds.py
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from enum import Enum, auto
 
 import numpy as np
 from napari.layers import Points
@@ -13,8 +14,16 @@ _global_points_bindings_installed = False
 
 
 @dataclass(frozen=True)
+class BindingContext:
+    controls: object
+    store: object
+
+
+@dataclass(frozen=True)
 class ShortcutSpec:
     keys: tuple[str, ...]
+    action: ShortcutAction | None = None  # optional enum for programmatic reference
+    get_callback: Callable[[BindingContext], Callable] | None = None
     description: str
     group: str
     scope: str
@@ -22,17 +31,53 @@ class ShortcutSpec:
     when: str | None = None  # optional UI note, e.g. "Multi-animal layers only"
 
 
+class ShortcutAction(Enum):
+    CYCLE_LABEL_MODE = auto()
+    CYCLE_COLOR_MODE = auto()
+    NEXT_KEYPOINT = auto()
+    PREV_KEYPOINT = auto()
+    JUMP_UNLABELED_FRAME = auto()
+    TOGGLE_EDGE_COLOR = auto()
+
+
+# ----------------------------------------
+#  Functions with associated keybind callbacks
+# ----------------------------------------
+def _cycle_label_mode(ctx: BindingContext):
+    return ctx.controls.cycle_through_label_modes
+
+
+def _cycle_color_mode(ctx: BindingContext):
+    return ctx.controls.cycle_through_color_modes
+
+
+def _next_keypoint(ctx: BindingContext):
+    return ctx.store.next_keypoint
+
+
+def _prev_keypoint(ctx: BindingContext):
+    return ctx.store.prev_keypoint
+
+
+def _jump_unlabeled_frame(ctx: BindingContext):
+    return ctx.store._find_first_unlabeled_frame
+
+
 # ---- Single source of truth for displayed shortcuts ----
 
 SHORTCUTS: tuple[ShortcutSpec, ...] = (
     ShortcutSpec(
         keys=("M",),
+        action=ShortcutAction.CYCLE_LABEL_MODE,
+        get_callback=_cycle_label_mode,
         description="Change labeling mode",
         group="Annotation",
         scope="points-layer",
     ),
     ShortcutSpec(
         keys=("F",),
+        action=ShortcutAction.CYCLE_COLOR_MODE,
+        get_callback=_cycle_color_mode,
         description="Change color mode",
         group="Display",
         scope="points-layer",
@@ -40,6 +85,8 @@ SHORTCUTS: tuple[ShortcutSpec, ...] = (
     ),
     ShortcutSpec(
         keys=("Down",),
+        action=ShortcutAction.NEXT_KEYPOINT,
+        get_callback=_next_keypoint,
         description="Select next keypoint",
         group="Navigation",
         scope="points-layer",
@@ -47,6 +94,8 @@ SHORTCUTS: tuple[ShortcutSpec, ...] = (
     ),
     ShortcutSpec(
         keys=("Up",),
+        action=ShortcutAction.PREV_KEYPOINT,
+        get_callback=_prev_keypoint,
         description="Select previous keypoint",
         group="Navigation",
         scope="points-layer",
@@ -54,12 +103,15 @@ SHORTCUTS: tuple[ShortcutSpec, ...] = (
     ),
     ShortcutSpec(
         keys=("Shift-Right", "Shift-Left"),
+        action=ShortcutAction.JUMP_UNLABELED_FRAME,
+        get_callback=_jump_unlabeled_frame,
         description="Jump to first unlabeled frame",
         group="Navigation",
         scope="points-layer",
     ),
     ShortcutSpec(
         keys=("E",),
+        action=ShortcutAction.TOGGLE_EDGE_COLOR,
         description="Toggle point edge color",
         group="Display",
         scope="global-points",
@@ -77,11 +129,17 @@ def _bind_each_key(layer: Points, keys: tuple[str, ...], callback, *, overwrite:
 
 
 def install_points_layer_keybindings(layer: Points, controls, store) -> None:
-    _bind_each_key(layer, ("M",), controls.cycle_through_label_modes)
-    _bind_each_key(layer, ("F",), controls.cycle_through_color_modes)
-    _bind_each_key(layer, ("Shift-Right", "Shift-Left"), store._find_first_unlabeled_frame)
-    _bind_each_key(layer, ("Down",), store.next_keypoint, overwrite=True)
-    _bind_each_key(layer, ("Up",), store.prev_keypoint, overwrite=True)
+    ctx = BindingContext(controls=controls, store=store)
+
+    for spec in SHORTCUTS:
+        if spec.scope != "points-layer" or spec.get_callback is None:
+            continue
+
+        callback = spec.get_callback(ctx)
+        _bind_each_key(layer, spec.keys, callback, overwrite=spec.overwrite)
+
+
+# ------- Global keybinds that apply to all points layers, e.g. toggling edge color -------
 
 
 def toggle_edge_color(layer):

--- a/src/napari_deeplabcut/config/keybinds.py
+++ b/src/napari_deeplabcut/config/keybinds.py
@@ -1,4 +1,4 @@
-"""Future file for centralizing keybinds."""
+"""Central registry and installers for napari-deeplabcut keybindings (source of truth)."""
 
 # src/napari_deeplabcut/config/keybinds.py
 from __future__ import annotations

--- a/src/napari_deeplabcut/config/keybinds.py
+++ b/src/napari_deeplabcut/config/keybinds.py
@@ -22,11 +22,11 @@ class BindingContext:
 @dataclass(frozen=True)
 class ShortcutSpec:
     keys: tuple[str, ...]
-    action: ShortcutAction | None = None  # optional enum for programmatic reference
-    get_callback: Callable[[BindingContext], Callable] | None = None
     description: str
     group: str
     scope: str
+    action: ShortcutAction | None = None  # optional enum for programmatic reference
+    get_callback: Callable[[BindingContext], Callable] | None = None
     overwrite: bool = False
     when: str | None = None  # optional UI note, e.g. "Multi-animal layers only"
 
@@ -151,7 +151,9 @@ def install_global_points_keybindings() -> None:
     if _global_points_bindings_installed:
         return
 
-    for key in ("E",):
-        Points.bind_key(key)(toggle_edge_color)
+    for spec in SHORTCUTS:
+        if spec.scope == "global-points" and spec.action == ShortcutAction.TOGGLE_EDGE_COLOR:
+            for key in spec.keys:
+                Points.bind_key(key)(toggle_edge_color)
 
     _global_points_bindings_installed = True

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -257,6 +257,8 @@ class Shortcuts(QDialog):
         """
         Return (available, reason) for a shortcut in the current viewer context.
         """
+        if self.viewer is None:
+            return False, "No viewer available."
         active = self._active_layer()
         active_is_points = isinstance(active, Points)
 

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -1,6 +1,7 @@
 # src/napari_deeplabcut/ui/dialogs.py
 from __future__ import annotations
 
+import html
 from collections import defaultdict, namedtuple
 
 from napari.layers import Points
@@ -160,6 +161,7 @@ class ShortcutRow(QFrame):
 class Shortcuts(QDialog):
     def __init__(self, parent=None, *, viewer=None):
         super().__init__(parent=parent)
+        self.setAttribute(Qt.WA_DeleteOnClose)
         self.viewer = viewer
         self._rows: list[ShortcutRow] = []
 
@@ -176,6 +178,7 @@ class Shortcuts(QDialog):
         root.addWidget(intro)
 
         self.context_banner = QLabel("")
+        self.context_banner.setTextFormat(Qt.RichText)
         self.context_banner.setWordWrap(True)
         self.context_banner.setStyleSheet(
             """
@@ -207,10 +210,17 @@ class Shortcuts(QDialog):
 
         # Live updates as the active layer changes
         if self.viewer is not None:
+            self._active_event_emitter = self.viewer.layers.selection.events.active
+            self._active_event_emitter.connect(self._refresh_availability)
+
+    def closeEvent(self, event):
+        if self._active_event_emitter is not None:
             try:
-                self.viewer.layers.selection.events.active.connect(self._refresh_availability)
-            except Exception:
+                self._active_event_emitter.disconnect(self._refresh_availability)
+            except (TypeError, RuntimeError):
                 pass
+            self._active_event_emitter = None
+        super().closeEvent(event)
 
     def _build_rows(self) -> None:
         grouped = defaultdict(list)
@@ -266,7 +276,7 @@ class Shortcuts(QDialog):
                 "Showing all known shortcuts. Availability cannot be determined without a viewer context."
             )
         elif active_is_points:
-            layer_name = getattr(active, "name", "active layer")
+            layer_name = html.escape(getattr(active, "name", "active layer"))
             self.context_banner.setText(
                 f"Active Points layer: <b>{layer_name}</b>. "
                 "Shortcuts specific to Points layers are currently available."

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -88,7 +88,7 @@ class ShortcutKeysWidget(QWidget):
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(3)
+        layout.setSpacing(2)
 
         for i, seq in enumerate(keys):
             if i > 0:
@@ -123,52 +123,38 @@ class ShortcutRow(QFrame):
 
         self.keys_widget = ShortcutKeysWidget(spec.keys)
         self.keys_widget.setFixedWidth(self.KEY_COL_WIDTH)
-        self.keys_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
-
-        text_col = QVBoxLayout()
-        text_col.setContentsMargins(0, 0, 0, 0)
-        text_col.setSpacing(0)
+        self.keys_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 
         self.title_label = QLabel(spec.description)
         self.title_label.setStyleSheet("font-weight: 600;")
-        self.title_label.setWordWrap(True)
+        self.title_label.setWordWrap(False)
+        self.title_label.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.title_label.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
-        subtitle_parts = [_scope_label(spec.scope)]
-        if getattr(spec, "when", None):
-            subtitle_parts.append(spec.when)
-
-        self.subtitle_label = QLabel(" • ".join(subtitle_parts))
-        self.subtitle_label.setStyleSheet("color: palette(mid); font-size: 11px;")
-        self.subtitle_label.setWordWrap(True)
-        self.subtitle_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-
-        self.state_label = QLabel("")
-        self.state_label.setStyleSheet("color: palette(mid); font-size: 11px;")
-        self.state_label.setWordWrap(True)
-        self.state_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
-        self.state_label.hide()
-
-        text_col.addWidget(self.title_label)
-        text_col.addWidget(self.subtitle_label)
-        text_col.addWidget(self.state_label)
-
-        layout.addWidget(self.keys_widget, 0, Qt.AlignLeft | Qt.AlignTop)
-        layout.addLayout(text_col, 1)
+        layout.addWidget(self.keys_widget, 0, Qt.AlignRight | Qt.AlignVCenter)
+        layout.addWidget(self.title_label, 1, Qt.AlignLeft | Qt.AlignVCenter)
 
         self._opacity_effect = QGraphicsOpacityEffect(self)
         self._opacity_effect.setOpacity(1.0)
         self.setGraphicsEffect(self._opacity_effect)
 
-    def set_available(self, available: bool, reason: str | None = None, *, show_reason: bool = True) -> None:
-        """Dim row and show an explanatory note when unavailable."""
+    def set_available(self, available: bool, reason: str | None = None) -> None:
+        """Dim row when unavailable and expose context via tooltip only."""
         self._opacity_effect.setOpacity(1.0 if available else 0.45)
 
-        if available or not show_reason or not reason:
-            self.state_label.hide()
-            self.state_label.setText("")
-        else:
-            self.state_label.setText(reason or "Currently unavailable in this context.")
-            self.state_label.show()
+        tooltip_parts = [self.spec.description, _scope_label(self.spec.scope)]
+
+        if getattr(self.spec, "when", None):
+            tooltip_parts.append(self.spec.when)
+
+        if not available and reason:
+            tooltip_parts.append(reason)
+
+        tooltip = "\n".join(tooltip_parts)
+
+        self.setToolTip(tooltip)
+        self.title_label.setToolTip(tooltip)
+        self.keys_widget.setToolTip(tooltip)
 
 
 class Shortcuts(QDialog):
@@ -182,7 +168,7 @@ class Shortcuts(QDialog):
 
         root = QVBoxLayout(self)
         root.setContentsMargins(10, 10, 10, 10)
-        root.setSpacing(10)
+        root.setSpacing(6)
 
         intro = QLabel("These shortcuts are generated from the napari-deeplabcut keybinding registry.")
         intro.setWordWrap(True)
@@ -234,7 +220,8 @@ class Shortcuts(QDialog):
         for group_name in sorted(grouped):
             box = QGroupBox(group_name)
             box_layout = QVBoxLayout(box)
-            box_layout.setSpacing(4)
+            box_layout.setContentsMargins(6, 14, 6, 4)
+            box_layout.setSpacing(1)
 
             for spec in grouped[group_name]:
                 row = ShortcutRow(spec)
@@ -278,26 +265,18 @@ class Shortcuts(QDialog):
             self.context_banner.setText(
                 "Showing all known shortcuts. Availability cannot be determined without a viewer context."
             )
-            suppress_generic_row_reason = False
         elif active_is_points:
             layer_name = getattr(active, "name", "active layer")
             self.context_banner.setText(
                 f"Active Points layer: <b>{layer_name}</b>. "
                 "Shortcuts specific to Points layers are currently available."
             )
-            suppress_generic_row_reason = False
         else:
             self.context_banner.setText("No active <b>Points</b> layer — some shortcuts are currently unavailable.")
-            suppress_generic_row_reason = True
 
         for row in self._rows:
             available, reason = self._availability_for_spec(row.spec)
-
-            show_reason = True
-            if suppress_generic_row_reason and reason == "No active Points layer.":
-                show_reason = False
-
-            row.set_available(available, reason, show_reason=show_reason)
+            row.set_available(available, reason)
 
 
 # --------------------------------------------------------------------------------------

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -219,7 +219,7 @@ class Shortcuts(QDialog):
         if emitter is not None:
             try:
                 emitter.disconnect(self._refresh_availability)
-            except (TypeError, RuntimeError):
+            except (TypeError, RuntimeError, ValueError):
                 pass
             self._active_event_emitter = None
 

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -164,6 +164,7 @@ class Shortcuts(QDialog):
         self.setAttribute(Qt.WA_DeleteOnClose)
         self.viewer = viewer
         self._rows: list[ShortcutRow] = []
+        self._active_event_emitter = None
 
         self.setWindowTitle("Keyboard shortcuts")
         self.resize(720, 560)
@@ -214,12 +215,14 @@ class Shortcuts(QDialog):
             self._active_event_emitter.connect(self._refresh_availability)
 
     def closeEvent(self, event):
-        if self._active_event_emitter is not None:
+        emitter = getattr(self, "_active_event_emitter", None)
+        if emitter is not None:
             try:
-                self._active_event_emitter.disconnect(self._refresh_availability)
+                emitter.disconnect(self._refresh_availability)
             except (TypeError, RuntimeError):
                 pass
             self._active_event_emitter = None
+
         super().closeEvent(event)
 
     def _build_rows(self) -> None:

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -127,7 +127,7 @@ class ShortcutRow(QFrame):
 
         text_col = QVBoxLayout()
         text_col.setContentsMargins(0, 0, 0, 0)
-        text_col.setSpacing(1)
+        text_col.setSpacing(0)
 
         self.title_label = QLabel(spec.description)
         self.title_label.setStyleSheet("font-weight: 600;")
@@ -159,11 +159,11 @@ class ShortcutRow(QFrame):
         self._opacity_effect.setOpacity(1.0)
         self.setGraphicsEffect(self._opacity_effect)
 
-    def set_available(self, available: bool, reason: str | None = None) -> None:
+    def set_available(self, available: bool, reason: str | None = None, *, show_reason: bool = True) -> None:
         """Dim row and show an explanatory note when unavailable."""
         self._opacity_effect.setOpacity(1.0 if available else 0.45)
 
-        if available:
+        if available or not show_reason or not reason:
             self.state_label.hide()
             self.state_label.setText("")
         else:
@@ -278,18 +278,26 @@ class Shortcuts(QDialog):
             self.context_banner.setText(
                 "Showing all known shortcuts. Availability cannot be determined without a viewer context."
             )
+            suppress_generic_row_reason = False
         elif active_is_points:
             layer_name = getattr(active, "name", "active layer")
             self.context_banner.setText(
                 f"Active Points layer: <b>{layer_name}</b>. "
                 "Shortcuts specific to Points layers are currently available."
             )
+            suppress_generic_row_reason = False
         else:
             self.context_banner.setText("No active <b>Points</b> layer — some shortcuts are currently unavailable.")
+            suppress_generic_row_reason = True
 
         for row in self._rows:
             available, reason = self._availability_for_spec(row.spec)
-            row.set_available(available, reason)
+
+            show_reason = True
+            if suppress_generic_row_reason and reason == "No active Points layer.":
+                show_reason = False
+
+            row.set_available(available, reason, show_reason=show_reason)
 
 
 # --------------------------------------------------------------------------------------

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -1,13 +1,24 @@
 # src/napari_deeplabcut/ui/dialogs.py
 from __future__ import annotations
 
-from collections import namedtuple
-from pathlib import Path
+from collections import defaultdict, namedtuple
 
+from napari.layers import Points
 from qtpy.QtCore import QPoint, Qt
-from qtpy.QtSvgWidgets import QSvgWidget
-from qtpy.QtWidgets import QDialog, QHBoxLayout, QLabel, QPlainTextEdit, QPushButton, QSizePolicy, QVBoxLayout
+from qtpy.QtWidgets import (
+    QDialog,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
 
+from napari_deeplabcut.config.keybinds import iter_shortcuts
 from napari_deeplabcut.config.settings import get_overwrite_confirmation_enabled
 from napari_deeplabcut.core.conflicts import OverwriteConflictReport
 
@@ -16,21 +27,161 @@ from napari_deeplabcut.core.conflicts import OverwriteConflictReport
 Tip = namedtuple("Tip", ["msg", "pos"])
 
 
-class Shortcuts(QDialog):
-    """Opens a window displaying available napari-deeplabcut shortcuts."""
+_KEY_LABELS = {
+    "Shift": "Shift",
+    "Right": "→",
+    "Left": "←",
+    "Up": "↑",
+    "Down": "↓",
+    "Space": "Space",
+    "Enter": "Enter",
+    "Return": "Return",
+}
 
-    def __init__(self, parent):
+
+def _split_key_sequence(seq: str) -> list[str]:
+    # napari keys look like: "Shift-Right", "M", etc.
+    return [_KEY_LABELS.get(part, part) for part in seq.split("-")]
+
+
+class KeycapLabel(QLabel):
+    def __init__(self, text: str, parent=None):
+        super().__init__(text, parent=parent)
+        self.setAlignment(Qt.AlignCenter)
+        self.setStyleSheet(
+            """
+            QLabel {
+                border: 1px solid palette(mid);
+                border-radius: 6px;
+                padding: 4px 8px;
+                background: palette(base);
+                font-weight: 600;
+                min-width: 12px;
+            }
+            """
+        )
+
+
+class ShortcutKeysWidget(QWidget):
+    def __init__(self, keys: tuple[str, ...], parent=None):
         super().__init__(parent=parent)
-        self.setParent(parent)
-        self.setWindowTitle("Shortcuts")
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
 
-        image_path = str(Path(__file__).resolve().parents[1] / "assets" / "napari_shortcuts.svg")
+        for i, seq in enumerate(keys):
+            if i > 0:
+                sep = QLabel("/")
+                layout.addWidget(sep)
 
-        vlayout = QVBoxLayout()
-        svg_widget = QSvgWidget(image_path)
-        svg_widget.setStyleSheet("background-color: white;")
-        vlayout.addWidget(svg_widget)
-        self.setLayout(vlayout)
+            parts = _split_key_sequence(seq)
+            for j, part in enumerate(parts):
+                if j > 0:
+                    plus = QLabel("+")
+                    layout.addWidget(plus)
+                layout.addWidget(KeycapLabel(part))
+        layout.addStretch(1)
+
+
+class ShortcutRow(QWidget):
+    def __init__(self, spec, parent=None):
+        super().__init__(parent=parent)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 4, 0, 4)
+        layout.setSpacing(12)
+
+        keys_widget = ShortcutKeysWidget(spec.keys)
+        keys_widget.setMinimumWidth(180)
+
+        text_col = QVBoxLayout()
+        text_col.setContentsMargins(0, 0, 0, 0)
+        text_col.setSpacing(2)
+
+        title = QLabel(spec.description)
+        title.setStyleSheet("font-weight: 600;")
+
+        subtitle_parts = []
+        if spec.scope == "points-layer":
+            subtitle_parts.append("Points layer")
+        elif spec.scope == "global-points":
+            subtitle_parts.append("All Points layers")
+
+        if spec.when:
+            subtitle_parts.append(spec.when)
+
+        subtitle = QLabel(" • ".join(subtitle_parts))
+        subtitle.setStyleSheet("color: palette(mid); font-size: 11px;")
+        subtitle.setWordWrap(True)
+
+        text_col.addWidget(title)
+        if subtitle_parts:
+            text_col.addWidget(subtitle)
+
+        layout.addWidget(keys_widget, 0)
+        layout.addLayout(text_col, 1)
+
+
+class Shortcuts(QDialog):
+    def __init__(self, parent=None, *, viewer=None):
+        super().__init__(parent=parent)
+        self.viewer = viewer
+        self.setWindowTitle("Keyboard shortcuts")
+        self.resize(640, 520)
+
+        root = QVBoxLayout(self)
+
+        intro = QLabel("These shortcuts are generated from the active napari-deeplabcut keybinding registry.")
+        intro.setWordWrap(True)
+        intro.setStyleSheet("color: palette(mid);")
+        root.addWidget(intro)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        root.addWidget(scroll, 1)
+
+        container = QWidget()
+        scroll.setWidget(container)
+        content = QVBoxLayout(container)
+        content.setContentsMargins(8, 8, 8, 8)
+        content.setSpacing(12)
+
+        grouped = defaultdict(list)
+        for spec in self._visible_shortcuts():
+            grouped[spec.group].append(spec)
+
+        for group_name in sorted(grouped):
+            box = QGroupBox(group_name)
+            box_layout = QVBoxLayout(box)
+            box_layout.setSpacing(6)
+
+            for spec in grouped[group_name]:
+                box_layout.addWidget(ShortcutRow(spec))
+
+            content.addWidget(box)
+
+        content.addStretch(1)
+
+    def _visible_shortcuts(self):
+        specs = list(iter_shortcuts())
+
+        # Optional: context-aware filtering
+        if self.viewer is None:
+            return specs
+
+        active = self.viewer.layers.selection.active
+        active_is_points = isinstance(active, Points)
+
+        visible = []
+        for spec in specs:
+            if spec.scope == "points-layer" and not active_is_points:
+                # Either hide these entirely…
+                continue
+                # …or keep them and annotate them. If you prefer that behavior,
+                # remove this continue and let the subtitle do the work.
+            visible.append(spec)
+
+        return visible
 
 
 class Tutorial(QDialog):

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -7,6 +7,8 @@ from napari.layers import Points
 from qtpy.QtCore import QPoint, Qt
 from qtpy.QtWidgets import (
     QDialog,
+    QFrame,
+    QGraphicsOpacityEffect,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -26,6 +28,9 @@ from napari_deeplabcut.core.conflicts import OverwriteConflictReport
 
 Tip = namedtuple("Tip", ["msg", "pos"])
 
+# --------------------------------------------------------------------------------
+# Keyboard shortcuts dialog, generated from the keybinding registry
+# --------------------------------------------------------------------------------
 
 _KEY_LABELS = {
     "Shift": "Shift",
@@ -35,28 +40,43 @@ _KEY_LABELS = {
     "Down": "↓",
     "Space": "Space",
     "Enter": "Enter",
-    "Return": "Return",
+    "Return": "Enter",
+    "Backspace": "⌫",
+    "Delete": "Del",
+    "Escape": "Esc",
+    "Ctrl": "Ctrl",
+    "Alt": "Alt",
+    "Meta": "Meta",
 }
 
 
 def _split_key_sequence(seq: str) -> list[str]:
-    # napari keys look like: "Shift-Right", "M", etc.
+    """Convert a napari key sequence like 'Shift-Right' into display parts."""
     return [_KEY_LABELS.get(part, part) for part in seq.split("-")]
+
+
+def _scope_label(scope: str) -> str:
+    if scope == "points-layer":
+        return "Points layer"
+    if scope == "global-points":
+        return "All Points layers"
+    return scope
 
 
 class KeycapLabel(QLabel):
     def __init__(self, text: str, parent=None):
         super().__init__(text, parent=parent)
         self.setAlignment(Qt.AlignCenter)
+        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.setStyleSheet(
             """
             QLabel {
                 border: 1px solid palette(mid);
-                border-radius: 6px;
-                padding: 4px 8px;
+                border-radius: 4px;
+                padding: 1px 5px;
                 background: palette(base);
                 font-weight: 600;
-                min-width: 12px;
+                min-width: 16px;
             }
             """
         )
@@ -65,9 +85,10 @@ class KeycapLabel(QLabel):
 class ShortcutKeysWidget(QWidget):
     def __init__(self, keys: tuple[str, ...], parent=None):
         super().__init__(parent=parent)
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(6)
+        layout.setSpacing(3)
 
         for i, seq in enumerate(keys):
             if i > 0:
@@ -79,109 +100,201 @@ class ShortcutKeysWidget(QWidget):
                 if j > 0:
                     plus = QLabel("+")
                     layout.addWidget(plus)
+
                 layout.addWidget(KeycapLabel(part))
+
         layout.addStretch(1)
 
 
-class ShortcutRow(QWidget):
+class ShortcutRow(QFrame):
+    """One shortcut row that can be enabled/dimmed based on availability."""
+
+    KEY_COL_WIDTH = 200
+
     def __init__(self, spec, parent=None):
         super().__init__(parent=parent)
+        self.spec = spec
+
+        self.setFrameShape(QFrame.NoFrame)
 
         layout = QHBoxLayout(self)
-        layout.setContentsMargins(0, 4, 0, 4)
-        layout.setSpacing(12)
+        layout.setContentsMargins(2, 4, 2, 4)
+        layout.setSpacing(10)
 
-        keys_widget = ShortcutKeysWidget(spec.keys)
-        keys_widget.setMinimumWidth(180)
+        self.keys_widget = ShortcutKeysWidget(spec.keys)
+        self.keys_widget.setFixedWidth(self.KEY_COL_WIDTH)
+        self.keys_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
 
         text_col = QVBoxLayout()
         text_col.setContentsMargins(0, 0, 0, 0)
-        text_col.setSpacing(2)
+        text_col.setSpacing(1)
 
-        title = QLabel(spec.description)
-        title.setStyleSheet("font-weight: 600;")
+        self.title_label = QLabel(spec.description)
+        self.title_label.setStyleSheet("font-weight: 600;")
+        self.title_label.setWordWrap(True)
 
-        subtitle_parts = []
-        if spec.scope == "points-layer":
-            subtitle_parts.append("Points layer")
-        elif spec.scope == "global-points":
-            subtitle_parts.append("All Points layers")
-
-        if spec.when:
+        subtitle_parts = [_scope_label(spec.scope)]
+        if getattr(spec, "when", None):
             subtitle_parts.append(spec.when)
 
-        subtitle = QLabel(" • ".join(subtitle_parts))
-        subtitle.setStyleSheet("color: palette(mid); font-size: 11px;")
-        subtitle.setWordWrap(True)
+        self.subtitle_label = QLabel(" • ".join(subtitle_parts))
+        self.subtitle_label.setStyleSheet("color: palette(mid); font-size: 11px;")
+        self.subtitle_label.setWordWrap(True)
+        self.subtitle_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
 
-        text_col.addWidget(title)
-        if subtitle_parts:
-            text_col.addWidget(subtitle)
+        self.state_label = QLabel("")
+        self.state_label.setStyleSheet("color: palette(mid); font-size: 11px;")
+        self.state_label.setWordWrap(True)
+        self.state_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
+        self.state_label.hide()
 
-        layout.addWidget(keys_widget, 0)
+        text_col.addWidget(self.title_label)
+        text_col.addWidget(self.subtitle_label)
+        text_col.addWidget(self.state_label)
+
+        layout.addWidget(self.keys_widget, 0, Qt.AlignLeft | Qt.AlignTop)
         layout.addLayout(text_col, 1)
+
+        self._opacity_effect = QGraphicsOpacityEffect(self)
+        self._opacity_effect.setOpacity(1.0)
+        self.setGraphicsEffect(self._opacity_effect)
+
+    def set_available(self, available: bool, reason: str | None = None) -> None:
+        """Dim row and show an explanatory note when unavailable."""
+        self._opacity_effect.setOpacity(1.0 if available else 0.45)
+
+        if available:
+            self.state_label.hide()
+            self.state_label.setText("")
+        else:
+            self.state_label.setText(reason or "Currently unavailable in this context.")
+            self.state_label.show()
 
 
 class Shortcuts(QDialog):
     def __init__(self, parent=None, *, viewer=None):
         super().__init__(parent=parent)
         self.viewer = viewer
+        self._rows: list[ShortcutRow] = []
+
         self.setWindowTitle("Keyboard shortcuts")
-        self.resize(640, 520)
+        self.resize(720, 560)
 
         root = QVBoxLayout(self)
+        root.setContentsMargins(10, 10, 10, 10)
+        root.setSpacing(10)
 
-        intro = QLabel("These shortcuts are generated from the active napari-deeplabcut keybinding registry.")
+        intro = QLabel("These shortcuts are generated from the napari-deeplabcut keybinding registry.")
         intro.setWordWrap(True)
         intro.setStyleSheet("color: palette(mid);")
         root.addWidget(intro)
 
+        self.context_banner = QLabel("")
+        self.context_banner.setWordWrap(True)
+        self.context_banner.setStyleSheet(
+            """
+            QLabel {
+                border: 1px solid palette(mid);
+                border-radius: 8px;
+                padding: 8px;
+                background: palette(alternate-base);
+            }
+            """
+        )
+        root.addWidget(self.context_banner)
+
+        # Scroll area for future scalability
         scroll = QScrollArea()
         scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.NoFrame)
         root.addWidget(scroll, 1)
 
-        container = QWidget()
-        scroll.setWidget(container)
-        content = QVBoxLayout(container)
-        content.setContentsMargins(8, 8, 8, 8)
-        content.setSpacing(12)
+        self._scroll_container = QWidget()
+        scroll.setWidget(self._scroll_container)
 
+        self._content_layout = QVBoxLayout(self._scroll_container)
+        self._content_layout.setContentsMargins(2, 2, 2, 2)
+        self._content_layout.setSpacing(12)
+
+        self._build_rows()
+        self._refresh_availability()
+
+        # Live updates as the active layer changes
+        if self.viewer is not None:
+            try:
+                self.viewer.layers.selection.events.active.connect(self._refresh_availability)
+            except Exception:
+                pass
+
+    def _build_rows(self) -> None:
         grouped = defaultdict(list)
-        for spec in self._visible_shortcuts():
+        for spec in iter_shortcuts():
             grouped[spec.group].append(spec)
 
         for group_name in sorted(grouped):
             box = QGroupBox(group_name)
             box_layout = QVBoxLayout(box)
-            box_layout.setSpacing(6)
+            box_layout.setSpacing(4)
 
             for spec in grouped[group_name]:
-                box_layout.addWidget(ShortcutRow(spec))
+                row = ShortcutRow(spec)
+                self._rows.append(row)
+                box_layout.addWidget(row)
 
-            content.addWidget(box)
+            self._content_layout.addWidget(box)
 
-        content.addStretch(1)
+        self._content_layout.addStretch(1)
 
-    def _visible_shortcuts(self):
-        specs = list(iter_shortcuts())
-
-        # Optional: context-aware filtering
+    def _active_layer(self):
         if self.viewer is None:
-            return specs
+            return None
+        try:
+            return self.viewer.layers.selection.active
+        except Exception:
+            return None
 
-        active = self.viewer.layers.selection.active
+    def _availability_for_spec(self, spec) -> tuple[bool, str | None]:
+        """
+        Return (available, reason) for a shortcut in the current viewer context.
+        """
+        active = self._active_layer()
         active_is_points = isinstance(active, Points)
 
-        visible = []
-        for spec in specs:
-            if spec.scope == "points-layer" and not active_is_points:
-                # Either hide these entirely…
-                continue
-                # …or keep them and annotate them. If you prefer that behavior,
-                # remove this continue and let the subtitle do the work.
-            visible.append(spec)
+        if spec.scope == "points-layer" and not active_is_points:
+            return False, "No active Points layer."
 
-        return visible
+        # Optional: support extra conditions later, e.g. multi-animal-only
+        # if getattr(spec, "requires_multianimal", False):
+        #     if not active_is_points or not self._is_multianimal(active):
+        #         return False, "Only available for multi-animal Points layers."
+
+        return True, None
+
+    def _refresh_availability(self, event=None) -> None:
+        active = self._active_layer()
+        active_is_points = isinstance(active, Points)
+
+        if self.viewer is None:
+            self.context_banner.setText(
+                "Showing all known shortcuts. Availability cannot be determined without a viewer context."
+            )
+        elif active_is_points:
+            layer_name = getattr(active, "name", "active layer")
+            self.context_banner.setText(
+                f"Active Points layer: <b>{layer_name}</b>. "
+                "Shortcuts specific to Points layers are currently available."
+            )
+        else:
+            self.context_banner.setText("No active <b>Points</b> layer — some shortcuts are currently unavailable.")
+
+        for row in self._rows:
+            available, reason = self._availability_for_spec(row.spec)
+            row.set_available(available, reason)
+
+
+# --------------------------------------------------------------------------------------
+# Tutorial dialog with a small set of tips for new users
+# --------------------------------------------------------------------------------------
 
 
 class Tutorial(QDialog):


### PR DESCRIPTION
This pull request introduces a centralized system for managing keyboard shortcuts in the napari-deeplabcut plugin. The most significant changes include the creation of a unified keybinding registry, refactoring of keybinding installation, and a dynamic, context-aware shortcuts dialog that displays available shortcuts to the user.

**Centralized Keybinding Management:**

* Introduced a new `src/napari_deeplabcut/config/keybinds.py` module that defines a single source of truth for all keyboard shortcuts using a `ShortcutSpec` dataclass, and provides functions for installing keybindings on layers and globally. 

**Refactoring Keybinding Installation:**

* Refactored `_widgets.py` to remove hardcoded keybinding logic and instead use `install_points_layer_keybindings` and `install_global_points_keybindings` from the new keybinds module, ensuring consistency and easier future updates.

**Dynamic Shortcuts Dialog:**

* Replaced the static shortcuts dialog with a new, dynamically generated dialog in `src/napari_deeplabcut/ui/dialogs.py` that groups shortcuts by theme, displays their key sequences visually, and updates their availability based on the current viewer context (e.g., whether a Points layer is active).

These changes make shortcut management more maintainable, improve user experience by providing real-time shortcut availability, and lay the groundwork for further extensibility.