### PR TITLE
Plugin refactor [5]: coverage pass, split code, check performance 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ email = "admin@deeplabcut.org"
 [project.entry-points."napari.manifest"]
 napari-deeplabcut = "napari_deeplabcut:napari.yaml"
 [project.optional-dependencies]
-testing = [
+dev = [
   "pillow",
   "pytest",
   "pytest-cov",

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -8,7 +8,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import pytest
-from qtpy.QtWidgets import QDockWidget
+from qtpy.QtWidgets import QApplication, QDockWidget
 from skimage.io import imsave
 
 from napari_deeplabcut.config.models import DLCHeaderModel
@@ -25,6 +25,34 @@ os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
 # os.environ["PYTEST_QT_API"] = "pyqt6" # only for local testing with pyqt6, we use pyside6 otherwise
 logging.getLogger("napari_deeplabcut").propagate = True
 logging.getLogger("napari-deeplabcut").propagate = True
+
+
+def force_show(widget, qtbot, *, process_ms: int = 50):
+    """
+    Best-effort show of a widget and all its Qt parents, even under
+    QT_QPA_PLATFORM=offscreen.
+
+    This does NOT require real screen exposure; it only ensures the widget
+    is no longer hidden and that Qt processes the resulting show events.
+    """
+    chain = []
+    w = widget
+    while w is not None:
+        chain.append(w)
+        w = w.parentWidget()
+
+    # Show from top-most parent down so child visibility can resolve.
+    for w in reversed(chain):
+        try:
+            w.show()
+        except RuntimeError:
+            pass
+
+    QApplication.processEvents()
+    qtbot.wait(process_ms)
+    QApplication.processEvents()
+
+    return widget
 
 
 @pytest.fixture(autouse=True)

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -139,6 +139,27 @@ def viewer(make_napari_viewer_proxy):
 
 
 @pytest.fixture
+def keypoint_controls_and_dock(viewer):
+    dock, controls = viewer.window.add_plugin_dock_widget(
+        "napari-deeplabcut",
+        "Keypoint controls",
+    )
+    return controls, dock
+
+
+@pytest.fixture
+def keypoint_controls(keypoint_controls_and_dock):
+    controls, _dock = keypoint_controls_and_dock
+    return controls
+
+
+@pytest.fixture
+def keypoint_controls_dock(keypoint_controls_and_dock):
+    _controls, dock = keypoint_controls_and_dock
+    return dock
+
+
+@pytest.fixture
 def fake_keypoints():
     n_rows = 10
     n_animals = 2

--- a/src/napari_deeplabcut/_tests/core/test_metadata.py
+++ b/src/napari_deeplabcut/_tests/core/test_metadata.py
@@ -374,11 +374,11 @@ def test_prepare_points_payload_migrates_legacy_source_h5(monkeypatch):
 
 
 # -----------------------------------------------------------------------------
-# attach_source_and_io
+# attach_source_and_io_to_layer_kwargs
 # -----------------------------------------------------------------------------
 
 
-def test_attach_source_and_io_sets_legacy_fields_and_io(monkeypatch, tmp_path: Path):
+def test_attach_source_and_io_to_layer_kwargs_sets_legacy_fields_and_io(monkeypatch, tmp_path: Path):
     file_path = tmp_path / "CollectedData_Jane.h5"
     file_path.touch()
 
@@ -386,7 +386,7 @@ def test_attach_source_and_io_sets_legacy_fields_and_io(monkeypatch, tmp_path: P
     monkeypatch.setattr(metadata_mod, "infer_annotation_kind_for_file", lambda p: AnnotationKind.GT)
 
     metadata = {}
-    metadata_mod.attach_source_and_io(metadata, file_path)
+    metadata_mod.attach_source_and_io_to_layer_kwargs(metadata, file_path)
 
     inner = metadata["metadata"]
     assert inner["source_h5_name"] == "CollectedData_Jane.h5"

--- a/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
@@ -246,7 +246,11 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
     controls_dock = viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     viewer.open(str(config_path), plugin="napari-deeplabcut")
-    qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
+    qtbot.waitUntil(
+        lambda: any(isinstance(ly, Points) for ly in viewer.layers),
+        timeout=5_000,
+    )
+
     force_show(viewer.window._qt_window, qtbot)
     force_show(controls_dock, qtbot)
     force_show(controls, qtbot)
@@ -255,6 +259,13 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
 
     placeholder = next((ly for ly in viewer.layers if isinstance(ly, Points)), None)
     assert placeholder is not None
+
+    qtbot.waitUntil(lambda: placeholder in controls._stores, timeout=5_000)
+    assert placeholder in controls._stores
+
+    qtbot.waitUntil(lambda: controls.color_mode == "individual", timeout=5_000)
+    assert controls.color_mode == "individual"
+
     assert placeholder.data is None or len(placeholder.data) == 0
 
     store = controls._stores.get(placeholder)

--- a/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
@@ -6,6 +6,7 @@ from napari.layers import Points
 
 from napari_deeplabcut.config.models import DLCHeaderModel
 
+from ..conftest import force_show
 from .utils import _cycles_from_policy, _make_minimal_dlc_project, _scheme_from_policy
 
 
@@ -159,7 +160,7 @@ def test_config_placeholder_multianimal_colors_by_id_after_first_keypoint_added(
 
 @pytest.mark.usefixtures("qtbot")
 def test_color_scheme_panel_toggle_shows_active_then_full_config_bodyparts(
-    make_napari_viewer,
+    viewer,
     qtbot,
     tmp_path,
 ):
@@ -173,13 +174,17 @@ def test_color_scheme_panel_toggle_shows_active_then_full_config_bodyparts(
     """
     project, config_path, labeled_folder, _h5_path = _make_minimal_dlc_project(tmp_path)
 
-    viewer = make_napari_viewer()
-
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
     controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    controls_dock = viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    # Force-show the viewer hierarchy and relevant docks/panels.
+    force_show(viewer.window._qt_window, qtbot)
+    force_show(controls_dock, qtbot)
+    force_show(controls, qtbot)
+    force_show(controls._color_scheme_display, qtbot)
+    force_show(controls._color_scheme_panel, qtbot)
 
     # 1) Open config first -> placeholder Points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -242,10 +247,15 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
     from napari_deeplabcut.core import keypoints
 
     controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    controls_dock = viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     viewer.open(str(config_path), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
+    force_show(viewer.window._qt_window, qtbot)
+    force_show(controls_dock, qtbot)
+    force_show(controls, qtbot)
+    force_show(controls._color_scheme_display, qtbot)
+    force_show(controls._color_scheme_panel, qtbot)
 
     placeholder = next((ly for ly in viewer.layers if isinstance(ly, Points)), None)
     assert placeholder is not None

--- a/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
@@ -3,11 +3,29 @@ from __future__ import annotations
 import numpy as np
 import pytest
 from napari.layers import Points
+from qtpy.QtWidgets import QDockWidget
 
 from napari_deeplabcut.config.models import DLCHeaderModel
 
 from ..conftest import force_show
 from .utils import _cycles_from_policy, _make_minimal_dlc_project, _scheme_from_policy
+
+
+def _get_existing_keypoint_controls(viewer):
+    from napari_deeplabcut._widgets import KeypointControls
+
+    matches = list(viewer.window._qt_window.findChildren(KeypointControls))
+    assert matches, "Expected viewer fixture to provide a KeypointControls widget"
+    assert len(matches) == 1, f"Expected exactly one KeypointControls widget, found {len(matches)}"
+
+    controls = matches[0]
+
+    dock = controls.parentWidget()
+    while dock is not None and not isinstance(dock, QDockWidget):
+        dock = dock.parentWidget()
+
+    assert dock is not None, "Expected KeypointControls to be docked in a QDockWidget"
+    return controls, dock
 
 
 @pytest.mark.usefixtures("qtbot")
@@ -19,11 +37,9 @@ def test_config_placeholder_points_layer_colors_after_first_keypoint_added(viewe
     """
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    controls, controls_dock = _get_existing_keypoint_controls(viewer)
 
     # 1) Open config.yaml -> creates placeholder Points layer (empty)
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -95,11 +111,9 @@ def test_config_placeholder_multianimal_colors_by_id_after_first_keypoint_added(
     """
     _, config_path = multianimal_config_project
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    controls, controls_dock = _get_existing_keypoint_controls(viewer)
 
     # 1) Open config.yaml -> empty placeholder Points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -172,11 +186,9 @@ def test_color_scheme_panel_toggle_shows_active_then_full_config_bodyparts(
     """
     project, config_path, labeled_folder, _h5_path = _make_minimal_dlc_project(tmp_path)
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
-    controls = KeypointControls(viewer)
-    controls_dock = viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    controls, controls_dock = _get_existing_keypoint_controls(viewer)
     # Force-show the viewer hierarchy and relevant docks/panels.
     force_show(viewer.window._qt_window, qtbot)
     force_show(controls_dock, qtbot)
@@ -232,24 +244,16 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
     E2E:
     - open multi-animal config first -> placeholder points layer
     - add one keypoint for animal1
-    - because KeypointControls switches multi-animal coloring to individual mode,
-      the color scheme panel should:
+    - because the first/real KeypointControls switches multi-animal coloring
+      to individual mode, the color scheme panel should:
         * unchecked: show only currently visible active individual(s)
         * checked: show all configured individuals from config.yaml
     """
     _, config_path = multianimal_config_project
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
-    controls = KeypointControls(viewer)
-    controls_dock = viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
-    viewer.open(str(config_path), plugin="napari-deeplabcut")
-    qtbot.waitUntil(
-        lambda: any(isinstance(ly, Points) for ly in viewer.layers),
-        timeout=5_000,
-    )
+    controls, controls_dock = _get_existing_keypoint_controls(viewer)
 
     force_show(viewer.window._qt_window, qtbot)
     force_show(controls_dock, qtbot)
@@ -257,22 +261,29 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
     force_show(controls._color_scheme_display, qtbot)
     force_show(controls._color_scheme_panel, qtbot)
 
+    # Open config -> placeholder Points layer
+    viewer.open(str(config_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(
+        lambda: any(isinstance(ly, Points) for ly in viewer.layers),
+        timeout=5_000,
+    )
+
     placeholder = next((ly for ly in viewer.layers if isinstance(ly, Points)), None)
     assert placeholder is not None
-
-    qtbot.waitUntil(lambda: placeholder in controls._stores, timeout=5_000)
-    assert placeholder in controls._stores
-
-    qtbot.waitUntil(lambda: controls.color_mode == "individual", timeout=5_000)
-    assert controls.color_mode == "individual"
-
     assert placeholder.data is None or len(placeholder.data) == 0
 
+    # Wait until the existing controls instance has wired the layer
+    qtbot.waitUntil(lambda: placeholder in controls._stores, timeout=5_000)
     store = controls._stores.get(placeholder)
     assert store is not None
 
-    # Multi-animal config should switch controls to individual mode on first wired store
+    # This assertion is now valid because we're using the controls instance
+    # that actually wired the layer.
+    qtbot.waitUntil(lambda: controls.color_mode == "individual", timeout=5_000)
     assert controls.color_mode == "individual"
+
+    # Make the placeholder the active target layer
+    viewer.layers.selection.active = placeholder
 
     # Add one keypoint for animal1
     store.current_keypoint = keypoints.Keypoint("bodypart1", "animal1")
@@ -280,6 +291,7 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
 
     qtbot.waitUntil(lambda: placeholder.data is not None and len(placeholder.data) == 1, timeout=2_000)
     qtbot.waitUntil(lambda: placeholder.face_color_mode == "cycle", timeout=5_000)
+    qtbot.waitUntil(lambda: placeholder._face.color_properties.name == "id", timeout=5_000)
 
     panel = controls._color_scheme_panel
 

--- a/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
@@ -11,7 +11,7 @@ from .utils import _cycles_from_policy, _make_minimal_dlc_project, _scheme_from_
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_placeholder_points_layer_colors_after_first_keypoint_added(make_napari_viewer, qtbot, tmp_path):
+def test_config_placeholder_points_layer_colors_after_first_keypoint_added(viewer, qtbot, tmp_path):
     """
     E2E regression: a Points layer created from config.yaml starts empty (placeholder).
     When the user begins adding keypoints, the layer must switch into categorical
@@ -19,7 +19,6 @@ def test_config_placeholder_points_layer_colors_after_first_keypoint_added(make_
     """
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
@@ -85,7 +84,7 @@ def test_config_placeholder_points_layer_colors_after_first_keypoint_added(make_
 
 @pytest.mark.usefixtures("qtbot")
 def test_config_placeholder_multianimal_colors_by_id_after_first_keypoint_added(
-    make_napari_viewer,
+    viewer,
     qtbot,
     multianimal_config_project,
 ):
@@ -96,7 +95,6 @@ def test_config_placeholder_multianimal_colors_by_id_after_first_keypoint_added(
     """
     _, config_path = multianimal_config_project
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
@@ -226,7 +224,7 @@ def test_color_scheme_panel_toggle_shows_active_then_full_config_bodyparts(
 
 @pytest.mark.usefixtures("qtbot")
 def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_individuals(
-    make_napari_viewer,
+    viewer,
     qtbot,
     multianimal_config_project,
 ):
@@ -240,8 +238,6 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
         * checked: show all configured individuals from config.yaml
     """
     _, config_path = multianimal_config_project
-
-    viewer = make_napari_viewer()
 
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints

--- a/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_first_hazard_regression_no_silent_deletion(make_napari_viewer, qtbot, tmp_path, caplog):
+def test_config_first_hazard_regression_no_silent_deletion(viewer, qtbot, tmp_path, caplog):
     """
     Regression for the original report:
     Save the WRONG (placeholder) layer and still preserve previous labels due to merge-on-save.
@@ -26,7 +26,6 @@ def test_config_first_hazard_regression_no_silent_deletion(make_napari_viewer, q
     assert np.isfinite(_get_coord_from_df(pre, "bodypart1", "x"))
     assert np.isnan(_get_coord_from_df(pre, "bodypart2", "x"))
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
@@ -70,7 +69,7 @@ def test_config_first_hazard_regression_no_silent_deletion(make_napari_viewer, q
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_no_overwrite_warning_when_only_filling_nans(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_no_overwrite_warning_when_only_filling_nans(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Adding new labels (filling NaNs) must not prompt overwrite confirmation.
     """
@@ -78,7 +77,6 @@ def test_no_overwrite_warning_when_only_filling_nans(make_napari_viewer, qtbot, 
 
     _, _, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -142,7 +140,7 @@ def test_no_overwrite_warning_when_only_filling_nans(make_napari_viewer, qtbot, 
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_overwrite_warning_triggers_on_conflict(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_overwrite_warning_triggers_on_conflict(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Modifying an existing non-NaN label must trigger overwrite confirmation.
     """
@@ -150,7 +148,6 @@ def test_overwrite_warning_triggers_on_conflict(make_napari_viewer, qtbot, tmp_p
 
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -180,7 +177,7 @@ def test_overwrite_warning_triggers_on_conflict(make_napari_viewer, qtbot, tmp_p
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_overwrite_warning_cancel_aborts_write(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_overwrite_warning_cancel_aborts_write(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     If overwrite confirmation is requested and user cancels, file must remain unchanged.
     """
@@ -192,7 +189,6 @@ def test_overwrite_warning_cancel_aborts_write(make_napari_viewer, qtbot, tmp_pa
     b1x_pre = _get_coord_from_df(pre, "bodypart1", "x")
     b1y_pre = _get_coord_from_df(pre, "bodypart1", "y")
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)

--- a/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_first_hazard_regression_no_silent_deletion(viewer, qtbot, tmp_path, caplog):
+def test_config_first_hazard_regression_no_silent_deletion(viewer, keypoint_controls, qtbot, tmp_path, caplog):
     """
     Regression for the original report:
     Save the WRONG (placeholder) layer and still preserve previous labels due to merge-on-save.
@@ -26,11 +26,9 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, qtbot, tmp_pa
     assert np.isfinite(_get_coord_from_df(pre, "bodypart1", "x"))
     assert np.isnan(_get_coord_from_df(pre, "bodypart2", "x"))
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    viewer.window.add_dock_widget(keypoint_controls, name="Keypoint controls", area="right")
 
     # Open config first -> placeholder Points layer exists
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -48,7 +46,7 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, qtbot, tmp_pa
     # Placeholder should still be present for this regression to apply
     assert placeholder in viewer.layers
 
-    store = controls._stores.get(placeholder)
+    store = keypoint_controls._stores.get(placeholder)
     assert store is not None
 
     # Add a new bodypart2 point to placeholder using (frame, y, x)
@@ -69,7 +67,7 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, qtbot, tmp_pa
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_no_overwrite_warning_when_only_filling_nans(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_no_overwrite_warning_when_only_filling_nans(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     Adding new labels (filling NaNs) must not prompt overwrite confirmation.
     """
@@ -77,10 +75,7 @@ def test_no_overwrite_warning_when_only_filling_nans(viewer, qtbot, tmp_path, ov
 
     _, _, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    viewer.window.add_dock_widget(keypoint_controls, name="Keypoint controls", area="right")
 
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)
@@ -124,7 +119,7 @@ def test_no_overwrite_warning_when_only_filling_nans(viewer, qtbot, tmp_path, ov
     logger.info("any NaNs in points.data = %s", np.isnan(points.data).any())
     logger.info("labels[:10] = %s", points.properties.get("label")[:10])
     logger.info("ids[:10] = %s", points.properties.get("id")[:10] if "id" in points.properties else None)
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     # Fill NaNs for bodypart2
@@ -140,32 +135,28 @@ def test_no_overwrite_warning_when_only_filling_nans(viewer, qtbot, tmp_path, ov
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_overwrite_warning_triggers_on_conflict(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_overwrite_warning_triggers_on_conflict(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     Modifying an existing non-NaN label must trigger overwrite confirmation.
     """
     overwrite_confirm.capture().reset_calls()
 
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
-
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    viewer.window.add_dock_widget(keypoint_controls, name="Keypoint controls", area="right")
 
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)
     qtbot.wait(200)
 
     points = _get_points_layer_with_data(viewer)
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     # Create conflict: overwrite bodypart1 from (10,20) -> (99,88)
     _set_or_add_bodypart_xy(points, store, "bodypart1", x=99.0, y=88.0)
 
     viewer.layers.selection.active = points
-    controls._save_layers_dialog(selected=True)
+    keypoint_controls._save_layers_dialog(selected=True)
     qtbot.wait(200)
 
     assert len(overwrite_confirm.calls) == 1, "Expected overwrite confirmation to be requested once."
@@ -177,7 +168,7 @@ def test_overwrite_warning_triggers_on_conflict(viewer, qtbot, tmp_path, overwri
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_overwrite_warning_cancel_aborts_write(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_overwrite_warning_cancel_aborts_write(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     If overwrite confirmation is requested and user cancels, file must remain unchanged.
     """
@@ -189,24 +180,21 @@ def test_overwrite_warning_cancel_aborts_write(viewer, qtbot, tmp_path, overwrit
     b1x_pre = _get_coord_from_df(pre, "bodypart1", "x")
     b1y_pre = _get_coord_from_df(pre, "bodypart1", "y")
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+    viewer.window.add_dock_widget(keypoint_controls, name="Keypoint controls", area="right")
 
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)
     qtbot.wait(200)
 
     points = _get_points_layer_with_data(viewer)
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     _set_or_add_bodypart_xy(points, store, "bodypart1", x=456.0, y=123.0)
 
     viewer.layers.selection.active = points
     try:
-        controls._save_layers_dialog(selected=True)
+        keypoint_controls._save_layers_dialog(selected=True)
     except Exception:
         # Some napari/npe2 versions may raise when writer aborts; file integrity is what matters.
         pass

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -181,7 +181,8 @@ def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
     layer = viewer.add_points(data, **md)
 
     assert isinstance(layer, Points)
-    assert getattr(layer, "_dlc_controls", None) is controls, "Layer was not wired by KeypointControls"
+    qtbot.waitUntil(lambda: layer in controls._stores, timeout=5_000)
+    assert layer in controls._stores
 
     # frame 0: select and copy
     viewer.dims.set_point(0, 0)

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -6,12 +6,11 @@ from napari_deeplabcut.core.layers import populate_keypoint_layer_properties
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_on_insert_empty_points_layer_does_not_crash(make_napari_viewer, make_real_header_factory):
+def test_on_insert_empty_points_layer_does_not_crash(viewer, make_real_header_factory):
     """
     Contract: inserting an empty Points layer must not crash.
     This guards against KeyError: nan coming from napari cycle colormap logic.
     """
-    viewer = make_napari_viewer()
 
     from napari_deeplabcut._widgets import KeypointControls
 
@@ -36,12 +35,11 @@ def test_on_insert_empty_points_layer_does_not_crash(make_napari_viewer, make_re
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_on_insert_empty_points_layer_does_not_enable_cycle_mode(make_napari_viewer, make_real_header_factory):
+def test_on_insert_empty_points_layer_does_not_enable_cycle_mode(viewer, make_real_header_factory):
     """
     Contract: for empty layers, widget should not set face_color_mode='cycle'
     (or should otherwise avoid the cycle colormap path that crashes on nan).
     """
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -66,12 +64,11 @@ def test_on_insert_empty_points_layer_does_not_enable_cycle_mode(make_napari_vie
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_adopt_existing_empty_points_layer_does_not_crash(make_napari_viewer, make_real_header_factory):
+def test_adopt_existing_empty_points_layer_does_not_crash(viewer, make_real_header_factory):
     """
     Contract: adoption path must not crash for empty points layers.
     This exercises _adopt_existing_layers -> _handle_existing_points_layer.
     """
-    viewer = make_napari_viewer()
 
     # Add layer BEFORE creating the widget (forces adoption path)
     header = make_real_header_factory(individuals=("animal1",))
@@ -96,12 +93,11 @@ def test_adopt_existing_empty_points_layer_does_not_crash(make_napari_viewer, ma
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_layer_insert_does_not_crash_when_current_property_is_nan(make_napari_viewer, make_real_header_factory):
+def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, make_real_header_factory):
     """
     Contract: even if a property value is NaN (bad input), widget must not crash.
     It may fall back to direct mode or sanitize the property.
     """
-    viewer = make_napari_viewer()
 
     from napari_deeplabcut._widgets import KeypointControls
 
@@ -133,7 +129,7 @@ def test_layer_insert_does_not_crash_when_current_property_is_nan(make_napari_vi
 
 @pytest.mark.usefixtures("qtbot")
 def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
-    make_napari_viewer,
+    viewer,
     make_real_header_factory,
     qtbot,
 ):
@@ -151,8 +147,6 @@ def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
     - pasted points must appear on the current frame
     - point properties (e.g. labels) must be preserved
     """
-    viewer = make_napari_viewer()
-
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -221,7 +215,7 @@ def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
 
 @pytest.mark.usefixtures("qtbot")
 def test_copy_paste_same_frame_does_not_duplicate_existing_keypoints(
-    make_napari_viewer,
+    viewer,
     make_real_header_factory,
     qtbot,
 ):
@@ -230,8 +224,6 @@ def test_copy_paste_same_frame_does_not_duplicate_existing_keypoints(
     If the copied keypoints are already annotated on the current frame,
     DLC's patched paste should not duplicate them.
     """
-    viewer = make_napari_viewer()
-
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -11,12 +11,6 @@ def test_on_insert_empty_points_layer_does_not_crash(viewer, make_real_header_fa
     Contract: inserting an empty Points layer must not crash.
     This guards against KeyError: nan coming from napari cycle colormap logic.
     """
-
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     header = make_real_header_factory(individuals=("animal1",))  # either is fine
     md = populate_keypoint_layer_properties(
         header,
@@ -40,11 +34,6 @@ def test_on_insert_empty_points_layer_does_not_enable_cycle_mode(viewer, make_re
     Contract: for empty layers, widget should not set face_color_mode='cycle'
     (or should otherwise avoid the cycle colormap path that crashes on nan).
     """
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     header = make_real_header_factory(individuals=("",))  # single animal
     md = populate_keypoint_layer_properties(
         header,
@@ -82,28 +71,17 @@ def test_adopt_existing_empty_points_layer_does_not_crash(viewer, make_real_head
     )
     viewer.add_points(np.empty((0, 3), dtype=float), **md)
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     # If we got here without exception, adoption didn’t crash
     pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
     assert pts_layers, "Expected the empty Points layer to exist"
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, make_real_header_factory):
+def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, keypoint_controls, make_real_header_factory):
     """
     Contract: even if a property value is NaN (bad input), widget must not crash.
     It may fall back to direct mode or sanitize the property.
     """
-
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     header = make_real_header_factory(individuals=("",))
     md = populate_keypoint_layer_properties(
         header,
@@ -122,7 +100,7 @@ def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, make_r
     layer = viewer.add_points(data, **md)
     # Plot cannot be formed because of the NaN,
     # but the layer must still be added and cycle mode must not be enabled.
-    assert controls._matplotlib_canvas.df is None
+    assert keypoint_controls._matplotlib_canvas.df is None
     assert isinstance(layer, Points)
     assert layer.face_color_mode != "cycle"
 
@@ -130,6 +108,7 @@ def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, make_r
 @pytest.mark.usefixtures("qtbot")
 def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
     viewer,
+    keypoint_controls,
     make_real_header_factory,
     qtbot,
 ):
@@ -147,11 +126,7 @@ def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
     - pasted points must appear on the current frame
     - point properties (e.g. labels) must be preserved
     """
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
+    controls = keypoint_controls
     # Add an image stack to make the time/frame axis explicit in a realistic way.
     viewer.add_image(
         np.zeros((2, 64, 64), dtype=np.uint8),
@@ -225,11 +200,6 @@ def test_copy_paste_same_frame_does_not_duplicate_existing_keypoints(
     If the copied keypoints are already annotated on the current frame,
     DLC's patched paste should not duplicate them.
     """
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     viewer.add_image(
         np.zeros((1, 64, 64), dtype=np.uint8),
         name="frame",

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -129,3 +129,150 @@ def test_layer_insert_does_not_crash_when_current_property_is_nan(make_napari_vi
     assert controls._matplotlib_canvas.df is None
     assert isinstance(layer, Points)
     assert layer.face_color_mode != "cycle"
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
+    make_napari_viewer,
+    make_real_header_factory,
+    qtbot,
+):
+    """
+    Regression test for DLC's patched Points._paste_data.
+
+    Scenario:
+    - create a 3D (t, y, x) points layer
+    - copy selected points on frame 0
+    - move to frame 1
+    - paste
+
+    Contract:
+    - must not crash
+    - pasted points must appear on the current frame
+    - point properties (e.g. labels) must be preserved
+    """
+    viewer = make_napari_viewer()
+
+    from napari_deeplabcut._widgets import KeypointControls
+
+    controls = KeypointControls(viewer)
+    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+
+    # Add an image stack to make the time/frame axis explicit in a realistic way.
+    viewer.add_image(
+        np.zeros((2, 64, 64), dtype=np.uint8),
+        name="frames",
+        metadata={"paths": ["frame0.png", "frame1.png"]},
+    )
+
+    header = make_real_header_factory(individuals=("",))  # single-animal layout
+    md = populate_keypoint_layer_properties(
+        header,
+        labels=["head", "tail"],
+        ids=["", ""],
+        likelihood=np.array([1.0, 1.0], dtype=float),
+        paths=["frame0.png", "frame1.png"],
+        colormap="viridis",
+    )
+
+    # two points on frame 0
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],  # (t, y, x)
+            [0.0, 30.0, 40.0],
+        ],
+        dtype=float,
+    )
+
+    layer = viewer.add_points(data, **md)
+
+    assert isinstance(layer, Points)
+    assert getattr(layer, "_dlc_controls", None) is controls, "Layer was not wired by KeypointControls"
+
+    # frame 0: select and copy
+    viewer.dims.set_point(0, 0)
+    qtbot.wait(0)
+
+    layer.selected_data = {0, 1}
+    layer._copy_data()
+
+    assert "data" in layer._clipboard
+    assert "features" in layer._clipboard
+    assert len(layer._clipboard["data"]) == 2
+
+    # move to frame 1 and paste
+    viewer.dims.set_point(0, 1)
+    qtbot.wait(0)
+
+    layer._paste_data()
+    qtbot.wait(0)
+
+    # original 2 + pasted 2
+    assert len(layer.data) == 4
+
+    pasted = np.asarray(layer.data)[-2:]
+    np.testing.assert_array_equal(pasted[:, 0], np.array([1.0, 1.0]))
+    np.testing.assert_allclose(pasted[:, 1:], data[:, 1:])
+
+    # labels/features should be preserved for pasted points
+    labels = list(layer.properties["label"])
+    assert labels[-2:] == ["head", "tail"]
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_copy_paste_same_frame_does_not_duplicate_existing_keypoints(
+    make_napari_viewer,
+    make_real_header_factory,
+    qtbot,
+):
+    """
+    Contract:
+    If the copied keypoints are already annotated on the current frame,
+    DLC's patched paste should not duplicate them.
+    """
+    viewer = make_napari_viewer()
+
+    from napari_deeplabcut._widgets import KeypointControls
+
+    controls = KeypointControls(viewer)
+    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
+
+    viewer.add_image(
+        np.zeros((1, 64, 64), dtype=np.uint8),
+        name="frame",
+        metadata={"paths": ["frame0.png"]},
+    )
+
+    header = make_real_header_factory(individuals=("",))
+    md = populate_keypoint_layer_properties(
+        header,
+        labels=["head", "tail"],
+        ids=["", ""],
+        likelihood=np.array([1.0, 1.0], dtype=float),
+        paths=["frame0.png"],
+        colormap="viridis",
+    )
+
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 30.0, 40.0],
+        ],
+        dtype=float,
+    )
+
+    layer = viewer.add_points(data, **md)
+    assert isinstance(layer, Points)
+
+    viewer.dims.set_point(0, 0)
+    qtbot.wait(0)
+
+    layer.selected_data = {0, 1}
+    layer._copy_data()
+
+    before = len(layer.data)
+    layer._paste_data()
+    qtbot.wait(0)
+
+    # no duplicates expected on same frame
+    assert len(layer.data) == before

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -37,7 +37,9 @@ def forbid_project_config_dialog(monkeypatch):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_save_routes_to_correct_gt_when_multiple_gt_exist(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_save_routes_to_correct_gt_when_multiple_gt_exist(
+    viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm
+):
     """
     Contract: Saving a Points layer must write back ONLY to the file it came from.
     No 'first CollectedData*.h5' selection when multiple exist.
@@ -50,12 +52,6 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(viewer, qtbot, tmp_pat
     gt_a, gt_b = gt_paths
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
-
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     # Open both GT files explicitly so we get two Points layers
     viewer.open(str(gt_a), plugin="napari-deeplabcut")
     viewer.open(str(gt_b), plugin="napari-deeplabcut")
@@ -66,7 +62,7 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(viewer, qtbot, tmp_pat
     points_b = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == gt_b.stem), None)
     assert points_b is not None, f"Expected a Points layer named {gt_b.stem}"
 
-    store_b = controls._stores.get(points_b)
+    store_b = keypoint_controls._stores.get(points_b)
     assert store_b is not None
 
     # Fill NaNs for bodypart2 in B only (no overwrite dialog)
@@ -92,7 +88,7 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(viewer, qtbot, tmp_pat
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_machine_layer_does_not_modify_gt_on_save(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_machine_layer_does_not_modify_gt_on_save(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: machine outputs must never save to their own file.
     Users must explicitly provide a scorer name that is then used to save the h5.
@@ -106,11 +102,6 @@ def test_machine_layer_does_not_modify_gt_on_save(viewer, qtbot, tmp_path, overw
 
     before = {p: _snapshot_coords(p) for p in gt_paths + [machine_path]}
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     viewer.open(str(machine_path), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len([ly for ly in viewer.layers if isinstance(ly, Points)]) >= 1, timeout=10_000)
     qtbot.wait(200)
@@ -118,7 +109,7 @@ def test_machine_layer_does_not_modify_gt_on_save(viewer, qtbot, tmp_path, overw
     machine_layer = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == machine_path.stem), None)
     assert machine_layer is not None
 
-    store = controls._stores.get(machine_layer)
+    store = keypoint_controls._stores.get(machine_layer)
     assert store is not None
 
     # Fill NaNs in machine file (no overwrite prompt)
@@ -140,7 +131,7 @@ def test_machine_layer_does_not_modify_gt_on_save(viewer, qtbot, tmp_path, overw
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_layer_rename_does_not_change_save_target(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_layer_rename_does_not_change_save_target(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: layer renaming must not redirect output or create new file.
     """
@@ -153,18 +144,13 @@ def test_layer_rename_does_not_change_save_target(viewer, qtbot, tmp_path, overw
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     viewer.open(str(gt_a), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len([ly for ly in viewer.layers if isinstance(ly, Points)]) >= 1, timeout=10_000)
     qtbot.wait(200)
 
     layer = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == gt_a.stem), None)
     assert layer is not None
-    store = controls._stores.get(layer)
+    store = keypoint_controls._stores.get(layer)
     assert store is not None
 
     # Rename in UI
@@ -185,7 +171,9 @@ def test_layer_rename_does_not_change_save_target(viewer, qtbot, tmp_path, overw
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(
+    viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm
+):
     """
     Contract: If provenance is missing and multiple candidate GT files exist,
     save must refuse (deterministic) rather than silently choosing.
@@ -198,11 +186,7 @@ def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(viewer, qtbot,
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     # Open config first => placeholder points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -219,7 +203,7 @@ def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(viewer, qtbot,
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.wait(200)
 
-    store = controls._stores.get(placeholder)
+    store = keypoint_controls._stores.get(placeholder)
     assert store is not None
 
     # Add a point to placeholder
@@ -278,7 +262,7 @@ def test_folder_open_loads_all_h5_when_multiple_exist(viewer, qtbot, tmp_path):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_first_save_writes_gt_into_dataset_folder(viewer, qtbot, tmp_path, overwrite_confirm):
+def test_config_first_save_writes_gt_into_dataset_folder(viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm):
     """
     Regression: config-first workflow must save CollectedData_<scorer>.h5 inside
     project/labeled-data/<dataset>/, not next to config.yaml.
@@ -286,11 +270,6 @@ def test_config_first_save_writes_gt_into_dataset_folder(viewer, qtbot, tmp_path
     overwrite_confirm.forbid()
 
     project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
-
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     # Open config first -> placeholder points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
@@ -305,7 +284,7 @@ def test_config_first_save_writes_gt_into_dataset_folder(viewer, qtbot, tmp_path
     assert pts_layers, "Expected a Points layer from config.yaml"
 
     points = pts_layers[0]
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     # Add a point and save
@@ -324,7 +303,7 @@ def test_config_first_save_writes_gt_into_dataset_folder(viewer, qtbot, tmp_path
 
 @pytest.mark.usefixtures("qtbot")
 def test_promotion_first_save_prompts_and_creates_sidecar(
-    viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
+    viewer, keypoint_controls, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
 ):
     """
     First save on a machine/prediction layer (no config.yaml, no sidecar):
@@ -338,11 +317,6 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
     machine_path = labeled_folder / "machinelabels-iter0.h5"
     machine_pre = pd.read_hdf(machine_path, key="keypoints")
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
     # Open folder
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)
@@ -354,7 +328,7 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
     machine_layer = next(p for p in pts_layers if p.name == "machinelabels-iter0")
 
     # Edit: add bodypart2 (use helper that works across versions)
-    store = controls._stores.get(machine_layer)
+    store = keypoint_controls._stores.get(machine_layer)
     assert store is not None
     _set_or_add_bodypart_xy(machine_layer, store, "bodypart2", x=44.0, y=33.0)
 
@@ -363,14 +337,14 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
 
     # Save via the widget path (ensures prompt runs)
     viewer.layers.selection.active = machine_layer
-    controls.viewer.layers.selection.active = machine_layer
-    controls.viewer.layers.selection.select_only(machine_layer)
+    keypoint_controls.viewer.layers.selection.active = machine_layer
+    keypoint_controls.viewer.layers.selection.select_only(machine_layer)
 
     assert "io" in machine_layer.metadata
     assert machine_layer.metadata["io"].get("kind") in ("machine", AnnotationKind.MACHINE)
 
     # Call your menu-hooked save action (this hits promotion logic)
-    controls._save_layers_dialog(selected=True)
+    keypoint_controls._save_layers_dialog(selected=True)
     qtbot.wait(200)
     assert "save_target" in machine_layer.metadata, machine_layer.metadata.keys()
 
@@ -390,7 +364,7 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
 
 @pytest.mark.usefixtures("qtbot")
 def test_promotion_second_save_uses_sidecar_no_prompt(
-    viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
+    viewer, keypoint_controls, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
 ):
     """
     After sidecar exists, saving again must not prompt:
@@ -407,9 +381,7 @@ def test_promotion_second_save_uses_sidecar_no_prompt(
     machine_path = labeled_folder / "machinelabels-iter0.h5"
     machine_pre = pd.read_hdf(machine_path, key="keypoints")
 
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
+    controls = keypoint_controls
     viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
@@ -442,6 +414,7 @@ def test_promotion_second_save_uses_sidecar_no_prompt(
 @pytest.mark.usefixtures("qtbot")
 def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_dlc_row_keys(
     viewer,
+    keypoint_controls,
     qtbot,
     tmp_path,
     monkeypatch,
@@ -481,18 +454,14 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     outside_img = outside_dir / "img999.png"
     outside_img.write_bytes(b"placeholder")
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     # Open config first -> placeholder points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
 
     points = next(ly for ly in viewer.layers if isinstance(ly, Points))
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     # Simulate project-less folder metadata:
@@ -538,10 +507,10 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     )
 
     viewer.layers.selection.active = points
-    controls.viewer.layers.selection.active = points
-    controls.viewer.layers.selection.select_only(points)
+    keypoint_controls.viewer.layers.selection.active = points
+    keypoint_controls.viewer.layers.selection.select_only(points)
 
-    controls._save_layers_dialog(selected=True)
+    keypoint_controls._save_layers_dialog(selected=True)
     qtbot.wait(300)
 
     # After project association, save should route into the chosen project's
@@ -588,6 +557,7 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
 @pytest.mark.usefixtures("qtbot")
 def test_projectless_folder_save_refuses_when_target_dataset_folder_already_contains_files(
     viewer,
+    keypoint_controls,
     qtbot,
     tmp_path,
     monkeypatch,
@@ -615,17 +585,13 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
     external_img = external_folder / "img_external.png"
     external_img.write_bytes(b"placeholder")
 
-    from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
-
-    controls = KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
 
     viewer.open(str(config_path), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
 
     points = next(ly for ly in viewer.layers if isinstance(ly, Points))
-    store = controls._stores.get(points)
+    store = keypoint_controls._stores.get(points)
     assert store is not None
 
     points.metadata = dict(points.metadata or {})
@@ -656,10 +622,10 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
         lambda *args, **kwargs: True,
     )
 
-    viewer.layers.selection.active = points
-    controls.viewer.layers.selection.select_only(points)
+    keypoint_controls.viewer.layers.selection.active = points
+    keypoint_controls.viewer.layers.selection.select_only(points)
 
-    controls._save_layers_dialog(selected=True)
+    keypoint_controls._save_layers_dialog(selected=True)
     qtbot.wait(200)
 
     assert warned.get("called", False), "Expected conflict warning for populated target dataset folder."

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -37,7 +37,7 @@ def forbid_project_config_dialog(monkeypatch):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_save_routes_to_correct_gt_when_multiple_gt_exist(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_save_routes_to_correct_gt_when_multiple_gt_exist(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: Saving a Points layer must write back ONLY to the file it came from.
     No 'first CollectedData*.h5' selection when multiple exist.
@@ -51,7 +51,6 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(make_napari_viewer, qt
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -93,7 +92,7 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(make_napari_viewer, qt
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_machine_layer_does_not_modify_gt_on_save(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_machine_layer_does_not_modify_gt_on_save(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: machine outputs must never save to their own file.
     Users must explicitly provide a scorer name that is then used to save the h5.
@@ -107,7 +106,6 @@ def test_machine_layer_does_not_modify_gt_on_save(make_napari_viewer, qtbot, tmp
 
     before = {p: _snapshot_coords(p) for p in gt_paths + [machine_path]}
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -142,7 +140,7 @@ def test_machine_layer_does_not_modify_gt_on_save(make_napari_viewer, qtbot, tmp
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_layer_rename_does_not_change_save_target(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_layer_rename_does_not_change_save_target(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: layer renaming must not redirect output or create new file.
     """
@@ -155,7 +153,6 @@ def test_layer_rename_does_not_change_save_target(make_napari_viewer, qtbot, tmp
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -188,9 +185,7 @@ def test_layer_rename_does_not_change_save_target(make_napari_viewer, qtbot, tmp
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(
-    make_napari_viewer, qtbot, tmp_path, overwrite_confirm
-):
+def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Contract: If provenance is missing and multiple candidate GT files exist,
     save must refuse (deterministic) rather than silently choosing.
@@ -203,7 +198,6 @@ def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(
 
     before = {p: _snapshot_coords(p) for p in gt_paths}
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
@@ -247,7 +241,7 @@ def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_folder_open_loads_all_h5_when_multiple_exist(make_napari_viewer, qtbot, tmp_path):
+def test_folder_open_loads_all_h5_when_multiple_exist(viewer, qtbot, tmp_path):
     """
     Contract: Opening a labeled-data folder with multiple H5 files should not
     silently pick the first one. Preferred policy: load all as separate Points layers.
@@ -255,8 +249,6 @@ def test_folder_open_loads_all_h5_when_multiple_exist(make_napari_viewer, qtbot,
     project, config_path, labeled_folder, gt_paths, machine_path = _make_dlc_project_with_multiple_gt(
         tmp_path, scorers=("John", "Jane"), with_machine=True
     )
-
-    viewer = make_napari_viewer()
 
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)  # images + points at least
@@ -286,7 +278,7 @@ def test_folder_open_loads_all_h5_when_multiple_exist(make_napari_viewer, qtbot,
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_first_save_writes_gt_into_dataset_folder(make_napari_viewer, qtbot, tmp_path, overwrite_confirm):
+def test_config_first_save_writes_gt_into_dataset_folder(viewer, qtbot, tmp_path, overwrite_confirm):
     """
     Regression: config-first workflow must save CollectedData_<scorer>.h5 inside
     project/labeled-data/<dataset>/, not next to config.yaml.
@@ -295,7 +287,6 @@ def test_config_first_save_writes_gt_into_dataset_folder(make_napari_viewer, qtb
 
     project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -333,7 +324,7 @@ def test_config_first_save_writes_gt_into_dataset_folder(make_napari_viewer, qtb
 
 @pytest.mark.usefixtures("qtbot")
 def test_promotion_first_save_prompts_and_creates_sidecar(
-    make_napari_viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
+    viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
 ):
     """
     First save on a machine/prediction layer (no config.yaml, no sidecar):
@@ -347,7 +338,6 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
     machine_path = labeled_folder / "machinelabels-iter0.h5"
     machine_pre = pd.read_hdf(machine_path, key="keypoints")
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -400,7 +390,7 @@ def test_promotion_first_save_prompts_and_creates_sidecar(
 
 @pytest.mark.usefixtures("qtbot")
 def test_promotion_second_save_uses_sidecar_no_prompt(
-    make_napari_viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
+    viewer, qtbot, tmp_path, inputdialog, forbid_project_config_dialog
 ):
     """
     After sidecar exists, saving again must not prompt:
@@ -417,7 +407,6 @@ def test_promotion_second_save_uses_sidecar_no_prompt(
     machine_path = labeled_folder / "machinelabels-iter0.h5"
     machine_pre = pd.read_hdf(machine_path, key="keypoints")
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
 
     controls = KeypointControls(viewer)
@@ -452,7 +441,7 @@ def test_promotion_second_save_uses_sidecar_no_prompt(
 
 @pytest.mark.usefixtures("qtbot")
 def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_dlc_row_keys(
-    make_napari_viewer,
+    viewer,
     qtbot,
     tmp_path,
     monkeypatch,
@@ -492,7 +481,6 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     outside_img = outside_dir / "img999.png"
     outside_img.write_bytes(b"placeholder")
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 
@@ -599,7 +587,7 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
 
 @pytest.mark.usefixtures("qtbot")
 def test_projectless_folder_save_refuses_when_target_dataset_folder_already_contains_files(
-    make_napari_viewer,
+    viewer,
     qtbot,
     tmp_path,
     monkeypatch,
@@ -627,7 +615,6 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
     external_img = external_folder / "img_external.png"
     external_img.write_bytes(b"placeholder")
 
-    viewer = make_napari_viewer()
     from napari_deeplabcut._widgets import KeypointControls
     from napari_deeplabcut.core import keypoints
 

--- a/src/napari_deeplabcut/_tests/e2e/test_trails_e2e.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_trails_e2e.py
@@ -33,6 +33,11 @@ def _open_multianimal_points(viewer, tmp_path: Path, *, n_animals: int = 3, n_kp
     return layer
 
 
+def _trails_layer(controls) -> Tracks | None:
+    """Current live trails layer managed by the extracted trails controller."""
+    return controls._trails_controller.layer
+
+
 def _expected_cycle_colors_from_controls(controls, points_layer):
     """
     Expected trails colors must come from the same resolved cycle path as the widget,
@@ -41,7 +46,7 @@ def _expected_cycle_colors_from_controls(controls, points_layer):
     prop = "id" if controls.color_mode == str(keypoints.ColorMode.INDIVIDUAL) else "label"
     vals = list(dict.fromkeys(map(str, points_layer.properties[prop])))
 
-    cycle = controls._resolved_trails_cycle(points_layer)
+    cycle = controls._resolved_cycle_for_layer(points_layer)
     out = []
     for v in vals:
         c = np.asarray(cycle[v], dtype=float)
@@ -65,19 +70,22 @@ def test_trails_mode_switch_does_not_fallback_to_track_id(viewer, tmp_path):
     viewer.layers.selection.active = points
 
     controls._trail_cb.setChecked(True)
-    assert controls._trails is not None
-    assert controls._trails.color_by == "id_codes"
+    trails = _trails_layer(controls)
+    assert trails is not None
+    assert trails.color_by == "id_codes"
 
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
 
         controls.color_mode = keypoints.ColorMode.BODYPART
-        assert controls._trails is not None
-        assert controls._trails.color_by == "label_codes"
+        trails = _trails_layer(controls)
+        assert trails is not None
+        assert trails.color_by == "label_codes"
 
         controls.color_mode = keypoints.ColorMode.INDIVIDUAL
-        assert controls._trails is not None
-        assert controls._trails.color_by == "id_codes"
+        trails = _trails_layer(controls)
+        assert trails is not None
+        assert trails.color_by == "id_codes"
 
     msgs = [str(w.message) for w in rec]
     assert not any("Falling back to track_id" in m for m in msgs), msgs
@@ -92,29 +100,39 @@ def test_trails_repeated_mode_switch_keeps_expected_colormap(viewer, tmp_path):
     viewer.layers.selection.active = points
     controls._trail_cb.setChecked(True)
 
+    trails = _trails_layer(controls)
+    assert trails is not None
+
     # Initial individual mode colors
     expected_id_colors, _ = _expected_cycle_colors_from_controls(controls, points)
-    actual_id_colors = _current_trails_cmap_colors(controls._trails)
+    actual_id_colors = _current_trails_cmap_colors(trails)
     np.testing.assert_allclose(actual_id_colors, expected_id_colors)
 
     # Switch to bodypart mode
     controls.color_mode = keypoints.ColorMode.BODYPART
-    assert controls._trails.color_by == "label_codes"
+    trails = _trails_layer(controls)
+    assert trails is not None
+    assert trails.color_by == "label_codes"
 
     expected_label_colors, _ = _expected_cycle_colors_from_controls(controls, points)
-    actual_label_colors = _current_trails_cmap_colors(controls._trails)
+    actual_label_colors = _current_trails_cmap_colors(trails)
     np.testing.assert_allclose(actual_label_colors, expected_label_colors)
 
     # Switch back to individual mode
     controls.color_mode = keypoints.ColorMode.INDIVIDUAL
-    assert controls._trails.color_by == "id_codes"
+    trails = _trails_layer(controls)
+    assert trails is not None
+    assert trails.color_by == "id_codes"
 
-    actual_id_colors_2 = _current_trails_cmap_colors(controls._trails)
+    actual_id_colors_2 = _current_trails_cmap_colors(trails)
     np.testing.assert_allclose(actual_id_colors_2, expected_id_colors)
 
     # And one more round trip for stability
     controls.color_mode = keypoints.ColorMode.BODYPART
-    actual_label_colors_2 = _current_trails_cmap_colors(controls._trails)
+    trails = _trails_layer(controls)
+    assert trails is not None
+
+    actual_label_colors_2 = _current_trails_cmap_colors(trails)
     np.testing.assert_allclose(actual_label_colors_2, expected_label_colors)
 
 
@@ -127,7 +145,7 @@ def test_trails_individual_mode_three_animals_have_three_distinct_mapped_colors(
     controls.color_mode = keypoints.ColorMode.INDIVIDUAL
     controls._trail_cb.setChecked(True)
 
-    trails = controls._trails
+    trails = _trails_layer(controls)
     assert trails is not None
     assert trails.color_by == "id_codes"
 
@@ -139,4 +157,6 @@ def test_trails_individual_mode_three_animals_have_three_distinct_mapped_colors(
     mapped = np.asarray(cmap.map(np.asarray(uniq_codes, dtype=float)))
     unique_rows = np.unique(np.round(mapped, decimals=8), axis=0)
 
-    assert unique_rows.shape[0] == 3
+    assert unique_rows.shape[0] == 3, (
+        f"Expected 3 unique colors for 3 animals, got {unique_rows.shape[0]} unique colors: {unique_rows}"
+    )

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -33,8 +33,8 @@ def test_guess_continuous():
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_keypoint_controls(viewer):
-    controls = _widgets.KeypointControls(viewer)
+def test_keypoint_controls(keypoint_controls):
+    controls = keypoint_controls
     controls.label_mode = "loop"
     assert controls._radio_group.checkedButton().text() == "Loop"
     controls.cycle_through_label_modes()
@@ -42,45 +42,41 @@ def test_keypoint_controls(viewer):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_save_layers(viewer, points):
-    controls = _widgets.KeypointControls(viewer)
+def test_save_layers(viewer, keypoint_controls, points):
     viewer.layers.selection.add(points)
-    controls._save_layers_dialog()
+    keypoint_controls._save_layers_dialog()
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_show_trails(viewer, store):
-    controls = _widgets.KeypointControls(viewer)
-    controls._stores[store.layer] = store
+def test_show_trails(viewer, keypoint_controls, store):
+    keypoint_controls._stores[store.layer] = store
     viewer.layers.selection.active = store.layer
-    controls._is_saved = True
+    keypoint_controls._is_saved = True
 
-    controls._trail_cb.setChecked(True)
+    keypoint_controls._trail_cb.setChecked(True)
 
-    trails = controls._trails_controller.layer
+    trails = keypoint_controls._trails_controller.layer
     assert trails is not None
     assert isinstance(trails, Tracks)
     assert trails.visible is True
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_extract_single_frame(viewer, images):
+def test_extract_single_frame(keypoint_controls, viewer, images):
     viewer.layers.selection.add(images)
-    controls = _widgets.KeypointControls(viewer)
-    controls._extract_single_frame()
+    keypoint_controls._extract_single_frame()
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_store_crop_coordinates(viewer, images, config_path):
+def test_store_crop_coordinates(keypoint_controls, viewer, images, config_path):
     viewer.layers.selection.add(images)
     _ = viewer.add_shapes(np.random.random((4, 3)), shape_type="rectangle")
-    controls = _widgets.KeypointControls(viewer)
     # _image_meta is expected to be an ImageMetadata instance
-    controls._image_meta = _widgets.ImageMetadata(name="fake_video")
+    keypoint_controls._image_meta = _widgets.ImageMetadata(name="fake_video")
     # _store_crop_coordinates now uses _project_path instead of reading "project" from _image_meta
-    controls._project_path = os.path.dirname(config_path)
+    keypoint_controls._project_path = os.path.dirname(config_path)
     # Stores crop coordinates from a rectangle shape into the project's config.yaml
-    controls._store_crop_coordinates()
+    keypoint_controls._store_crop_coordinates()
 
 
 @pytest.mark.usefixtures("qtbot")
@@ -277,10 +273,9 @@ def _no_autodock(monkeypatch):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ensure_mpl_canvas_docked_already_docked(viewer, qtbot, monkeypatch):
+def test_ensure_mpl_canvas_docked_already_docked(keypoint_controls, qtbot, monkeypatch):
     """If already docked, it must be a no-op: do not call add_dock_widget again."""
-    controls = _widgets.KeypointControls(viewer)
-    qtbot.add_widget(controls)
+    controls = keypoint_controls
     controls._mpl_docked = True  # simulate already docked
 
     called = {"count": 0}
@@ -297,9 +292,9 @@ def test_ensure_mpl_canvas_docked_already_docked(viewer, qtbot, monkeypatch):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ensure_mpl_canvas_docked_missing_window(viewer, qtbot):
+def test_ensure_mpl_canvas_docked_missing_window(keypoint_controls, qtbot):
     """If viewer has no window attribute, method should safely no-op."""
-    controls = _widgets.KeypointControls(viewer)
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     # Swap the viewer for a minimal stub object with *no* 'window' attribute
@@ -313,10 +308,7 @@ def test_ensure_mpl_canvas_docked_missing_window(viewer, qtbot):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_trajectory_loader_ignores_invalid_properties(viewer, make_real_header_factory):
-    controls = _widgets.KeypointControls(viewer)
-    viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
-
+def test_trajectory_loader_ignores_invalid_properties(viewer, keypoint_controls, make_real_header_factory):
     header = make_real_header_factory(individuals=("",))
     md = populate_keypoint_layer_properties(
         header,
@@ -330,13 +322,13 @@ def test_trajectory_loader_ignores_invalid_properties(viewer, make_real_header_f
 
     layer = viewer.add_points(np.array([[0.0, 10.0, 20.0]]), **md)
     assert layer is not None
-    assert controls._matplotlib_canvas.df is None  # loader should have bailed out safely
+    assert keypoint_controls._matplotlib_canvas.df is None  # loader should have bailed out safely
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ensure_mpl_canvas_docked_missing_qt_window(viewer, qtbot):
+def test_ensure_mpl_canvas_docked_missing_qt_window(keypoint_controls, qtbot):
     """If window._qt_window is None, method should safely no-op."""
-    controls = _widgets.KeypointControls(viewer)
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     class DummyWindow:
@@ -356,9 +348,9 @@ def test_ensure_mpl_canvas_docked_missing_qt_window(viewer, qtbot):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ensure_mpl_canvas_docked_exception_during_docking(viewer, qtbot):
+def test_ensure_mpl_canvas_docked_exception_during_docking(keypoint_controls, qtbot):
     """If add_dock_widget raises, method should catch, log, and remain undocked (no crash)."""
-    controls = _widgets.KeypointControls(viewer)
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     class DummyWindow:
@@ -380,9 +372,9 @@ def test_ensure_mpl_canvas_docked_exception_during_docking(viewer, qtbot):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_display_shortcuts_dialog(viewer, qtbot):
+def test_display_shortcuts_dialog(keypoint_controls, qtbot):
     """Ensure that the Shortcuts dialog can be created and shown without errors."""
-    controls = _widgets.KeypointControls(viewer)
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     # Create the dialog directly
@@ -404,10 +396,7 @@ def test_display_shortcuts_dialog(viewer, qtbot):
 # these tests currently exercise only a narrow "everything fine" path and rely on specific metadata
 # layout and SuperAnimal conversion-table conventions, which makes them susceptible to API changes
 @pytest.mark.usefixtures("qtbot")
-def test_widget_load_superkeypoints_diagram(viewer, qtbot, points, monkeypatch):
-    controls = _widgets.KeypointControls(viewer)
-    qtbot.add_widget(controls)
-
+def test_widget_load_superkeypoints_diagram(keypoint_controls, viewer, qtbot, points, monkeypatch):
     # Arrange: conversion table uses *realistic* keys (not SK1/SK2),
     # and does not depend on any asset conventions.
     layer = points
@@ -426,7 +415,7 @@ def test_widget_load_superkeypoints_diagram(viewer, qtbot, points, monkeypatch):
     n_layers_before = len(viewer.layers)
 
     # Act
-    controls.load_superkeypoints_diagram()
+    keypoint_controls.load_superkeypoints_diagram()
 
     # Assert: one new image layer is added
     assert len(viewer.layers) == n_layers_before + 1
@@ -442,13 +431,13 @@ def test_widget_load_superkeypoints_diagram(viewer, qtbot, points, monkeypatch):
     assert np.allclose(layer.data[:, 1:], np.array([[1.0, 2.0], [3.0, 4.0]]))
 
     # Assert: UI updated
-    assert controls._keypoint_mapping_button.text() == "Map keypoints"
-    assert controls._keypoint_mapping_button.text() == "Map keypoints"
+    assert keypoint_controls._keypoint_mapping_button.text() == "Map keypoints"
+    assert keypoint_controls._keypoint_mapping_button.text() == "Map keypoints"
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_widget_map_keypoints_writes_to_config(viewer, qtbot, points, config_path, monkeypatch):
-    controls = _widgets.KeypointControls(viewer)
+def test_widget_map_keypoints_writes_to_config(keypoint_controls, qtbot, points, config_path, monkeypatch):
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     # Arrange: ensure the points layer has some data (shape: [t, x, y])
@@ -557,8 +546,8 @@ def test_read_config_injects_tables_metadata(tmp_path):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_points_layer_with_tables_shows_superkeypoints_button(viewer, qtbot, points):
-    controls = _widgets.KeypointControls(viewer)
+def test_points_layer_with_tables_shows_superkeypoints_button(keypoint_controls, qtbot, points):
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     assert not controls._keypoint_mapping_button.isVisible()
@@ -573,8 +562,8 @@ def test_points_layer_with_tables_shows_superkeypoints_button(viewer, qtbot, poi
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_points_layer_with_tables_button_not_lost_on_merge_path(viewer, qtbot, points, monkeypatch):
-    controls = _widgets.KeypointControls(viewer)
+def test_points_layer_with_tables_button_not_lost_on_merge_path(keypoint_controls, qtbot, points, monkeypatch):
+    controls = keypoint_controls
     qtbot.add_widget(controls)
 
     points.metadata["tables"] = {"superanimal_quadruped": {"bp1": "nose"}}
@@ -588,12 +577,8 @@ def test_points_layer_with_tables_button_not_lost_on_merge_path(viewer, qtbot, p
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_video_panel_has_extraction_options(viewer, qtbot):
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
-    qtbot.addWidget(controls)
-
+def test_video_panel_has_extraction_options(keypoint_controls):
+    controls = keypoint_controls
     panel = controls._video_group
     assert panel.extract_button.text() == "Extract current frame"
     assert panel.crop_button.text() == "Save crop to config"
@@ -602,10 +587,8 @@ def test_video_panel_has_extraction_options(viewer, qtbot):
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_extract_single_frame_warns_without_image_layer(viewer, qtbot, monkeypatch):
-    from napari_deeplabcut._widgets import KeypointControls
-
-    controls = KeypointControls(viewer)
+def test_extract_single_frame_warns_without_image_layer(keypoint_controls, qtbot, monkeypatch):
+    controls = keypoint_controls
     qtbot.addWidget(controls)
 
     seen = {}

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 import yaml
-from napari.layers import Image
+from napari.layers import Image, Tracks
 from qtpy.QtWidgets import QScrollArea
 from vispy import keys
 
@@ -52,7 +52,13 @@ def test_show_trails(viewer, store):
     controls._stores[store.layer] = store
     viewer.layers.selection.active = store.layer
     controls._is_saved = True
-    controls._show_trails(state=2)
+
+    controls._trail_cb.setChecked(True)
+
+    trails = controls._trails_controller.layer
+    assert trails is not None
+    assert isinstance(trails, Tracks)
+    assert trails.visible is True
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -18,6 +18,8 @@ from napari_deeplabcut.ui.dialogs import ShortcutRow
 from napari_deeplabcut.ui.labels_and_dropdown import KeypointsDropdownMenu, LabelPair
 from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
 
+from .conftest import force_show
+
 
 def test_guess_continuous():
     import numpy as np
@@ -195,6 +197,7 @@ def test_keypoints_dropdown_menu_updates_from_store_current_properties(store, qt
 def test_keypoints_dropdown_menu_smart_reset(store, qtbot):
     widget = KeypointsDropdownMenu(store)
     qtbot.add_widget(widget)
+    force_show(widget, qtbot)
     label_menu = widget.menus["label"]
     label_menu.update_to("kpt_2")
     widget._locked = True

--- a/src/napari_deeplabcut/_tests/ui/test_color_scheme.py
+++ b/src/napari_deeplabcut/_tests/ui/test_color_scheme.py
@@ -17,6 +17,8 @@ from napari_deeplabcut.ui.color_scheme_display import (
     _to_hex,
 )
 
+from ..conftest import force_show
+
 
 def _header_model_from_layer(layer) -> DLCHeaderModel:
     hdr = layer.metadata.get("header")
@@ -294,6 +296,7 @@ def test_panel_initial_active_mode_updates_display_from_current_frame(
         get_header_model=get_header_model,
     )
     qtbot.addWidget(panel)
+    force_show(panel, qtbot)
 
     expected = _expected_scheme_from_policy(layer, prop="label", names=["nose"])
     qtbot.waitUntil(lambda: panel.display.scheme_dict == expected)
@@ -328,6 +331,7 @@ def test_panel_reacts_to_frame_change_event(
         get_header_model=get_header_model,
     )
     qtbot.addWidget(panel)
+    force_show(panel, qtbot)
 
     expected0 = _expected_scheme_from_policy(layer, prop="label", names=["nose"])
     qtbot.waitUntil(lambda: panel.display.scheme_dict == expected0)
@@ -365,6 +369,7 @@ def test_panel_toggle_switches_from_active_to_config_preview(
         get_header_model=get_header_model,
     )
     qtbot.addWidget(panel)
+    force_show(panel, qtbot)
 
     # Active mode should show the currently visible label from the layer.
     expected_active = _expected_scheme_from_policy(layer, prop="label", names=["nose"])
@@ -376,6 +381,7 @@ def test_panel_toggle_switches_from_active_to_config_preview(
     qtbot.waitUntil(lambda: panel.display.scheme_dict == expected_config)
 
 
+@pytest.mark.usefixtures("qtbot")
 def test_color_scheme_panel_delete_later_does_not_crash_on_pending_update(qtbot, fake_viewer, get_header_model):
     panel = ColorSchemePanel(
         viewer=fake_viewer,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -215,7 +215,7 @@ class KeypointControls(QWidget):
 
         grid = QGridLayout()
 
-        self._confirm_overwrite_cb = QCheckBox("Confirm overwrite saves", parent=self)
+        self._confirm_overwrite_cb = QCheckBox("Warn on overwrite", parent=self)
         self._confirm_overwrite_cb.setToolTip(
             "When enabled, saving a layer that would overwrite existing keypoints will show a confirmation dialog."
         )

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -57,7 +57,6 @@ from napari_deeplabcut.core.metadata import (
     apply_project_paths_override_to_points_meta,
     infer_image_root,
     migrate_points_layer_metadata,
-    parse_points_metadata,
     read_points_meta,
     sync_points_from_image,
     write_points_meta,
@@ -74,17 +73,9 @@ from napari_deeplabcut.core.project_paths import (
 from napari_deeplabcut.core.remap import remap_layer_data_by_paths
 from napari_deeplabcut.core.sidecar import (
     get_default_scorer,
-    get_trails_config,
     set_default_scorer,
-    set_trails_config,
 )
-from napari_deeplabcut.core.trails import (
-    build_trails_payload,
-    display_config_from_tracks_layer,
-    tracks_kwargs_from_display_config,
-    trails_geometry_signature,
-    trails_signature,
-)
+from napari_deeplabcut.core.trails import TrailsController, safe_folder_anchor_from_points_layer
 from napari_deeplabcut.napari_compat import (
     apply_points_layer_ui_tweaks,
     install_add_wrapper,
@@ -111,35 +102,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
 from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
-logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp
-
-
-def _safe_folder_anchor_from_points_layer(layer: Points) -> str | None:
-    """Best-effort anchor folder for sidecar + CollectedData creation."""
-    md = layer.metadata or {}
-
-    # Prefer IO provenance project_root if present
-    try:
-        pts = parse_points_metadata(md)
-        if pts.io and pts.io.project_root:
-            return str(pts.io.project_root)
-    except Exception:
-        pass
-
-    # Fall back to root field
-    root = md.get("root")
-    if isinstance(root, str) and root:
-        return root
-
-    # Fall back to legacy source_h5 parent
-    src = md.get("source_h5")
-    if isinstance(src, str) and src:
-        try:
-            return str(Path(src).expanduser().resolve().parent)
-        except Exception:
-            return str(Path(src).parent)
-
-    return None
+logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
 
 
 def _find_config_scorer_nearby(anchor: str) -> str | None:
@@ -280,11 +243,13 @@ class KeypointControls(QWidget):
         self._trail_cb.setToolTip("Show the trails for each keypoint over time, in the main video viewer")
         self._trail_cb.setChecked(False)
         self._trail_cb.setEnabled(False)
-        self._trail_cb.stateChanged.connect(self._show_trails)
-        self._trails = None
-        self._trails_geom_sig = None
-        self._trails_style_sig = None
-        self._refreshing_trails = False
+        self._trail_cb.stateChanged.connect(self._on_show_trails_toggled)
+        self._trails_controller = TrailsController(
+            self.viewer,
+            managed_points_layers_getter=lambda: tuple(self._stores.keys()),
+            color_mode_getter=lambda: self.color_mode,
+            resolved_cycle_getter=self._resolved_cycle_for_layer,
+        )
 
         self._mpl_docked = False
         self._matplotlib_canvas = KeypointMatplotlibCanvas(self.viewer)
@@ -556,8 +521,7 @@ class KeypointControls(QWidget):
         # apply cycles (works even if empty; see method)
         self._apply_points_coloring_from_metadata(layer)
         # refresh trails if enabled (e.g. when merging a config points layer with trails metadata)
-        if self._trail_cb.isChecked() and self._trails is not None:
-            self._refresh_trails()
+        self._trails_controller.on_points_layer_added_or_rewired(checkbox_checked=self._trail_cb.isChecked())
 
         # menus
         self._form_dropdown_menus(store)
@@ -1069,307 +1033,6 @@ class KeypointControls(QWidget):
         show = self._view_scheme_cb.isChecked()
         self._color_scheme_display.setVisible(show)
 
-    def _snapshot_selection(self):
-        selected = [layer for layer in self.viewer.layers.selection if layer in self.viewer.layers]
-        active = self.viewer.layers.selection.active
-        return selected, active
-
-    def _restore_selection(self, selected, active):
-        try:
-            self.viewer.layers.selection.clear()
-            for layer in selected:
-                if layer in self.viewer.layers:
-                    self.viewer.layers.selection.add(layer)
-            if active in self.viewer.layers:
-                self.viewer.layers.selection.active = active
-        except Exception:
-            pass
-
-    def _get_trails_anchor(self, layer: Points | None = None) -> str | None:
-        """
-        Resolve the folder-scoped sidecar anchor for the trails source layer.
-
-        This is intentionally a tiny wrapper so future multi-layer support can swap
-        the source-selection logic without touching persistence code.
-        """
-        pts_layer = layer if layer is not None else self._get_trails_source_layer()
-        if pts_layer is None:
-            return None
-        return _safe_folder_anchor_from_points_layer(pts_layer)
-
-    def _persist_current_trails_config(self, *, visible: bool | None = None) -> None:
-        """
-        Persist the current trails display config to the folder sidecar.
-
-        Option A policy:
-        - persist on our own lifecycle actions only
-        - do not try to watch napari's native layer controls continuously
-        """
-        if self._trails is None:
-            return
-
-        anchor = (self._trails.metadata or {}).get("_dlc_trails_anchor")
-        if not anchor:
-            anchor = self._get_trails_anchor()
-
-        if not anchor:
-            return
-
-        try:
-            cfg = display_config_from_tracks_layer(self._trails, visible=visible)
-            set_trails_config(anchor, cfg)
-        except Exception:
-            logger.debug("Failed to persist trails config for anchor=%r", anchor, exc_info=True)
-
-    def _persist_folder_ui_state_for_points_layer(self, layer: Points) -> None:
-        """
-        Best-effort persistence of folder-scoped UI state for a specific DLC-managed
-        points layer.
-
-        This never raises and must never block annotation saving.
-
-        Policy
-        ------
-        - If the current global trails layer belongs to this points layer (or same anchor),
-        snapshot its full display config.
-        - Otherwise, preserve the existing stored trails config and only mark visible=False.
-        """
-        anchor = _safe_folder_anchor_from_points_layer(layer)
-        if not anchor:
-            return
-
-        try:
-            # Case 1: live trails exist and belong to this saved layer/folder.
-            if self._trails is not None:
-                trails_md = self._trails.metadata or {}
-                trails_anchor = trails_md.get("_dlc_trails_anchor")
-                trails_src_id = trails_md.get("_source_points_layer_id")
-
-                same_source = trails_src_id == id(layer)
-                same_anchor = trails_anchor is not None and str(trails_anchor) == str(anchor)
-
-                if same_source or same_anchor:
-                    cfg = display_config_from_tracks_layer(
-                        self._trails,
-                        visible=bool(self._trail_cb.isChecked() and self._trails.visible),
-                    )
-                    set_trails_config(anchor, cfg)
-                    return
-
-            # Case 2: no live trails for this layer -> preserve existing config, but mark hidden.
-            cfg = get_trails_config(anchor)
-            cfg = cfg.model_copy(update={"visible": False})
-            set_trails_config(anchor, cfg)
-
-        except Exception:
-            logger.debug(
-                "Failed to persist folder UI state for saved points layer=%r",
-                getattr(layer, "name", layer),
-                exc_info=True,
-            )
-
-    def _resolved_trails_cycle(self, layer: Points) -> dict:
-        """
-        Return the resolved category->color mapping used by the points layer,
-        so trails match the exact displayed colors.
-        """
-        resolver = self._color_scheme_panel._resolver
-        cycles = resolver.get_face_color_cycles(layer) or {}
-
-        prop = resolver.get_active_color_property(layer)
-        props = getattr(layer, "properties", {}) or {}
-        values = props.get(prop)
-
-        if prop == "id":
-            try:
-                vals = np.asarray(values, dtype=object).ravel() if values is not None else np.array([], dtype=object)
-                if len(vals) == 0 or all(v in ("", None) or misc._is_nan_value(v) for v in vals):
-                    prop = "label"
-            except Exception:
-                prop = "label"
-
-        cycle = cycles.get(prop, {}) or {}
-        return {str(k): np.asarray(v, dtype=float) for k, v in cycle.items()}
-
-    def _update_trails_style(self) -> None:
-        """Update trails color mapping in-place without rebuilding geometry."""
-        if self._trails is None:
-            return
-
-        pts_layer = self._get_trails_source_layer()
-        if pts_layer is None:
-            return
-
-        try:
-            payload = build_trails_payload(
-                pts_layer,
-                self._color_mode,
-                cycle_override=self._resolved_trails_cycle(pts_layer),
-            )
-        except ValueError:
-            return
-
-        try:
-            new_props = dict(getattr(self._trails, "properties", {}) or {})
-            new_props.update(payload.properties)
-            self._trails.properties = new_props
-
-            new_cmaps = dict(getattr(self._trails, "colormaps_dict", {}) or {})
-            new_cmaps.update(payload.colormaps_dict)
-            self._trails.colormaps_dict = new_cmaps
-
-            self._trails.color_by = payload.color_by
-            self._trails.visible = True
-            self._trails_style_sig = payload.signature
-
-            # IMPORTANT: keep trails ownership metadata in sync with the actual source layer
-            self._trails.metadata = dict(self._trails.metadata or {})
-            self._trails.metadata["_source_points_layer_id"] = id(pts_layer)
-            self._trails.metadata["_dlc_trails_anchor"] = self._get_trails_anchor(pts_layer)
-
-        except Exception:
-            # Fallback to full rebuild if in-place update is not supported
-            self._refresh_trails()
-
-    def _remove_trails_layer(self) -> None:
-        """Remove trails without triggering checkbox side effects."""
-        if self._trails is None:
-            return
-
-        self._refreshing_trails = True
-        try:
-            self.viewer.layers.remove(self._trails)
-        except Exception:
-            pass
-        finally:
-            self._trails = None
-            self._trails_geom_sig = None
-            self._trails_style_sig = None
-            self._refreshing_trails = False
-
-    def _refresh_trails(self) -> None:
-        if not self._trail_cb.isChecked():
-            return
-
-        selected, active = self._snapshot_selection()
-        try:
-            self._remove_trails_layer()
-            self._create_trails()
-        finally:
-            self._restore_selection(selected, active)
-
-    def _show_trails(self, state):
-        checked = Qt.CheckState(state) == Qt.CheckState.Checked
-
-        if not checked:
-            if self._trails is not None:
-                self._trails.visible = False
-                # Persist `visible=False` to the trails display config
-                try:
-                    pts_layer = self._get_trails_source_layer()
-                    if pts_layer is not None:
-                        anchor = self._get_trails_anchor(pts_layer)
-                        if anchor:
-                            cfg = get_trails_config(anchor)
-                            if cfg is None and self._trails is not None:
-                                cfg = display_config_from_tracks_layer(self._trails)
-                            if cfg is not None:
-                                cfg = cfg.model_copy(update={"visible": False})
-                                set_trails_config(anchor, cfg)
-                except Exception:
-                    # Do not break UI behavior if persistence fails
-                    logger.debug(
-                        "Failed to persist trails visibility state on hide.",
-                        exc_info=True,
-                    )
-            return
-
-        if not self._stores:
-            return
-
-        pts_layer = self._get_trails_source_layer()
-        if pts_layer is None:
-            return
-
-        geom_sig = trails_geometry_signature(pts_layer)
-        style_sig = trails_signature(pts_layer, self._color_mode)
-
-        if self._trails is None:
-            self._create_trails()
-            return
-
-        if self._trails_geom_sig != geom_sig:
-            self._refresh_trails()
-            return
-
-        if self._trails_style_sig != style_sig:
-            self._update_trails_style()
-            return
-
-        self._trails.visible = True
-
-    def _create_trails(self):
-        if self._trails is not None or not self._stores:
-            return
-
-        pts_layer = self._get_trails_source_layer()
-        if pts_layer is None:
-            return
-
-        anchor = self._get_trails_anchor(pts_layer)
-        cfg = get_trails_config(anchor) if anchor else None
-        track_kwargs = tracks_kwargs_from_display_config(cfg) if cfg is not None else {}
-
-        selected, active = self._snapshot_selection()
-        try:
-            payload = build_trails_payload(
-                pts_layer,
-                self._color_mode,
-                cycle_override=self._resolved_trails_cycle(pts_layer),
-            )
-        except ValueError:
-            return
-
-        try:
-            self._trails = self.viewer.add_tracks(
-                payload.tracks_data,
-                properties=payload.properties,
-                color_by=payload.color_by,
-                colormaps_dict=payload.colormaps_dict,
-                name="trails",
-                metadata={
-                    "_source_points_layer_id": id(pts_layer),
-                    "_dlc_trails_anchor": anchor,
-                },
-                **track_kwargs,
-            )
-            # The user explicitly asked to show trails, so force visible True here.
-            # We still persist visible state in the sidecar for future use, but we do
-            # not let a stale visible=False sidecar entry override an explicit checkbox action.
-            self._trails.visible = True
-
-            self._trails_geom_sig = payload.geometry_signature
-            self._trails_style_sig = payload.signature
-
-            # Persist once so sidecar is normalized even if it was missing/partial.
-            self._persist_current_trails_config(visible=True)
-        finally:
-            self._restore_selection(selected, active)
-
-    def _get_trails_source_layer(self) -> Points | None:
-        active = self.viewer.layers.selection.active
-        if isinstance(active, Points) and active in self._stores:
-            return active
-
-        if self._trails is not None:
-            src_id = (self._trails.metadata or {}).get("_source_points_layer_id")
-            if src_id is not None:
-                for layer in self._stores:
-                    if id(layer) == src_id:
-                        return layer
-
-        return next(iter(self._stores.keys()), None)
-
     def _form_help_buttons(self):
         layout = QVBoxLayout()
         help_buttons_layout = QHBoxLayout()
@@ -1659,10 +1322,7 @@ class KeypointControls(QWidget):
 
             # Refresh color scheme panel regardless; it will clear itself if no valid target remains.
             self._update_color_scheme()
-            if self._trails is not None:
-                src_id = (self._trails.metadata or {}).get("_source_points_layer_id")
-                if src_id == id(layer):
-                    self._remove_trails_layer()
+            self._trails_controller.on_points_layer_removed(layer)
 
             if n_points_layer == 0:
                 while self._menus:
@@ -1683,19 +1343,16 @@ class KeypointControls(QWidget):
                 self.video_widget.setVisible(False)
 
         elif isinstance(layer, Tracks):
-            if getattr(self, "_refreshing_trails", False):
-                self._trails = None
-                self._trails_geom_sig = None
-                self._trails_style_sig = None
+            was_trails = self._trails_controller.on_tracks_layer_removed(layer)
+            if was_trails:
+                self._trail_cb.setChecked(False)
+                self._show_traj_plot_cb.setChecked(False)
                 return
 
-            self._trail_cb.setChecked(False)
-            self._show_traj_plot_cb.setChecked(False)
-            self._trails = None
-            self._trails_geom_sig = None
-            self._trails_style_sig = None
-
         self._refresh_video_panel_context()
+
+    def _on_show_trails_toggled(self, state):
+        self._trails_controller.toggle(Qt.CheckState(state) == Qt.CheckState.Checked)
 
     def _ensure_promotion_save_target(self, layer: Points) -> bool:
         """Ensure a prediction/machine source layer has a GT save_target set.
@@ -1739,7 +1396,7 @@ class KeypointControls(QWidget):
             return True
 
         # ---- machine source + no save_target: require promotion target ----
-        anchor = _safe_folder_anchor_from_points_layer(layer)
+        anchor = safe_folder_anchor_from_points_layer(layer)
         if not anchor:
             QMessageBox.warning(self, "Cannot save", "Could not determine a folder anchor for saving.")
             return False
@@ -1872,7 +1529,10 @@ class KeypointControls(QWidget):
                 self.viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
             # hook to persist UI state on successful save
             try:
-                self._persist_folder_ui_state_for_points_layer(layer)
+                self._trails_controller.persist_folder_ui_state_for_points_layer(
+                    layer,
+                    checkbox_checked=self._trail_cb.isChecked(),
+                )
             except Exception:
                 logger.debug(
                     "Failed to persist folder UI state after save for layer=%r",
@@ -1899,7 +1559,10 @@ class KeypointControls(QWidget):
 
                     for ly in candidate_layers:
                         if ly in self.viewer.layers:
-                            self._persist_folder_ui_state_for_points_layer(ly)
+                            self._trails_controller.persist_folder_ui_state_for_points_layer(
+                                ly,
+                                checkbox_checked=self._trail_cb.isChecked(),
+                            )
                 except Exception:
                     logger.debug("Failed to persist sidecar UI state after multi-layer save", exc_info=True)
 
@@ -1953,9 +1616,8 @@ class KeypointControls(QWidget):
             mark_layer_presentation_changed(layer)
             self._apply_points_coloring_from_metadata(layer)
 
-        self._update_color_scheme()
-        if self._trail_cb.isChecked() and self._trails is not None:
-            self._update_trails_style()
+            self._update_color_scheme()
+            self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
 
     @register_points_action("Change labeling mode")
     def cycle_through_label_modes(self, *args):
@@ -2004,8 +1666,7 @@ class KeypointControls(QWidget):
                 break
 
         self._update_color_scheme()
-        if self._trail_cb.isChecked() and self._trails is not None:
-            self._update_trails_style()
+        self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
 
     def _is_multianimal(self, layer) -> bool:
         if layer is None or not isinstance(layer, Points):
@@ -2029,3 +1690,26 @@ class KeypointControls(QWidget):
                 return True
 
         return False
+
+    def _resolved_cycle_for_layer(self, layer: Points) -> dict:
+        """
+        Return the resolved category->color mapping used by the points layer,
+        so trails match the exact displayed colors.
+        """
+        resolver = self._color_scheme_panel._resolver
+        cycles = resolver.get_face_color_cycles(layer) or {}
+
+        prop = resolver.get_active_color_property(layer)
+        props = getattr(layer, "properties", {}) or {}
+        values = props.get(prop)
+
+        if prop == "id":
+            try:
+                vals = np.asarray(values, dtype=object).ravel() if values is not None else np.array([], dtype=object)
+                if len(vals) == 0 or all(v in ("", None) or misc._is_nan_value(v) for v in vals):
+                    prop = "label"
+            except Exception:
+                prop = "label"
+
+        cycle = cycles.get(prop, {}) or {}
+        return {str(k): np.asarray(v, dtype=float) for k, v in cycle.items()}

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -18,7 +18,7 @@ from napari.layers import Image, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import get_save_history, update_save_history
 from pydantic import ValidationError
-from qtpy.QtCore import QSettings, Qt, QTimer
+from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -1345,9 +1345,8 @@ class KeypointControls(QWidget):
         elif isinstance(layer, Tracks):
             was_trails = self._trails_controller.on_tracks_layer_removed(layer)
             if was_trails:
-                self._trail_cb.setChecked(False)
-                self._show_traj_plot_cb.setChecked(False)
-                return
+                with QSignalBlocker(self._trail_cb):
+                    self._trail_cb.setChecked(False)
 
         self._refresh_video_panel_context()
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -3,7 +3,6 @@
 # src/napari_deeplabcut/_widgets.py
 from __future__ import annotations
 
-import hashlib
 import logging
 from contextlib import contextmanager
 from copy import deepcopy
@@ -43,7 +42,7 @@ from napari_deeplabcut.config.keybinds import (
     install_global_points_keybindings,
     install_points_layer_keybindings,
 )
-from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, ImageMetadata, IOProvenance, PointsMetadata
+from napari_deeplabcut.config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
 from napari_deeplabcut.core import keypoints
 from napari_deeplabcut.core.conflicts import compute_overwrite_report_for_points_save
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
@@ -65,10 +64,15 @@ from napari_deeplabcut.core.project_paths import (
     PathMatchPolicy,
     coerce_paths_to_dlc_row_keys,
     dataset_folder_has_files,
-    infer_dlc_project_from_points_meta,
-    is_windows_absolute_path,
     resolve_project_root_from_config,
     target_dataset_folder_for_config,
+)
+from napari_deeplabcut.core.provenance import (
+    apply_gt_save_target,
+    find_config_scorer_nearby,
+    is_projectless_folder_association_candidate,
+    requires_gt_promotion,
+    suggest_human_placeholder,
 )
 from napari_deeplabcut.core.remap import remap_layer_data_by_paths
 from napari_deeplabcut.core.sidecar import (
@@ -102,28 +106,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
 from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
-logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
-
-
-def _find_config_scorer_nearby(anchor: str) -> str | None:
-    """Try to find config.yaml scorer (best-effort)."""
-    try:
-        # misc.find_project_config_path expects a path; anchor works fine as starting point.
-        cfg_path = misc.find_project_config_path(anchor)
-        if cfg_path:
-            cfg = io.load_config(cfg_path)
-            s = cfg.get("scorer")
-            if isinstance(s, str) and s.strip():
-                return s.strip()
-    except Exception:
-        pass
-    return None
-
-
-def _suggest_human_placeholder(anchor: str) -> str:
-    """Deterministic placeholder: human_<6hex> derived from anchor path."""
-    h = hashlib.sha1(anchor.encode("utf-8", errors="ignore")).hexdigest()[:6]
-    return f"human_{h}"
+# logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
 
 
 def _prompt_for_scorer(parent_widget, *, anchor: str, suggested: str) -> str | None:
@@ -844,90 +827,6 @@ class KeypointControls(QWidget):
                     out,
                 )
 
-    def _is_projectless_folder_association_candidate(self, layer: Points, pts_meta: PointsMetadata) -> bool:
-        """
-        Return True for the 'associate current labeled folder with a DLC project'
-        workflow.
-
-        Non-candidates include:
-        - machine/promotion layers
-        - layers with an explicit save_target
-        - layers that already have a resolved DLC project/config context
-        - layers without a usable folder root
-        - layers whose paths do not look like a simple single-folder labeling session
-        """
-        # Promotion / machine-save path is a separate workflow.
-        if is_machine_layer(layer):
-            return False
-
-        # If save routing was already explicitly chosen, do not override it here.
-        if getattr(pts_meta, "save_target", None) is not None:
-            return False
-
-        # Already project-backed -> do not prompt again.
-        project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
-        if project_ctx.project_root is not None and project_ctx.config_path is not None:
-            return False
-
-        root = getattr(pts_meta, "root", None)
-        paths = list(getattr(pts_meta, "paths", None) or [])
-        if not root or not paths:
-            return False
-
-        try:
-            root_path = Path(root).expanduser().resolve(strict=False)
-        except Exception:
-            root_path = Path(root)
-
-        # Simple single-folder path shape only:
-        # - relative basenames
-        # - absolute files directly under root
-        # - already-canonical labeled-data/<dataset>/<image>
-        for value in paths:
-            text = str(value).replace("\\", "/")
-            p = Path(value)
-
-            parts = [part for part in text.split("/") if part]
-            lowered = [part.lower() for part in parts]
-            if "labeled-data" in lowered:
-                idx = lowered.index("labeled-data")
-                if idx + 2 < len(parts):
-                    continue
-
-            # On POSIX, pathlib.Path(...) does not recognize Windows drive-letter
-            # / UNC paths as absolute. Prevent those from being misclassified as
-            # simple relative basenames.
-            is_windows_abs_misclassified = not p.is_absolute() and is_windows_absolute_path(value)
-            if not p.is_absolute():
-                if is_windows_abs_misclassified:
-                    # Treat as an absolute/unresolved path, not as a basename candidate.
-                    # In this lightweight workflow, unrelated absolute paths are allowed
-                    # and preserved unchanged.
-                    continue
-
-                # Only allow simple basenames as projectless candidates.
-                # Any directory components or '.' / '..' segments are rejected.
-                if len(p.parts) == 1 and p.parts[0] not in (".", ".."):
-                    continue
-                return False
-
-            try:
-                rel_to_root = p.expanduser().resolve(strict=False).relative_to(root_path)
-            except Exception:
-                # Unrelated absolute path outside the current labeled folder is allowed:
-                # it will simply be preserved unchanged.
-                continue
-
-            # Only direct children of the current labeled folder are considered
-            # safely coercible in this lightweight workflow.
-            if len(rel_to_root.parts) == 1:
-                continue
-
-            # Nested paths *inside* the current root are considered ambiguous for now.
-            return False
-
-        return True
-
     def _maybe_prepare_project_path_override_metadata(self, layer: Points) -> tuple[dict | None, bool]:
         """
         Optionally prepare save-time metadata by associating a project-less labeled
@@ -951,7 +850,7 @@ class KeypointControls(QWidget):
         if not paths:
             return None, False
 
-        if not self._is_projectless_folder_association_candidate(layer, pts_meta):
+        if not is_projectless_folder_association_candidate(pts_meta):
             return None, False
 
         source_root = pts_meta.root
@@ -1358,11 +1257,9 @@ class KeypointControls(QWidget):
 
         Returns True if save_target is set (or already existed), False if user cancels.
         """
-        # Only machine layers need promotion; non-machine layers can be saved as-is without a save_target
         if not is_machine_layer(layer):
             return True
 
-        # Best-effort migrate provenance (may fill io/save_target for legacy layers)
         mig = migrate_points_layer_metadata(layer)
         if hasattr(mig, "errors"):
             logger.warning(
@@ -1382,27 +1279,18 @@ class KeypointControls(QWidget):
             return False
 
         pts: PointsMetadata = res
-        io_meta = pts.io
-        save_target = pts.save_target
 
-        # If this machine layer already has a promotion target, we're done
-        if save_target is not None:
+        if not requires_gt_promotion(pts):
             return True
 
-        # If io is missing or doesn't look like a machine source, don't block (fail open)
-        src_kind = getattr(io_meta, "kind", None) if io_meta is not None else None
-        if src_kind is not AnnotationKind.MACHINE:
-            return True
-
-        # ---- machine source + no save_target: require promotion target ----
         anchor = safe_folder_anchor_from_points_layer(layer)
         if not anchor:
             QMessageBox.warning(self, "Cannot save", "Could not determine a folder anchor for saving.")
             return False
 
-        scorer = _find_config_scorer_nearby(anchor) or get_default_scorer(anchor)
+        scorer = find_config_scorer_nearby(anchor) or get_default_scorer(anchor)
         if not scorer:
-            suggested = _suggest_human_placeholder(anchor)
+            suggested = suggest_human_placeholder(anchor)
             while True:
                 s = _prompt_for_scorer(self, anchor=anchor, suggested=suggested)
                 if s is None:
@@ -1426,16 +1314,13 @@ class KeypointControls(QWidget):
             except Exception:
                 logger.debug("Failed to persist default scorer to sidecar", exc_info=True)
 
-        target_name = f"CollectedData_{scorer}.h5"
-        st = IOProvenance(
-            project_root=anchor,
-            source_relpath_posix=target_name,
-            kind=AnnotationKind.GT,
-            dataset_key="keypoints",
+        updated = apply_gt_save_target(
+            pts,
+            anchor=anchor,
             scorer=scorer,
+            dataset_key="keypoints",
         )
 
-        updated = pts.model_copy(update={"save_target": st})
         out = write_points_meta(
             layer,
             updated,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1146,16 +1146,17 @@ class KeypointControls(QWidget):
             # Determine time column (napari-specific choice)
             time_col = 1 if isinstance(layer, Tracks) else 0
 
-            arr_before = np.asarray(layer.data)
-            logger.debug(
-                "Remap start layer=%r old_paths_len=%s new_paths_len=%s data_shape=%s frame_min=%s frame_max=%s",
-                getattr(layer, "name", str(layer)),
-                len(old_paths),
-                len(new_paths or []),
-                getattr(arr_before, "shape", None),
-                int(np.nanmin(arr_before[:, time_col])) if arr_before.size else None,
-                int(np.nanmax(arr_before[:, time_col])) if arr_before.size else None,
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                arr_before = np.asarray(layer.data)
+                logger.debug(
+                    "Remap start layer=%r old_paths_len=%s new_paths_len=%s data_shape=%s frame_min=%s frame_max=%s",
+                    getattr(layer, "name", str(layer)),
+                    len(old_paths),
+                    len(new_paths or []),
+                    getattr(arr_before, "shape", None),
+                    int(np.nanmin(arr_before[:, time_col])) if arr_before.size else None,
+                    int(np.nanmax(arr_before[:, time_col])) if arr_before.size else None,
+                )
 
             res = remap_layer_data_by_paths(
                 data=layer.data,

--- a/src/napari_deeplabcut/config/supported_files.py
+++ b/src/napari_deeplabcut/config/supported_files.py
@@ -1,0 +1,4 @@
+"""Supported file formats for images and videos."""
+
+SUPPORTED_IMAGES = (".jpg", ".jpeg", ".png")
+SUPPORTED_VIDEOS = (".mp4", ".mov", ".avi")

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -12,8 +12,10 @@ Includes:
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import logging
+import os
 from collections.abc import Callable
 from importlib import resources
 from pathlib import Path
@@ -56,6 +58,12 @@ logger = logging.getLogger(__name__)
 # FIXME move to config/data_formats.py or similar if more formats are added
 SUPPORTED_IMAGES = (".jpg", ".jpeg", ".png")
 SUPPORTED_VIDEOS = (".mp4", ".mov", ".avi")
+_GLOB_MAGIC = set("*?[")
+_SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
+
+
+def _has_glob_magic(name: str) -> bool:
+    return any(ch in name for ch in _GLOB_MAGIC)
 
 
 # =============================================================================
@@ -496,22 +504,68 @@ def _normalize_to_rgb(arr: np.ndarray) -> np.ndarray:
     return cv2.cvtColor(arr, cv2.COLOR_BGR2RGB)
 
 
-def _expand_image_paths(path: str | Path | list[str | Path] | tuple[str | Path, ...]) -> list[Path]:
-    # Normalize input to list[Path]
-    raw_paths = [Path(p) for p in path] if isinstance(path, (list, tuple)) else [Path(path)]
+# FIXME remove later
+# def _expand_image_paths(path: str | Path | list[str | Path] | tuple[str | Path, ...]) -> list[Path]:
+#     # Normalize input to list[Path]
+#     raw_paths = [Path(p) for p in path] if isinstance(path, (list, tuple)) else [Path(path)]
 
+#     expanded: list[Path] = []
+#     for p in tqdm(raw_paths, desc="Expanding image paths", leave=False, unit="files"):
+#         if p.is_dir() and p.suffix.lower() != ".zarr":
+#             file_matches: list[Path] = []
+#             for ext in SUPPORTED_IMAGES:
+#                 file_matches.extend(p.glob(f"*{ext}"))
+#             expanded.extend(x for x in natsorted(file_matches, key=str) if x.is_file())
+#         else:
+#             matches = list(p.parent.glob(p.name))
+#             expanded.extend(matches or [p])
+
+#     return [p for p in expanded if p.is_file() and p.suffix.lower() in SUPPORTED_IMAGES]
+
+
+def _expand_image_paths(path: str | Path | list[str | Path] | tuple[str | Path, ...]) -> list[Path]:
+    raw_paths = [Path(p) for p in path] if isinstance(path, (list, tuple)) else [Path(path)]
     expanded: list[Path] = []
+
     for p in raw_paths:
         if p.is_dir() and p.suffix.lower() != ".zarr":
-            file_matches: list[Path] = []
-            for ext in SUPPORTED_IMAGES:
-                file_matches.extend(p.glob(f"*{ext}"))
-            expanded.extend(x for x in natsorted(file_matches, key=str) if x.is_file())
-        else:
-            matches = list(p.parent.glob(p.name))
-            expanded.extend(matches or [p])
+            try:
+                with os.scandir(p) as it:
+                    files = [
+                        Path(entry.path)
+                        for entry in it
+                        if entry.is_file() and Path(entry.name).suffix.lower() in _SUPPORTED_SUFFIXES
+                    ]
+            except OSError:
+                continue
 
-    return [p for p in expanded if p.is_file() and p.suffix.lower() in SUPPORTED_IMAGES]
+            files.sort(key=lambda q: q.name)
+            expanded.extend(files)
+            continue
+
+        if not _has_glob_magic(p.name):
+            if p.is_file() and p.suffix.lower() in _SUPPORTED_SUFFIXES:
+                expanded.append(p)
+            continue
+
+        parent = p.parent if str(p.parent) else Path(".")
+        pattern = p.name
+        try:
+            with os.scandir(parent) as it:
+                matches = [
+                    Path(entry.path)
+                    for entry in it
+                    if entry.is_file()
+                    and fnmatch.fnmatchcase(entry.name, pattern)
+                    and Path(entry.name).suffix.lower() in _SUPPORTED_SUFFIXES
+                ]
+        except OSError:
+            continue
+
+        matches.sort(key=lambda q: q.name)
+        expanded.extend(matches)
+
+    return expanded
 
 
 # Lazy image reader that supports directories and lists of files

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -47,7 +47,7 @@ from napari_deeplabcut.core.dataframes import (
 )
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
 from napari_deeplabcut.core.layers import populate_keypoint_layer_properties
-from napari_deeplabcut.core.metadata import attach_source_and_io, parse_points_metadata
+from napari_deeplabcut.core.metadata import attach_source_and_io_to_layer_kwargs, parse_points_metadata
 from napari_deeplabcut.core.project_paths import canonicalize_path, infer_dlc_project_from_points_meta
 from napari_deeplabcut.core.provenance import resolve_output_path_from_metadata
 
@@ -109,7 +109,7 @@ def write_config(config_path: str | Path, params: dict[str, Any]) -> None:
 # KEYPOINTS / ANNOTATIONS (HDF5)
 # =============================================================================
 # NOTE: This reader returns a napari Points layer (data + metadata + "points")
-# and attaches provenance via attach_source_and_io.
+# and attaches provenance via attach_source_and_io_to_layer_kwargs.
 
 
 def read_hdf(filename: str) -> list[LayerData]:
@@ -197,12 +197,12 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     if kind is not None:
         meta = layer_props.setdefault("metadata", {})
         # Keep legacy source fields too
-        attach_source_and_io(layer_props, file)
+        attach_source_and_io_to_layer_kwargs(layer_props, file)
         # Override kind in io with explicit kind arg
         if isinstance(meta.get("io"), dict):
             meta["io"]["kind"] = kind  # stored as actual enum, not value
     else:
-        attach_source_and_io(layer_props, file)
+        attach_source_and_io_to_layer_kwargs(layer_props, file)
 
     return [(data, layer_props, "points")]
 

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -35,6 +35,7 @@ from pydantic import ValidationError
 from napari_deeplabcut import misc
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, PointsMetadata
 from napari_deeplabcut.config.settings import DEFAULT_SINGLE_ANIMAL_CMAP
+from napari_deeplabcut.config.supported_files import SUPPORTED_IMAGES, SUPPORTED_VIDEOS
 from napari_deeplabcut.core import schemas as dlc_schemas
 from napari_deeplabcut.core.dataframes import (
     form_df_from_validated,
@@ -55,9 +56,6 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 # Supported formats (shared by image/video readers)
 # -----------------------------------------------------------------------------
-# FIXME move to config/data_formats.py or similar if more formats are added
-SUPPORTED_IMAGES = (".jpg", ".jpeg", ".png")
-SUPPORTED_VIDEOS = (".mp4", ".mov", ".avi")
 _GLOB_MAGIC = set("*?[")
 _SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
 

--- a/src/napari_deeplabcut/core/metadata.py
+++ b/src/napari_deeplabcut/core/metadata.py
@@ -416,10 +416,8 @@ def require_unique_target(candidates: list[Path], *, context: str = "save target
 # -----------------------------------------------------------------------------
 # Provenance attachment (napari metadata glue)
 # -----------------------------------------------------------------------------
-
-
-def attach_source_and_io(
-    metadata: dict[str, Any],
+def attach_source_and_io_to_layer_kwargs(
+    layer_kwargs: dict[str, Any],
     file_path: Path,
     *,
     kind: AnnotationKind | None = None,
@@ -436,8 +434,20 @@ def attach_source_and_io(
 
     # FUTURE NOTE hardcoded DLC structure:
     # kind inference relies on discovery filename patterns (CollectedData*, machinelabels*).
+
+    Notes
+    -----
+    This function does not expect ``layer.metadata`` directly.
+    It expects the middle dict of a napari LayerData tuple, e.g.:
+
+        (data, layer_kwargs, "points")
+
+    and writes into:
+
+        layer_kwargs["metadata"]
     """
-    meta = metadata.setdefault("metadata", {})
+
+    meta = layer_kwargs.setdefault("metadata", {})
 
     # Legacy migration fields
     try:

--- a/src/napari_deeplabcut/core/provenance.py
+++ b/src/napari_deeplabcut/core/provenance.py
@@ -1,16 +1,172 @@
 # src/napari_deeplabcut/core/provenance.py
 from __future__ import annotations
 
+import hashlib
 import logging
 from pathlib import Path, PurePosixPath
 
 from pydantic import ValidationError
 
-from napari_deeplabcut.config.models import AnnotationKind, IOProvenance
+import napari_deeplabcut.core.io as io
+from napari_deeplabcut import misc
+from napari_deeplabcut.config.models import AnnotationKind, IOProvenance, PointsMetadata
 from napari_deeplabcut.core.errors import MissingProvenanceError, UnresolvablePathError
 from napari_deeplabcut.core.metadata import parse_points_metadata
+from napari_deeplabcut.core.project_paths import infer_dlc_project_from_points_meta, is_windows_absolute_path
 
 logger = logging.getLogger(__name__)
+
+
+# ----------------------------------------
+# Helper functions
+# ----------------------------------------
+def find_config_scorer_nearby(anchor: str) -> str | None:
+    """
+    Best-effort lookup of DLC config.yaml scorer near a folder anchor.
+    """
+    try:
+        cfg_path = misc.find_project_config_path(anchor)
+        if cfg_path:
+            cfg = io.load_config(cfg_path)
+            scorer = cfg.get("scorer")
+            if isinstance(scorer, str) and scorer.strip():
+                return scorer.strip()
+    except Exception:
+        pass
+    return None
+
+
+def suggest_human_placeholder(anchor: str) -> str:
+    """
+    Deterministic fallback scorer placeholder derived from anchor path.
+    """
+    h = hashlib.sha1(anchor.encode("utf-8", errors="ignore")).hexdigest()[:6]
+    return f"human_{h}"
+
+
+def requires_gt_promotion(pts_meta: PointsMetadata) -> bool:
+    """
+    Return True when a machine/prediction source must be promoted to a GT save_target
+    before saving.
+
+    Rules:
+    - if save_target already exists -> no promotion needed
+    - if io.kind is MACHINE -> promotion required
+    - otherwise -> no promotion required
+    """
+    if getattr(pts_meta, "save_target", None) is not None:
+        return False
+
+    io_meta = getattr(pts_meta, "io", None)
+    src_kind = getattr(io_meta, "kind", None) if io_meta is not None else None
+    return src_kind is AnnotationKind.MACHINE
+
+
+def build_gt_save_target(
+    anchor: str,
+    scorer: str,
+    *,
+    dataset_key: str = "keypoints",
+) -> IOProvenance:
+    """
+    Build a GT save_target pointing to CollectedData_<scorer>.h5 under a folder anchor.
+    """
+    scorer_clean = str(scorer).strip()
+    target_name = f"CollectedData_{scorer_clean}.h5"
+    return IOProvenance(
+        project_root=anchor,
+        source_relpath_posix=target_name,
+        kind=AnnotationKind.GT,
+        dataset_key=dataset_key,
+        scorer=scorer_clean,
+    )
+
+
+def apply_gt_save_target(
+    pts_meta: PointsMetadata,
+    *,
+    anchor: str,
+    scorer: str,
+    dataset_key: str = "keypoints",
+) -> PointsMetadata:
+    """
+    Return an updated PointsMetadata with a GT promotion save_target attached.
+    """
+    st = build_gt_save_target(anchor, scorer, dataset_key=dataset_key)
+    return pts_meta.model_copy(update={"save_target": st})
+
+
+def is_projectless_folder_association_candidate(
+    pts_meta: PointsMetadata,
+    *,
+    treat_machine_as_ineligible: bool = True,
+) -> bool:
+    """
+    Return True for the 'associate current labeled folder with a DLC project' workflow.
+
+    Non-candidates include:
+    - machine/promotion layers (optional policy)
+    - layers with an explicit save_target
+    - layers that already have a resolved DLC project/config context
+    - layers without a usable folder root
+    - layers whose paths do not look like a simple single-folder labeling session
+    """
+    if treat_machine_as_ineligible and requires_gt_promotion(pts_meta):
+        return False
+
+    if getattr(pts_meta, "save_target", None) is not None:
+        return False
+
+    project_ctx = infer_dlc_project_from_points_meta(pts_meta, prefer_project_root=False)
+    if project_ctx.project_root is not None and project_ctx.config_path is not None:
+        return False
+
+    root = getattr(pts_meta, "root", None)
+    paths = list(getattr(pts_meta, "paths", None) or [])
+    if not root or not paths:
+        return False
+
+    try:
+        root_path = Path(root).expanduser().resolve(strict=False)
+    except Exception:
+        root_path = Path(root)
+
+    for value in paths:
+        text = str(value).replace("\\", "/")
+        p = Path(value)
+
+        parts = [part for part in text.split("/") if part]
+        lowered = [part.lower() for part in parts]
+        if "labeled-data" in lowered:
+            idx = lowered.index("labeled-data")
+            if idx + 2 < len(parts):
+                continue
+
+        is_windows_abs_misclassified = not p.is_absolute() and is_windows_absolute_path(value)
+        if not p.is_absolute():
+            if is_windows_abs_misclassified:
+                continue
+
+            if len(p.parts) == 1 and p.parts[0] not in (".", ".."):
+                continue
+            return False
+
+        try:
+            rel_to_root = p.expanduser().resolve(strict=False).relative_to(root_path)
+        except Exception:
+            continue
+
+        if len(rel_to_root.parts) == 1:
+            continue
+
+        return False
+
+    return True
+
+
+# ----------------------------------------
+# Core provenance logic
+# ----------------------------------------
 
 
 def resolve_output_path_from_metadata(metadata: dict) -> tuple[str | None, str | None, AnnotationKind | None]:

--- a/src/napari_deeplabcut/core/trails.py
+++ b/src/napari_deeplabcut/core/trails.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,6 +14,8 @@ from napari.utils.colormaps import Colormap
 from napari_deeplabcut.config.models import TrailsDisplayConfig
 from napari_deeplabcut.core import keypoints
 from napari_deeplabcut.core.layer_versioning import layer_change_generations
+from napari_deeplabcut.core.metadata import parse_points_metadata
+from napari_deeplabcut.core.sidecar import get_trails_config, set_trails_config
 
 
 @dataclass(frozen=True)
@@ -270,3 +274,379 @@ def display_config_from_tracks_layer(layer: Tracks, *, visible: bool | None = No
         blending=str(getattr(layer, "blending", "translucent")),
         visible=bool(layer.visible if visible is None else visible),
     )
+
+
+def safe_folder_anchor_from_points_layer(layer: Points) -> str | None:
+    """Best-effort anchor folder for folder-scoped sidecar state."""
+    md = layer.metadata or {}
+
+    try:
+        pts = parse_points_metadata(md)
+        if pts.io and pts.io.project_root:
+            return str(pts.io.project_root)
+    except Exception:
+        pass
+
+    root = md.get("root")
+    if isinstance(root, str) and root:
+        return root
+
+    src = md.get("source_h5")
+    if isinstance(src, str) and src:
+        try:
+            return str(Path(src).expanduser().resolve().parent)
+        except Exception:
+            return str(Path(src).parent)
+
+    return None
+
+
+# ------------------------------------------
+# Trails layer controller
+# ------------------------------------------
+class TrailsController:
+    """
+    Owns trails layer lifecycle, signature tracking, and folder-scoped persistence.
+
+    The widget remains responsible only for wiring user/viewer events into this
+    controller.
+    """
+
+    def __init__(
+        self,
+        viewer,
+        *,
+        managed_points_layers_getter: Callable[[], Iterable[Points]],
+        color_mode_getter: Callable[[], str],
+        resolved_cycle_getter: Callable[[Points], dict],
+    ) -> None:
+        self._viewer = viewer
+        self._managed_points_layers_getter = managed_points_layers_getter
+        self._color_mode_getter = color_mode_getter
+        self._resolved_cycle_getter = resolved_cycle_getter
+
+        self._trails: Tracks | None = None
+        self._trails_geom_sig: tuple | None = None
+        self._trails_style_sig: tuple | None = None
+        self._refreshing_trails = False
+
+    @property
+    def layer(self) -> Tracks | None:
+        return self._trails
+
+    def has_live_trails(self) -> bool:
+        return self._trails is not None
+
+    def current_source_layer(self) -> Points | None:
+        active = self._viewer.layers.selection.active
+        managed = list(self._managed_points_layers_getter())
+
+        if isinstance(active, Points) and active in managed:
+            return active
+
+        if self._trails is not None:
+            src_id = (self._trails.metadata or {}).get("_source_points_layer_id")
+            if src_id is not None:
+                for layer in managed:
+                    if id(layer) == src_id:
+                        return layer
+
+        return managed[0] if managed else None
+
+    def current_anchor(self, layer: Points | None = None) -> str | None:
+        pts_layer = layer if layer is not None else self.current_source_layer()
+        if pts_layer is None:
+            return None
+        return safe_folder_anchor_from_points_layer(pts_layer)
+
+    def persist_current_config(self, *, visible: bool | None = None) -> None:
+        """
+        Persist the current live trails display config to the folder sidecar.
+        """
+        if self._trails is None:
+            return
+
+        anchor = (self._trails.metadata or {}).get("_dlc_trails_anchor")
+        if not anchor:
+            anchor = self.current_anchor()
+
+        if not anchor:
+            return
+
+        try:
+            cfg = display_config_from_tracks_layer(self._trails, visible=visible)
+            set_trails_config(anchor, cfg)
+        except Exception:
+            # best-effort only
+            pass
+
+    def persist_folder_ui_state_for_points_layer(
+        self,
+        layer: Points,
+        *,
+        checkbox_checked: bool,
+    ) -> None:
+        """
+        Best-effort persistence of folder-scoped UI state for a specific points layer.
+
+        Policy:
+        - If live trails belong to this layer/folder, persist their full display config.
+        - Otherwise preserve stored config and mark visible=False.
+        """
+        anchor = safe_folder_anchor_from_points_layer(layer)
+        if not anchor:
+            return
+
+        try:
+            if self._trails is not None:
+                trails_md = self._trails.metadata or {}
+                trails_anchor = trails_md.get("_dlc_trails_anchor")
+                trails_src_id = trails_md.get("_source_points_layer_id")
+
+                same_source = trails_src_id == id(layer)
+                same_anchor = trails_anchor is not None and str(trails_anchor) == str(anchor)
+
+                if same_source or same_anchor:
+                    cfg = display_config_from_tracks_layer(
+                        self._trails,
+                        visible=bool(checkbox_checked and self._trails.visible),
+                    )
+                    set_trails_config(anchor, cfg)
+                    return
+
+            cfg = get_trails_config(anchor)
+            if cfg is None:
+                return
+
+            cfg = cfg.model_copy(update={"visible": False})
+            set_trails_config(anchor, cfg)
+        except Exception:
+            pass
+
+    def toggle(self, checked: bool) -> None:
+        """
+        Main entry point from the widget checkbox.
+        """
+        if not checked:
+            self._hide_and_persist()
+            return
+
+        if not list(self._managed_points_layers_getter()):
+            return
+
+        pts_layer = self.current_source_layer()
+        if pts_layer is None:
+            return
+
+        geom_sig = trails_geometry_signature(pts_layer)
+        style_sig = trails_signature(pts_layer, self._color_mode_getter())
+
+        if self._trails is None:
+            self.create()
+            return
+
+        if self._trails_geom_sig != geom_sig:
+            self.refresh()
+            return
+
+        if self._trails_style_sig != style_sig:
+            self.update_style()
+            return
+
+        self._trails.visible = True
+
+    def _hide_and_persist(self) -> None:
+        if self._trails is None:
+            return
+
+        self._trails.visible = False
+
+        try:
+            pts_layer = self.current_source_layer()
+            if pts_layer is None:
+                return
+
+            anchor = self.current_anchor(pts_layer)
+            if not anchor:
+                return
+
+            cfg = get_trails_config(anchor)
+            if cfg is None and self._trails is not None:
+                cfg = display_config_from_tracks_layer(self._trails)
+
+            if cfg is not None:
+                cfg = cfg.model_copy(update={"visible": False})
+                set_trails_config(anchor, cfg)
+        except Exception:
+            pass
+
+    def refresh(self) -> None:
+        selected, active = self._snapshot_selection()
+        try:
+            self.remove()
+            self.create()
+        finally:
+            self._restore_selection(selected, active)
+
+    def remove(self) -> None:
+        if self._trails is None:
+            return
+
+        self._refreshing_trails = True
+        try:
+            self._viewer.layers.remove(self._trails)
+        except Exception:
+            pass
+        finally:
+            self._trails = None
+            self._trails_geom_sig = None
+            self._trails_style_sig = None
+            self._refreshing_trails = False
+
+    def create(self) -> None:
+        if self._trails is not None:
+            return
+
+        pts_layer = self.current_source_layer()
+        if pts_layer is None:
+            return
+
+        anchor = self.current_anchor(pts_layer)
+        cfg = get_trails_config(anchor) if anchor else None
+        track_kwargs = tracks_kwargs_from_display_config(cfg) if cfg is not None else {}
+
+        selected, active = self._snapshot_selection()
+        try:
+            payload = build_trails_payload(
+                pts_layer,
+                self._color_mode_getter(),
+                cycle_override=self._resolved_cycle_getter(pts_layer),
+            )
+        except ValueError:
+            return
+        finally:
+            # don't restore yet; add_tracks should happen inside preserved selection scope
+            pass
+
+        try:
+            self._trails = self._viewer.add_tracks(
+                payload.tracks_data,
+                properties=payload.properties,
+                color_by=payload.color_by,
+                colormaps_dict=payload.colormaps_dict,
+                name="trails",
+                metadata={
+                    "_source_points_layer_id": id(pts_layer),
+                    "_dlc_trails_anchor": anchor,
+                },
+                **track_kwargs,
+            )
+            self._trails.visible = True
+            self._trails_geom_sig = payload.geometry_signature
+            self._trails_style_sig = payload.signature
+
+            self.persist_current_config(visible=True)
+        finally:
+            self._restore_selection(selected, active)
+
+    def update_style(self) -> None:
+        """
+        Recolor existing trails layer in place when geometry is unchanged.
+        Falls back to a full rebuild if in-place update is not supported.
+        """
+        if self._trails is None:
+            return
+
+        pts_layer = self.current_source_layer()
+        if pts_layer is None:
+            return
+
+        try:
+            payload = build_trails_payload(
+                pts_layer,
+                self._color_mode_getter(),
+                cycle_override=self._resolved_cycle_getter(pts_layer),
+            )
+        except ValueError:
+            return
+
+        try:
+            new_props = dict(getattr(self._trails, "properties", {}) or {})
+            new_props.update(payload.properties)
+            self._trails.properties = new_props
+
+            new_cmaps = dict(getattr(self._trails, "colormaps_dict", {}) or {})
+            new_cmaps.update(payload.colormaps_dict)
+            self._trails.colormaps_dict = new_cmaps
+
+            self._trails.color_by = payload.color_by
+            self._trails.visible = True
+            self._trails_style_sig = payload.signature
+
+            self._trails.metadata = dict(self._trails.metadata or {})
+            self._trails.metadata["_source_points_layer_id"] = id(pts_layer)
+            self._trails.metadata["_dlc_trails_anchor"] = self.current_anchor(pts_layer)
+        except Exception:
+            self.refresh()
+
+    def on_points_visual_inputs_changed(self, *, checkbox_checked: bool) -> None:
+        """
+        Call this when the source layer coloring inputs changed (color mode, colormap,
+        face-color cycles, etc.).
+        """
+        if checkbox_checked and self._trails is not None:
+            self.update_style()
+
+    def on_points_layer_added_or_rewired(self, *, checkbox_checked: bool) -> None:
+        """
+        Call when a managed points layer becomes available or changes ownership.
+        """
+        if checkbox_checked and self._trails is not None:
+            self.refresh()
+
+    def on_points_layer_removed(self, layer: Points) -> None:
+        if self._trails is None:
+            return
+
+        src_id = (self._trails.metadata or {}).get("_source_points_layer_id")
+        if src_id == id(layer):
+            self.remove()
+
+    def on_tracks_layer_removed(self, layer: Tracks) -> bool:
+        """
+        Returns True if the removed tracks layer was our trails layer.
+        """
+        if self._trails is None:
+            return False
+
+        if getattr(self, "_refreshing_trails", False):
+            if layer is self._trails:
+                self._trails = None
+                self._trails_geom_sig = None
+                self._trails_style_sig = None
+                return True
+            return False
+
+        if layer is self._trails:
+            self._trails = None
+            self._trails_geom_sig = None
+            self._trails_style_sig = None
+            return True
+
+        return False
+
+    def _snapshot_selection(self):
+        selected = [layer for layer in self._viewer.layers.selection if layer in self._viewer.layers]
+        active = self._viewer.layers.selection.active
+        return selected, active
+
+    def _restore_selection(self, selected, active):
+        try:
+            self._viewer.layers.selection.clear()
+            for layer in selected:
+                if layer in self._viewer.layers:
+                    self._viewer.layers.selection.add(layer)
+            if active in self._viewer.layers:
+                self._viewer.layers.selection.active = active
+        except Exception:
+            pass

--- a/src/napari_deeplabcut/napari_compat/points_layer.py
+++ b/src/napari_deeplabcut/napari_compat/points_layer.py
@@ -7,6 +7,8 @@ from types import MethodType
 
 import numpy as np
 
+from napari_deeplabcut.core.keypoints import Keypoint
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -102,23 +104,83 @@ def make_paste_data(controls, *, store):
     """
     Build a paste handler that mimics the previous KeypointControls._paste_data behavior,
     but lives in compat.
+
+    Compat goals:
+    - old/new napari slice APIs (_slice_indices vs _slice_input.point)
+    - old/new napari points style keys (edge_* vs border_*)
     """
 
+    def _normalize_id(id_):
+        if id_ is None:
+            return id_
+        try:
+            if np.isnan(id_):
+                return ""
+        except Exception:
+            pass
+        try:
+            return id_.item() if hasattr(id_, "item") else id_
+        except Exception:
+            return id_
+
+    def _get_current_slice_point(layer_self):
+        # Best source for "where the user currently is" is the viewer dims.
+        try:
+            current_step = tuple(controls.viewer.dims.current_step)
+            if len(current_step) == layer_self.data.shape[1]:
+                return current_step
+        except Exception:
+            pass
+
+        # Older napari private API fallback
+        if hasattr(layer_self, "_slice_indices"):
+            return layer_self._slice_indices
+
+        # Newer napari private API fallback
+        slice_input = getattr(layer_self, "_slice_input", None)
+        if slice_input is not None and hasattr(slice_input, "point"):
+            return slice_input.point
+
+        return None
+
+    def _get_clipboard_slice_point(clipboard_indices):
+        # Newer napari stores a _ThickNDSlice-like object with .point
+        if hasattr(clipboard_indices, "point"):
+            return clipboard_indices.point
+        return clipboard_indices
+
+    def _get_clipboard_key(clipboard, *names):
+        for name in names:
+            if name in clipboard:
+                return name
+        return None
+
+    def _get_private_color_manager(layer_self, *names):
+        for name in names:
+            obj = getattr(layer_self, name, None)
+            if obj is not None:
+                return obj
+        return None
+
     def _paste_data(layer_self, _store=store):
-        features = layer_self._clipboard.pop("features", None)
+        features = layer_self._clipboard.get("features")
         if features is None:
             return
 
         unannotated = [
-            controls.keypoints.Keypoint(label, id_) not in _store.annotated_keypoints
+            Keypoint(label, _normalize_id(id_)) not in _store.annotated_keypoints
             for label, id_ in zip(features["label"], features["id"], strict=False)
         ]
         if not any(unannotated):
             return
 
+        # Only mutate clipboard after we know we want to paste
+        features = layer_self._clipboard.pop("features")
         new_features = features.iloc[unannotated]
+
         indices_ = layer_self._clipboard.pop("indices")
-        text_ = layer_self._clipboard.pop("text", None)  # <- guard missing key
+        text_ = layer_self._clipboard.pop("text", None)
+
         layer_self._clipboard = {k: v[unannotated] for k, v in layer_self._clipboard.items()}
         layer_self._clipboard["features"] = new_features
         layer_self._clipboard["indices"] = indices_
@@ -133,39 +195,85 @@ def make_paste_data(controls, *, store):
         npoints = len(layer_self._view_data)
         totpoints = len(layer_self.data)
 
-        if len(layer_self._clipboard.keys()) > 0:
+        if len(layer_self._clipboard) > 0:
             not_disp = layer_self._slice_input.not_displayed
             data = deepcopy(layer_self._clipboard["data"])
-            offset = [layer_self._slice_indices[i] - layer_self._clipboard["indices"][i] for i in not_disp]
-            data[:, not_disp] = data[:, not_disp] + np.array(offset)
+
+            # ---- compat: current slice point / copied slice point ----
+            current_point = _get_current_slice_point(layer_self)
+            copied_point = _get_clipboard_slice_point(layer_self._clipboard["indices"])
+
+            if current_point is not None and copied_point is not None and len(not_disp) > 0:
+                offset = []
+                for i in not_disp:
+                    cur = current_point[i]
+                    old = copied_point[i]
+                    offset.append(float(cur) - float(old))
+                data[:, not_disp] = data[:, not_disp] + np.asarray(offset, dtype=float)
+
             layer_self._data = np.append(layer_self.data, data, axis=0)
-            layer_self._shown = np.append(layer_self.shown, deepcopy(layer_self._clipboard["shown"]), axis=0)
-            layer_self._size = np.append(layer_self.size, deepcopy(layer_self._clipboard["size"]), axis=0)
-            layer_self._symbol = np.append(layer_self.symbol, deepcopy(layer_self._clipboard["symbol"]), axis=0)
+            layer_self._shown = np.append(
+                layer_self.shown,
+                deepcopy(layer_self._clipboard["shown"]),
+                axis=0,
+            )
+            layer_self._size = np.append(
+                layer_self.size,
+                deepcopy(layer_self._clipboard["size"]),
+                axis=0,
+            )
+            layer_self._symbol = np.append(
+                layer_self.symbol,
+                deepcopy(layer_self._clipboard["symbol"]),
+                axis=0,
+            )
 
             layer_self._feature_table.append(layer_self._clipboard["features"])
 
             text_payload = layer_self._clipboard.get("text")
-            if text_payload is not None:  # <- guard missing / None payload
+            if text_payload is not None:
                 layer_self.text._paste(**text_payload)
 
-            layer_self._edge_width = np.append(
-                layer_self.edge_width,
-                deepcopy(layer_self._clipboard["edge_width"]),
-                axis=0,
-            )
+            # ---- compat: edge_width vs border_width ----
+            width_key = _get_clipboard_key(layer_self._clipboard, "border_width", "edge_width")
+            if width_key is not None:
+                current_width = None
+                for public_name in ("border_width", "edge_width"):
+                    if hasattr(layer_self, public_name):
+                        current_width = getattr(layer_self, public_name)
+                        break
 
-            # private napari helpers: guarded by compat usage
+                if current_width is not None:
+                    new_width = np.append(
+                        current_width,
+                        deepcopy(layer_self._clipboard[width_key]),
+                        axis=0,
+                    )
+                    for private_name in ("_border_width", "_edge_width"):
+                        if hasattr(layer_self, private_name):
+                            setattr(layer_self, private_name, new_width)
+                            break
+
             from napari.layers.utils.layer_utils import _features_to_properties
 
-            layer_self._edge._paste(
-                colors=layer_self._clipboard["edge_color"],
-                properties=_features_to_properties(layer_self._clipboard["features"]),
-            )
-            layer_self._face._paste(
-                colors=layer_self._clipboard["face_color"],
-                properties=_features_to_properties(layer_self._clipboard["features"]),
-            )
+            props = _features_to_properties(layer_self._clipboard["features"])
+
+            # ---- compat: edge/border color managers ----
+            border_manager = _get_private_color_manager(layer_self, "_border", "_edge")
+            border_color_key = _get_clipboard_key(layer_self._clipboard, "border_color", "edge_color")
+
+            if border_manager is not None and border_color_key is not None:
+                border_manager._paste(
+                    colors=layer_self._clipboard[border_color_key],
+                    properties=props,
+                )
+
+            face_manager = _get_private_color_manager(layer_self, "_face")
+            if face_manager is not None and "face_color" in layer_self._clipboard:
+                face_manager._paste(
+                    colors=layer_self._clipboard["face_color"],
+                    properties=props,
+                )
 
             layer_self._selected_view = list(range(npoints, npoints + len(layer_self._clipboard["data"])))
             layer_self._selected_data = set(range(totpoints, totpoints + len(layer_self._clipboard["data"])))

--- a/src/napari_deeplabcut/napari_compat/points_layer.py
+++ b/src/napari_deeplabcut/napari_compat/points_layer.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from types import MethodType
+from typing import Any
 
 import numpy as np
 
 from napari_deeplabcut.core.keypoints import Keypoint
 
 logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Optional napari private import
+# -----------------------------------------------------------------------------
 
 try:
     from napari.layers.points._points_key_bindings import register_points_action
@@ -24,10 +29,211 @@ except Exception:
     logger.debug("napari private register_points_action unavailable; skipping action registration.")
 
 
+# -----------------------------------------------------------------------------
+# Compat constants
+# -----------------------------------------------------------------------------
+
+_WIDTH_KEYS = ("border_width", "edge_width")
+_BORDER_COLOR_KEYS = ("border_color", "edge_color")
+_BORDER_MANAGERS = ("_border", "_edge")
+_WIDTH_ATTRS = ("_border_width", "_edge_width")
+
+
+# -----------------------------------------------------------------------------
+# Small helpers
+# -----------------------------------------------------------------------------
+
+
+def _first_present(mapping: dict[str, Any], *names: str) -> str | None:
+    """Return the first key present in a mapping."""
+    for name in names:
+        if name in mapping:
+            return name
+    return None
+
+
+def _first_attr(obj: Any, *names: str) -> Any | None:
+    """Return the first existing attribute value from an object."""
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def _normalize_id(id_: Any) -> Any:
+    """Normalize clipboard/stored ids so Keypoint comparisons are stable."""
+    if id_ is None:
+        return id_
+
+    try:
+        if np.isnan(id_):
+            return ""
+    except Exception:
+        pass
+
+    try:
+        return id_.item() if hasattr(id_, "item") else id_
+    except Exception:
+        return id_
+
+
+def _get_current_slice_point(controls: Any, layer: Any) -> tuple | Any | None:
+    """
+    Best-effort current slice position.
+
+    Preference order:
+    1. viewer dims (authoritative user-visible state)
+    2. old napari private layer state: _slice_indices
+    3. newer napari private layer state: _slice_input.point
+    """
+    try:
+        current_step = tuple(controls.viewer.dims.current_step)
+        if current_step:
+            return current_step
+    except Exception:
+        pass
+
+    if hasattr(layer, "_slice_indices"):
+        return layer._slice_indices
+
+    slice_input = getattr(layer, "_slice_input", None)
+    if slice_input is not None and hasattr(slice_input, "point"):
+        return slice_input.point
+
+    return None
+
+
+def _get_clipboard_slice_point(indices: Any) -> Any:
+    """Extract the copied slice point from old/new napari clipboard payloads."""
+    if hasattr(indices, "point"):
+        return indices.point
+    return indices
+
+
+def _get_not_displayed_axes(controls: Any, layer: Any, data: np.ndarray) -> list[int]:
+    """
+    Best-effort non-displayed axes.
+
+    Preference order:
+    1. newer napari private layer state: _slice_input.not_displayed
+    2. infer from ndim / viewer ndisplay
+    """
+    slice_input = getattr(layer, "_slice_input", None)
+    if slice_input is not None and hasattr(slice_input, "not_displayed"):
+        try:
+            return list(slice_input.not_displayed)
+        except Exception:
+            pass
+
+    try:
+        ndim = int(data.shape[1])
+    except Exception:
+        return []
+
+    try:
+        ndisplay = int(controls.viewer.dims.ndisplay)
+    except Exception:
+        ndisplay = 2
+
+    n_not_displayed = max(0, ndim - ndisplay)
+    return list(range(n_not_displayed))
+
+
+def _filter_clipboard_payload(clipboard: dict[str, Any], mask: list[bool]) -> dict[str, Any]:
+    """Return a filtered clipboard payload keeping only rows selected by mask."""
+    return {k: v[mask] for k, v in clipboard.items()}
+
+
+def _paste_text_payload(layer: Any, clipboard: dict[str, Any]) -> None:
+    """Paste text payload if present."""
+    text_payload = clipboard.get("text")
+    if text_payload is None:
+        return
+
+    try:
+        layer.text._paste(**text_payload)
+    except Exception:
+        logger.debug("Failed to paste text payload", exc_info=True)
+
+
+def _append_widths(layer: Any, clipboard: dict[str, Any]) -> None:
+    """Append border/edge widths compatibly across napari versions."""
+    width_key = _first_present(clipboard, *_WIDTH_KEYS)
+    if width_key is None:
+        return
+
+    current_width = _first_attr(layer, "border_width", "edge_width")
+    if current_width is None:
+        return
+
+    new_width = np.append(current_width, deepcopy(clipboard[width_key]), axis=0)
+
+    for private_name in _WIDTH_ATTRS:
+        if hasattr(layer, private_name):
+            setattr(layer, private_name, new_width)
+            return
+
+
+def _paste_colors(layer: Any, clipboard: dict[str, Any]) -> None:
+    """Paste face/border colors compatibly across napari versions."""
+    from napari.layers.utils.layer_utils import _features_to_properties
+
+    props = _features_to_properties(clipboard["features"])
+
+    border_manager = _first_attr(layer, *_BORDER_MANAGERS)
+    border_color_key = _first_present(clipboard, *_BORDER_COLOR_KEYS)
+    if border_manager is not None and border_color_key is not None:
+        border_manager._paste(colors=clipboard[border_color_key], properties=props)
+
+    face_manager = getattr(layer, "_face", None)
+    if face_manager is not None and "face_color" in clipboard:
+        face_manager._paste(colors=clipboard["face_color"], properties=props)
+
+
+def _offset_pasted_data(
+    controls: Any,
+    layer: Any,
+    clipboard: dict[str, Any],
+    data: np.ndarray,
+) -> np.ndarray:
+    """
+    Shift pasted coordinates along non-displayed axes so paste occurs
+    on the viewer's current slice/frame.
+    """
+    not_disp = _get_not_displayed_axes(controls, layer, data)
+    if not not_disp:
+        return data
+
+    current_point = _get_current_slice_point(controls, layer)
+    copied_point = _get_clipboard_slice_point(clipboard["indices"])
+    if current_point is None or copied_point is None:
+        return data
+
+    try:
+        offset = [float(current_point[i]) - float(copied_point[i]) for i in not_disp]
+    except Exception:
+        logger.debug("Failed to compute paste offset", exc_info=True)
+        return data
+
+    shifted = deepcopy(data)
+    shifted[:, not_disp] = shifted[:, not_disp] + np.asarray(offset, dtype=float)
+    return shifted
+
+
+# -----------------------------------------------------------------------------
+# Public compat helpers
+# -----------------------------------------------------------------------------
+
+
 def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> object | None:
     """
-    Private napari UI wiring (best-effort).
-    If napari changes internals, degrade gracefully.
+    Best-effort private napari UI wiring.
+
+    Returns
+    -------
+    object | None
+        The created colormap selector, or None if unavailable.
     """
     try:
         controls = viewer.window.qt_viewer.dockLayerControls
@@ -35,30 +241,30 @@ def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> 
     except Exception:
         return None
 
-    # Hide face/border editors/out-of-slice toggle (guarded)
-    for attr_path in [
+    widgets_to_hide = [
         ("_face_color_control", "face_color_edit"),
         ("_face_color_control", "face_color_label"),
         ("_border_color_control", "border_color_edit"),
         ("_border_color_control", "border_color_edit_label"),
         ("_out_slice_checkbox_control", "out_of_slice_checkbox"),
         ("_out_slice_checkbox_control", "out_of_slice_checkbox_label"),
-    ]:
+    ]
+
+    for parent_attr, widget_attr in widgets_to_hide:
         try:
-            obj = getattr(point_controls, attr_path[0])
-            widget = getattr(obj, attr_path[1])
+            parent = getattr(point_controls, parent_attr)
+            widget = getattr(parent, widget_attr)
             widget.hide()
         except Exception:
             pass
 
-    # Add colormap selector (guarded)
     try:
         cmap_source = plt_module.colormaps
         if callable(cmap_source):
             cmap_source = cmap_source()
+
         colormap_selector = dropdown_cls(cmap_source, point_controls)
         colormap_selector.update_to(layer.metadata.get("colormap_name", "viridis"))
-        # caller wires signal to its handler; keep this compat layer minimal
         point_controls.layout().addRow("colormap", colormap_selector)
         return colormap_selector
     except Exception as e:
@@ -70,8 +276,12 @@ def install_add_wrapper(layer, *, add_impl, schedule_recolor) -> None:
     """
     Wrap layer.add to schedule recolor after add.
 
-    add_impl: callable like keypoints._add bound to store
-    schedule_recolor: callable(layer) -> None
+    Parameters
+    ----------
+    add_impl
+        Callable like keypoints._add bound to store.
+    schedule_recolor
+        Callable(layer) -> None.
     """
     try:
 
@@ -91,8 +301,6 @@ def install_add_wrapper(layer, *, add_impl, schedule_recolor) -> None:
 def install_paste_patch(layer, *, paste_func) -> None:
     """
     Patch napari Points._paste_data with our safe implementation.
-
-    paste_func: callable(layer, store) -> None or callable with signature used by original patch
     """
     try:
         layer._paste_data = MethodType(paste_func, layer)
@@ -102,186 +310,77 @@ def install_paste_patch(layer, *, paste_func) -> None:
 
 def make_paste_data(controls, *, store):
     """
-    Build a paste handler that mimics the previous KeypointControls._paste_data behavior,
-    but lives in compat.
+    Build a compat paste handler for napari Points layers.
 
-    Compat goals:
-    - old/new napari slice APIs (_slice_indices vs _slice_input.point)
-    - old/new napari points style keys (edge_* vs border_*)
+    Behavior:
+    - pastes only keypoints not already annotated in the target frame
+    - shifts pasted coordinates to the viewer's current non-displayed slice(s)
+    - supports old/new napari clipboard/style internals
     """
-
-    def _normalize_id(id_):
-        if id_ is None:
-            return id_
-        try:
-            if np.isnan(id_):
-                return ""
-        except Exception:
-            pass
-        try:
-            return id_.item() if hasattr(id_, "item") else id_
-        except Exception:
-            return id_
-
-    def _get_current_slice_point(layer_self):
-        # Best source for "where the user currently is" is the viewer dims.
-        try:
-            current_step = tuple(controls.viewer.dims.current_step)
-            if len(current_step) == layer_self.data.shape[1]:
-                return current_step
-        except Exception:
-            pass
-
-        # Older napari private API fallback
-        if hasattr(layer_self, "_slice_indices"):
-            return layer_self._slice_indices
-
-        # Newer napari private API fallback
-        slice_input = getattr(layer_self, "_slice_input", None)
-        if slice_input is not None and hasattr(slice_input, "point"):
-            return slice_input.point
-
-        return None
-
-    def _get_clipboard_slice_point(clipboard_indices):
-        # Newer napari stores a _ThickNDSlice-like object with .point
-        if hasattr(clipboard_indices, "point"):
-            return clipboard_indices.point
-        return clipboard_indices
-
-    def _get_clipboard_key(clipboard, *names):
-        for name in names:
-            if name in clipboard:
-                return name
-        return None
-
-    def _get_private_color_manager(layer_self, *names):
-        for name in names:
-            obj = getattr(layer_self, name, None)
-            if obj is not None:
-                return obj
-        return None
+    keypoint_cls = getattr(getattr(controls, "keypoints", None), "Keypoint", Keypoint)
 
     def _paste_data(layer_self, _store=store):
-        features = layer_self._clipboard.get("features")
+        clipboard = getattr(layer_self, "_clipboard", None) or {}
+        features = clipboard.get("features")
         if features is None:
             return
 
         unannotated = [
-            Keypoint(label, _normalize_id(id_)) not in _store.annotated_keypoints
+            keypoint_cls(label, _normalize_id(id_)) not in _store.annotated_keypoints
             for label, id_ in zip(features["label"], features["id"], strict=False)
         ]
         if not any(unannotated):
             return
 
-        # Only mutate clipboard after we know we want to paste
-        features = layer_self._clipboard.pop("features")
+        # Only mutate clipboard once we know there is something to paste.
+        features = clipboard.pop("features")
+        indices = clipboard.pop("indices")
+        text = clipboard.pop("text", None)
+
         new_features = features.iloc[unannotated]
+        filtered_clipboard = _filter_clipboard_payload(clipboard, unannotated)
+        filtered_clipboard["features"] = new_features
+        filtered_clipboard["indices"] = indices
 
-        indices_ = layer_self._clipboard.pop("indices")
-        text_ = layer_self._clipboard.pop("text", None)
-
-        layer_self._clipboard = {k: v[unannotated] for k, v in layer_self._clipboard.items()}
-        layer_self._clipboard["features"] = new_features
-        layer_self._clipboard["indices"] = indices_
-
-        if text_ is not None:
-            new_text = {
-                "string": text_["string"][unannotated],
-                "color": text_["color"],
+        if text is not None:
+            filtered_clipboard["text"] = {
+                "string": text["string"][unannotated],
+                "color": text["color"],
             }
-            layer_self._clipboard["text"] = new_text
+
+        layer_self._clipboard = filtered_clipboard
+
+        if not filtered_clipboard:
+            return
 
         npoints = len(layer_self._view_data)
         totpoints = len(layer_self.data)
 
-        if len(layer_self._clipboard) > 0:
-            not_disp = layer_self._slice_input.not_displayed
-            data = deepcopy(layer_self._clipboard["data"])
+        data = _offset_pasted_data(
+            controls=controls,
+            layer=layer_self,
+            clipboard=filtered_clipboard,
+            data=deepcopy(filtered_clipboard["data"]),
+        )
 
-            # ---- compat: current slice point / copied slice point ----
-            current_point = _get_current_slice_point(layer_self)
-            copied_point = _get_clipboard_slice_point(layer_self._clipboard["indices"])
+        layer_self._data = np.append(layer_self.data, data, axis=0)
+        layer_self._shown = np.append(layer_self.shown, deepcopy(filtered_clipboard["shown"]), axis=0)
+        layer_self._size = np.append(layer_self.size, deepcopy(filtered_clipboard["size"]), axis=0)
+        layer_self._symbol = np.append(layer_self.symbol, deepcopy(filtered_clipboard["symbol"]), axis=0)
 
-            if current_point is not None and copied_point is not None and len(not_disp) > 0:
-                offset = []
-                for i in not_disp:
-                    cur = current_point[i]
-                    old = copied_point[i]
-                    offset.append(float(cur) - float(old))
-                data[:, not_disp] = data[:, not_disp] + np.asarray(offset, dtype=float)
+        layer_self._feature_table.append(filtered_clipboard["features"])
+        _paste_text_payload(layer_self, filtered_clipboard)
+        _append_widths(layer_self, filtered_clipboard)
+        _paste_colors(layer_self, filtered_clipboard)
 
-            layer_self._data = np.append(layer_self.data, data, axis=0)
-            layer_self._shown = np.append(
-                layer_self.shown,
-                deepcopy(layer_self._clipboard["shown"]),
-                axis=0,
-            )
-            layer_self._size = np.append(
-                layer_self.size,
-                deepcopy(layer_self._clipboard["size"]),
-                axis=0,
-            )
-            layer_self._symbol = np.append(
-                layer_self.symbol,
-                deepcopy(layer_self._clipboard["symbol"]),
-                axis=0,
-            )
+        n_new = len(filtered_clipboard["data"])
+        layer_self._selected_view = list(range(npoints, npoints + n_new))
+        layer_self._selected_data = set(range(totpoints, totpoints + n_new))
+        layer_self.refresh()
 
-            layer_self._feature_table.append(layer_self._clipboard["features"])
-
-            text_payload = layer_self._clipboard.get("text")
-            if text_payload is not None:
-                layer_self.text._paste(**text_payload)
-
-            # ---- compat: edge_width vs border_width ----
-            width_key = _get_clipboard_key(layer_self._clipboard, "border_width", "edge_width")
-            if width_key is not None:
-                current_width = None
-                for public_name in ("border_width", "edge_width"):
-                    if hasattr(layer_self, public_name):
-                        current_width = getattr(layer_self, public_name)
-                        break
-
-                if current_width is not None:
-                    new_width = np.append(
-                        current_width,
-                        deepcopy(layer_self._clipboard[width_key]),
-                        axis=0,
-                    )
-                    for private_name in ("_border_width", "_edge_width"):
-                        if hasattr(layer_self, private_name):
-                            setattr(layer_self, private_name, new_width)
-                            break
-
-            from napari.layers.utils.layer_utils import _features_to_properties
-
-            props = _features_to_properties(layer_self._clipboard["features"])
-
-            # ---- compat: edge/border color managers ----
-            border_manager = _get_private_color_manager(layer_self, "_border", "_edge")
-            border_color_key = _get_clipboard_key(layer_self._clipboard, "border_color", "edge_color")
-
-            if border_manager is not None and border_color_key is not None:
-                border_manager._paste(
-                    colors=layer_self._clipboard[border_color_key],
-                    properties=props,
-                )
-
-            face_manager = _get_private_color_manager(layer_self, "_face")
-            if face_manager is not None and "face_color" in layer_self._clipboard:
-                face_manager._paste(
-                    colors=layer_self._clipboard["face_color"],
-                    properties=props,
-                )
-
-            layer_self._selected_view = list(range(npoints, npoints + len(layer_self._clipboard["data"])))
-            layer_self._selected_data = set(range(totpoints, totpoints + len(layer_self._clipboard["data"])))
-            layer_self.refresh()
-
-            try:
-                controls._schedule_recolor(_store.layer)
-            except Exception:
-                pass
+        try:
+            controls._schedule_recolor(_store.layer)
+        except Exception:
+            pass
 
     return _paste_data

--- a/src/napari_deeplabcut/ui/color_scheme_display.py
+++ b/src/napari_deeplabcut/ui/color_scheme_display.py
@@ -9,6 +9,7 @@ from typing import Any
 import numpy as np
 from napari.layers import Points
 from qtpy.QtCore import Qt, QTimer, Signal
+from qtpy.QtGui import QShowEvent
 from qtpy.QtWidgets import (
     QCheckBox,
     QScrollArea,
@@ -160,6 +161,30 @@ class ColorSchemeResolver:
         self._get_color_mode = get_color_mode
         self._get_header_model = get_header_model
         self._config_header_cache: dict[str, DLCHeaderModel | None] = {}
+
+    def _is_effectively_visible(self) -> bool:
+        """
+        Best-effort visibility check for the docked panel content.
+
+        We want to no-op when the color scheme dock is hidden so frame stepping
+        and points edits do not keep resolving / repainting the legend.
+        """
+        if self._disposed:
+            return False
+
+        try:
+            if not self.isVisible():
+                return False
+        except RuntimeError:
+            return False
+
+        return True
+
+    def showEvent(self, event: QShowEvent):  # type: ignore[override]
+        super().showEvent(event)
+        # If we were hidden for a while, we may have skipped many updates.
+        # Refresh once when shown again.
+        self.schedule_update()
 
     def is_multianimal(self, layer: Points) -> bool:
         md = layer.metadata or {}
@@ -453,6 +478,7 @@ class ColorSchemePanel(QWidget):
     ):
         super().__init__(parent)
         self.viewer = viewer
+        self._last_scheme: dict[str, str] | None = None
         self._disposed = False
         self._wired_layers: set[int] = set()
         self._connections: list[tuple[object, object]] = []
@@ -538,7 +564,7 @@ class ColorSchemePanel(QWidget):
         super().closeEvent(event)
 
     def _connect_viewer_events(self) -> None:
-        self._connect(self.viewer.layers.selection.events.active, self.schedule_update)
+        self._connect(self.viewer.layers.selection.events.active, self._on_current_step)
         self._connect(self.viewer.layers.events.inserted, self._on_layers_changed)
         self._connect(self.viewer.layers.events.removed, self._on_layers_removed)
         self._connect(self.viewer.dims.events.current_step, self.schedule_update)
@@ -564,6 +590,24 @@ class ColorSchemePanel(QWidget):
                 layer = None
 
         self._maybe_wire_layer(layer)
+        self.schedule_update()
+
+    def _on_current_step(self, event=None) -> None:
+        """
+        Frame-step updates only matter in ACTIVE mode.
+
+        In CONFIG mode the legend reflects configured categories, not currently
+        visible categories, so current_step should be a no-op.
+        """
+        if self._disposed:
+            return
+
+        if not self._is_effectively_visible():
+            return
+
+        if self.show_config_keypoints:
+            return
+
         self.schedule_update()
 
     def _on_layers_removed(self, event=None) -> None:
@@ -605,8 +649,16 @@ class ColorSchemePanel(QWidget):
             self._connect(emitter, self.schedule_update)
 
     def schedule_update(self, event=None) -> None:
-        """Debounced update to avoid refresh storms."""
+        """Debounced update to avoid refresh issues."""
         if self._disposed:
+            return
+
+        if not self._is_effectively_visible():
+            try:
+                if self._update_timer.isActive():
+                    self._update_timer.stop()
+            except RuntimeError:
+                pass
             return
 
         try:
@@ -626,6 +678,9 @@ class ColorSchemePanel(QWidget):
         if self._disposed:
             return
 
+        if not self._is_effectively_visible():
+            return
+
         try:
             scheme = self._resolver.resolve(show_config_keypoints=self.show_config_keypoints)
         except RuntimeError:
@@ -636,9 +691,13 @@ class ColorSchemePanel(QWidget):
             return
 
         try:
-            self.display.reset()
+            if scheme == self._last_scheme:
+                return
+            self._last_scheme = dict(scheme)
             if scheme:
                 self.display.update_color_scheme(scheme)
+            else:
+                self.display.reset()
         except RuntimeError:
             # display already deleted
             return

--- a/src/napari_deeplabcut/ui/color_scheme_display.py
+++ b/src/napari_deeplabcut/ui/color_scheme_display.py
@@ -162,30 +162,6 @@ class ColorSchemeResolver:
         self._get_header_model = get_header_model
         self._config_header_cache: dict[str, DLCHeaderModel | None] = {}
 
-    def _is_effectively_visible(self) -> bool:
-        """
-        Best-effort visibility check for the docked panel content.
-
-        We want to no-op when the color scheme dock is hidden so frame stepping
-        and points edits do not keep resolving / repainting the legend.
-        """
-        if self._disposed:
-            return False
-
-        try:
-            if not self.isVisible():
-                return False
-        except RuntimeError:
-            return False
-
-        return True
-
-    def showEvent(self, event: QShowEvent):  # type: ignore[override]
-        super().showEvent(event)
-        # If we were hidden for a while, we may have skipped many updates.
-        # Refresh once when shown again.
-        self.schedule_update()
-
     def is_multianimal(self, layer: Points) -> bool:
         md = layer.metadata or {}
         header = self._get_header_model(md)
@@ -526,6 +502,30 @@ class ColorSchemePanel(QWidget):
             # Underlying C++ widget already deleted
             return False
 
+    def _is_effectively_visible(self) -> bool:
+        """
+        Best-effort visibility check for the docked panel content.
+
+        We want to no-op when the color scheme dock is hidden so frame stepping
+        and points edits do not keep resolving / repainting the legend.
+        """
+        if self._disposed:
+            return False
+
+        try:
+            if not self.isVisible():
+                return False
+        except RuntimeError:
+            return False
+
+        return True
+
+    def showEvent(self, event: QShowEvent):  # type: ignore[override]
+        super().showEvent(event)
+        # If we were hidden for a while, we may have skipped many updates.
+        # Refresh once when shown again.
+        self.schedule_update()
+
     def _connect(self, emitter, callback) -> None:
         """Connect and remember emitter/callback so we can disconnect later."""
         try:
@@ -564,10 +564,10 @@ class ColorSchemePanel(QWidget):
         super().closeEvent(event)
 
     def _connect_viewer_events(self) -> None:
-        self._connect(self.viewer.layers.selection.events.active, self._on_current_step)
+        self._connect(self.viewer.layers.selection.events.active, self.schedule_update)
         self._connect(self.viewer.layers.events.inserted, self._on_layers_changed)
         self._connect(self.viewer.layers.events.removed, self._on_layers_removed)
-        self._connect(self.viewer.dims.events.current_step, self.schedule_update)
+        self._connect(self.viewer.dims.events.current_step, self._on_current_step)
 
         for layer in list(self.viewer.layers):
             self._maybe_wire_layer(layer)
@@ -592,6 +592,12 @@ class ColorSchemePanel(QWidget):
         self._maybe_wire_layer(layer)
         self.schedule_update()
 
+    def _on_layers_removed(self, event=None) -> None:
+        if self._disposed:
+            return
+        # We don't try to disconnect per-layer emitters defensively here; just refresh.
+        self.schedule_update()
+
     def _on_current_step(self, event=None) -> None:
         """
         Frame-step updates only matter in ACTIVE mode.
@@ -608,12 +614,6 @@ class ColorSchemePanel(QWidget):
         if self.show_config_keypoints:
             return
 
-        self.schedule_update()
-
-    def _on_layers_removed(self, event=None) -> None:
-        if self._disposed:
-            return
-        # We don't try to disconnect per-layer emitters defensively here; just refresh.
         self.schedule_update()
 
     def _maybe_wire_layer(self, layer) -> None:
@@ -649,7 +649,7 @@ class ColorSchemePanel(QWidget):
             self._connect(emitter, self.schedule_update)
 
     def schedule_update(self, event=None) -> None:
-        """Debounced update to avoid refresh issues."""
+        """Debounced update to avoid refresh storms."""
         if self._disposed:
             return
 

--- a/src/napari_deeplabcut/ui/color_scheme_display.py
+++ b/src/napari_deeplabcut/ui/color_scheme_display.py
@@ -513,8 +513,13 @@ class ColorSchemePanel(QWidget):
             return False
 
         try:
-            if not self.isVisible():
+            if self.isHidden():
                 return False
+            parent = self.parentWidget()
+            while parent is not None:
+                if parent.isHidden():
+                    return False
+                parent = parent.parentWidget()
         except RuntimeError:
             return False
 

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -203,6 +203,20 @@ def ensure_dlc_crop_layer(viewer) -> Shapes:
     return layer
 
 
+def _panel_is_displayed(panel) -> bool:
+    if panel is None:
+        return False
+    try:
+        if not panel.isVisible():
+            return False
+        parent = panel.parentWidget()
+        if parent is not None and not parent.isVisible():
+            return False
+    except Exception:
+        pass
+    return True
+
+
 def handle_apply_crop_toggled(viewer, panel, checked: bool) -> None:
     """
     When crop application is enabled, create/select the dedicated crop layer and
@@ -246,25 +260,10 @@ def _schedule_crop_refresh(panel, refresh_callback) -> None:
     timer.start()
 
 
-def sync_crop_layer_autorefresh(viewer, panel, refresh_callback) -> None:
-    """
-    Keep a debounced data-change listener attached only to the dedicated DLC crop layer.
-
-    This is intentionally a no-op in all other contexts:
-    - no dedicated crop layer -> nothing connected
-    - same layer already connected -> nothing changes
-    - crop layer removed/replaced -> disconnect old, connect new
-    """
-    current_layer = get_dlc_crop_layer(viewer)
-
+def _detach_crop_autorefresh(panel) -> None:
     prev_layer = getattr(panel, "_dlc_crop_refresh_layer", None)
     prev_handler = getattr(panel, "_dlc_crop_refresh_handler", None)
 
-    # Fast no-op path: already synced to the current dedicated crop layer
-    if current_layer is not None and prev_layer is current_layer and prev_handler is not None:
-        return
-
-    # Disconnect previous listener if present
     if prev_layer is not None and prev_handler is not None:
         try:
             prev_layer.events.data.disconnect(prev_handler)
@@ -279,11 +278,32 @@ def sync_crop_layer_autorefresh(viewer, panel, refresh_callback) -> None:
     panel._dlc_crop_refresh_handler = None
 
     timer = getattr(panel, "_dlc_crop_refresh_timer", None)
-    if current_layer is None and timer is not None:
+    if timer is not None:
         try:
             timer.stop()
         except Exception:
             pass
+
+
+def sync_crop_layer_autorefresh(viewer, panel, refresh_callback) -> None:
+    """
+    Keep a debounced data-change listener attached only to the dedicated DLC crop layer.
+
+    This is intentionally a no-op in all other contexts:
+    - no dedicated crop layer -> nothing connected
+    - same layer already connected -> nothing changes
+    - crop layer removed/replaced -> disconnect old, connect new
+    """
+    current_layer = get_dlc_crop_layer(viewer)
+    prev_layer = getattr(panel, "_dlc_crop_refresh_layer", None)
+    prev_handler = getattr(panel, "_dlc_crop_refresh_handler", None)
+
+    # Fast no-op path: already synced to the current dedicated crop layer
+    if current_layer is not None and prev_layer is current_layer and prev_handler is not None:
+        return
+
+    # Disconnect previous listener if present
+    _detach_crop_autorefresh(panel)
 
     if current_layer is None:
         return
@@ -862,6 +882,10 @@ def resolve_project_path_from_image_layer(layer: Image) -> str | None:
 def update_video_panel_context(viewer, panel) -> None:
     """Refresh lightweight user-facing context shown in the video action panel."""
     if panel is None:
+        return
+
+    if not _panel_is_displayed(panel):
+        _detach_crop_autorefresh(panel)
         return
 
     sync_crop_layer_autorefresh(

--- a/src/napari_deeplabcut/ui/cropping.py
+++ b/src/napari_deeplabcut/ui/cropping.py
@@ -917,14 +917,14 @@ def update_video_panel_context(viewer, panel) -> None:
         )
         return
 
-    viewer_crop_text = str(crop_spec.viewer_crop.values)
+    str(crop_spec.viewer_crop.values)
     config_crop_text = str(crop_spec.config_crop.values)
 
     panel.set_context_text(
         f"{frame_text}\n"
         f"Output folder: {root_text}\n"
         f"Crop source: {crop_source}\n"
-        f"Viewer crop: {viewer_crop_text}\n"
+        # f"Viewer crop: {viewer_crop_text}\n" # TMI ?
         f"Config crop: {config_crop_text}"
     )
 

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -310,11 +310,10 @@ class Tutorial(QDialog):
     def __init__(self, parent):
         super().__init__(parent=parent)
         self.setParent(parent)
-        self.setWindowTitle("Tutorial")
+        self.setWindowTitle("💡Tutorial")
         self.setModal(True)
-        self.setStyleSheet("background:#361AE5")
         self.setAttribute(Qt.WA_DeleteOnClose)
-        self.setWindowOpacity(0.95)
+        self.setWindowOpacity(0.96)
         self.setWindowFlags(self.windowFlags() | Qt.WindowCloseButtonHint)
 
         self._current_tip = -1
@@ -353,28 +352,93 @@ class Tutorial(QDialog):
             ),
         ]
 
+        self.setStyleSheet(
+            """
+            QDialog {
+                background: #1E1F26;
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: 14px;
+            }
+            QLabel {
+                color: #F5F7FF;
+            }
+            QLabel#messageLabel {
+                background: #2A2D38;
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: 12px;
+                padding: 18px 20px;
+                font-size: 14px;
+                line-height: 1.45em;
+            }
+            QLabel#countLabel {
+                color: #B8BED3;
+                font-size: 12px;
+                padding-left: 2px;
+            }
+            QPushButton {
+                background: #34394A;
+                color: white;
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                border-radius: 8px;
+                min-width: 30px;
+                min-height: 30px;
+                padding: 2px 8px;
+                font-weight: 600;
+            }
+            QPushButton:hover {
+                background: #42485C;
+            }
+            QPushButton:pressed {
+                background: #2D3140;
+            }
+            QPushButton:disabled {
+                background: #262935;
+                color: #7E859C;
+                border: 1px solid rgba(255, 255, 255, 0.05);
+            }
+            """
+        )
+
         vlayout = QVBoxLayout()
-        self.message = QLabel("💡\n\nLet's get started with a quick walkthrough!")
+        vlayout.setContentsMargins(14, 14, 14, 12)
+        vlayout.setSpacing(10)
+
+        self.message = QLabel("Let's get started with a quick walkthrough!")
+        self.message.setObjectName("messageLabel")
+        self.message.setWordWrap(True)
         self.message.setTextInteractionFlags(Qt.LinksAccessibleByMouse)
         self.message.setOpenExternalLinks(True)
+        self.message.setMinimumWidth(360)
+        self.message.setMaximumWidth(460)
+        self.message.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         vlayout.addWidget(self.message)
 
         nav_layout = QHBoxLayout()
-        self.prev_button = QPushButton("<")
+        nav_layout.setSpacing(6)
+
+        self.prev_button = QPushButton("←")
         self.prev_button.clicked.connect(self.prev_tip)
         nav_layout.addWidget(self.prev_button)
-        self.next_button = QPushButton(">")
+
+        self.next_button = QPushButton("→")
         self.next_button.clicked.connect(self.next_tip)
         nav_layout.addWidget(self.next_button)
 
-        self.update_nav_buttons()
+        nav_layout.addStretch(1)
 
-        hlayout = QHBoxLayout()
         self.count = QLabel("")
-        hlayout.addWidget(self.count)
-        hlayout.addLayout(nav_layout)
-        vlayout.addLayout(hlayout)
+        self.count.setObjectName("countLabel")
+
+        footer = QHBoxLayout()
+        footer.setContentsMargins(2, 0, 2, 0)
+        footer.addWidget(self.count)
+        footer.addStretch(1)
+        footer.addLayout(nav_layout)
+
+        vlayout.addLayout(footer)
         self.setLayout(vlayout)
+
+        self.update_nav_buttons()
 
     def prev_tip(self):
         self._current_tip = (self._current_tip - 1) % len(self._tips)
@@ -389,11 +453,8 @@ class Tutorial(QDialog):
     def update_tip(self):
         tip = self._tips[self._current_tip]
         msg = tip.msg
-        # No emoji in the last tip otherwise the hyperlink breaks
-        if self._current_tip < len(self._tips) - 1:
-            msg = "💡\n\n" + msg
         self.message.setText(msg)
-        self.count.setText(f"Tip {self._current_tip + 1}|{len(self._tips)}")
+        self.count.setText(f"Tip {self._current_tip + 1} of {len(self._tips)}")
         self.adjustSize()
 
         xrel, yrel = tip.pos

--- a/src/napari_deeplabcut/ui/labels_and_dropdown.py
+++ b/src/napari_deeplabcut/ui/labels_and_dropdown.py
@@ -137,8 +137,12 @@ class KeypointsDropdownMenu(QWidget):
         """Set current keypoint to the first unlabeled one."""
         if self._locked:
             return
+
+        # Skip work for explicitly hidden/inactive menus, but do not require the
+        # widget to be shown yet: tests and some construction paths invoke this
+        # before a top-level show().
         try:
-            if not self.isVisible():
+            if self.isHidden():
                 return
         except RuntimeError:
             return

--- a/src/napari_deeplabcut/ui/labels_and_dropdown.py
+++ b/src/napari_deeplabcut/ui/labels_and_dropdown.py
@@ -137,13 +137,28 @@ class KeypointsDropdownMenu(QWidget):
         """Set current keypoint to the first unlabeled one."""
         if self._locked:
             return
+        try:
+            if not self.isVisible():
+                return
+        except RuntimeError:
+            return
+
+        keypoints_ = getattr(self.store, "_keypoints", None) or []
+        if not keypoints_:
+            return
+
         unannotated = ""
         already_annotated = self.store.annotated_keypoints
-        for keypoint in self.store._keypoints:
+        for keypoint in keypoints_:
             if keypoint not in already_annotated:
                 unannotated = keypoint
                 break
-        self.store.current_keypoint = unannotated if unannotated else self.store._keypoints[0]
+
+        target = unannotated if unannotated else keypoints_[0]
+
+        # Avoid redundant setter/event churn on every frame step.
+        if self.store.current_keypoint != target:
+            self.store.current_keypoint = target
 
 
 class ClickableLabel(QLabel):


### PR DESCRIPTION
## Code improvements

- Moved trail display logic to trails.py in a TrailsController class to keep _widgets.py lean
- Moved provenance-related code to provenance.py
- Moved supported formats specifications to config file
- Clarified some ambiguous functions names/signatures 

## Performance improvements

- Added several visibility guards to ensure hidden widgets do not add overhead when not displayed

---
This pull request introduces several improvements and refactorings focused on testing robustness, code clarity, and file format handling in the napari-deeplabcut plugin.

**Testing improvements and utilities:**

* Added a `force_show` utility in `conftest.py` to ensure Qt widgets and their parents are properly shown during tests, even in headless environments. 

* Updated various tests to use `force_show` and refactored widget visibility and docking logic to ensure all relevant panels and docks are visible before assertions

**Image and video file handling:**

* Moved supported image and video file suffixes to a new `supported_files.py` module, centralizing format definitions for easier updates and reuse.

* Refactored `_expand_image_paths` in `core/io.py` for robustness and efficiency: now uses `os.scandir` for directory listing, supports glob patterns, and ensures only supported file types are included. This greatly improves performance and reliability when handling large directories or complex path patterns.

**Test code refactors and reliability:**

* Improved naming and assertion clarity in trails and coloring tests, including extracting a `_trails_layer` helper and enhancing assertion messages for color uniqueness.

**Minor improvements:**

* Added a test marker to ensure proper fixture usage in color scheme panel tests.