### PR TITLE
Plugin refactor [7]: Fix trajectory plot, better interactions

### DIFF
--- a/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
@@ -5,7 +5,6 @@ Validate the overrides and monkeypatches don't crash and have the intended effec
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from napari_deeplabcut.napari_compat import (
     apply_points_layer_ui_tweaks,
@@ -111,7 +110,6 @@ def test_install_paste_patch_smoke_real_points_layer(viewer):
     assert seen == [layer]
 
 
-@pytest.mark.xfail(reason="This test is fixed in a subsequent PR, to be added")
 def test_apply_points_layer_ui_tweaks_real_dropdown(qtbot):
     from types import SimpleNamespace
 
@@ -147,7 +145,12 @@ def test_apply_points_layer_ui_tweaks_real_dropdown(qtbot):
         def layout(self):
             return self._layout
 
-    layer = SimpleNamespace(metadata={"colormap_name": "magma"})
+    class DummyLayer:
+        def __init__(self):
+            self.metadata = {"colormap_name": "magma"}
+
+    layer = DummyLayer()
+
     point_controls = PointControls()
     qtbot.addWidget(point_controls)
 

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from napari.layers import Points
 
-from napari_deeplabcut.core.layers import populate_keypoint_layer_properties
+from napari_deeplabcut.core.layers import PointsInteractionObserver, populate_keypoint_layer_properties
 
 
 @pytest.mark.usefixtures("qtbot")
@@ -239,3 +241,67 @@ def test_copy_paste_same_frame_does_not_duplicate_existing_keypoints(
 
     # no duplicates expected on same frame
     assert len(layer.data) == before
+
+
+def test_points_interaction_observer_emits_on_selected_data_change(viewer, qtbot):
+    layer = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+    viewer.layers.selection.active = layer
+
+    seen = []
+
+    observer = PointsInteractionObserver(viewer, seen.append, debounce_ms=0)
+    observer.install()
+
+    layer.selected_data.select_only(1)
+
+    qtbot.waitUntil(lambda: len(seen) >= 1, timeout=1000)
+
+    assert seen[-1].layer is layer
+    assert "selection" in seen[-1].reasons
+
+    observer.close()
+
+
+def test_points_interaction_observer_rebinds_when_active_layer_changes(viewer, qtbot):
+    layer1 = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+        name="points-1",
+    )
+    layer2 = viewer.add_points(
+        np.array([[2, 2], [3, 3]]),
+        properties={"label": np.array(["paw", "ear"], dtype=object)},
+        name="points-2",
+    )
+
+    seen = []
+    observer = PointsInteractionObserver(viewer, seen.append, debounce_ms=0)
+    observer.install()
+
+    viewer.layers.selection.active = layer1
+    layer1.selected_data.select_only(0)
+    qtbot.waitUntil(lambda: any("selection" in ev.reasons for ev in seen), timeout=1000)
+
+    count_after_layer1 = len(seen)
+
+    # Switch active layer
+    viewer.layers.selection.active = layer2
+    qtbot.waitUntil(lambda: len(seen) > count_after_layer1, timeout=1000)
+
+    count_after_active_switch = len(seen)
+
+    # Mutating old inactive layer selection should not produce a new callback
+    layer1.selected_data.select_only(1)
+    qtbot.wait(50)
+    assert len(seen) == count_after_active_switch
+
+    # Mutating new active layer selection should produce a callback
+    layer2.selected_data.select_only(1)
+    qtbot.waitUntil(lambda: len(seen) > count_after_active_switch, timeout=1000)
+    assert seen[-1].layer is layer2
+    assert "selection" in seen[-1].reasons
+
+    observer.close()

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -301,7 +301,8 @@ def test_points_interaction_observer_rebinds_when_active_layer_changes(viewer, q
     # Mutating new active layer selection should produce a callback
     layer2.selected_data.select_only(1)
     qtbot.waitUntil(lambda: len(seen) > count_after_active_switch, timeout=1000)
-    assert seen[-1].layer is layer2
+    assert seen[-1].layer is not None
+    assert seen[-1].layer.name == layer2.name
     assert "selection" in seen[-1].reasons
 
     observer.close()

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -102,7 +102,7 @@ def test_layer_insert_does_not_crash_when_current_property_is_nan(viewer, keypoi
     layer = viewer.add_points(data, **md)
     # Plot cannot be formed because of the NaN,
     # but the layer must still be added and cycle mode must not be enabled.
-    assert keypoint_controls._matplotlib_canvas.df is None
+    assert keypoint_controls._traj_mpl_canvas.df is None
     assert isinstance(layer, Points)
     assert layer.face_color_mode != "cycle"
 

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -259,8 +259,11 @@ def test_points_interaction_observer_emits_on_selected_data_change(viewer, qtbot
 
     qtbot.waitUntil(lambda: len(seen) >= 1, timeout=1000)
 
-    assert seen[-1].layer is layer
-    assert "selection" in seen[-1].reasons
+    evt = seen[-1]
+    assert evt.viewer is viewer
+    assert isinstance(evt.layer, Points)
+    assert "selection" in evt.reasons
+    assert tuple(sorted(evt.layer.selected_data)) == (1,)
 
     observer.close()
 

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -254,8 +254,11 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     assert canvas._window == initial_window + 100
     assert canvas.slider_value.text() == str(initial_window + 100)
 
-    # Test plot refresh on frame change
+    # Test plot refresh does nothing when plot is hidden
     canvas.update_plot_range(event=type("Event", (), {"value": [5]}))
+    assert canvas._n == 0
+    # Test plot refresh on frame change (forced as it is hidden)
+    canvas.update_plot_range(event=type("Event", (), {"value": [5]}), force=True)
     assert canvas._n == 5
     # Check that x-limits reflect the new window
     start, end = canvas.ax.get_xlim()

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -1,5 +1,5 @@
 """
-NOTE: This file can be a litle non-specific, please ensure functionalities from ui/ are tested
+NOTE: This file can be somewhat non-specific, please ensure functionalities from ui/ are tested
 in the _tests/ui folder and consider moving tests below to more specific files as needed."""
 
 # src/napari_deeplabcut/_tests/test_widgets.py

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -1,3 +1,7 @@
+"""
+NOTE: This file can be a litle non-specific, please ensure functionalities from ui/ are tested
+in the _tests/ui folder and consider moving tests below to more specific files as needed."""
+
 # src/napari_deeplabcut/_tests/test_widgets.py
 import os
 import types

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -16,7 +16,7 @@ from napari_deeplabcut.core.io import populate_keypoint_layer_properties
 from napari_deeplabcut.ui.color_scheme_display import ColorSchemeDisplay
 from napari_deeplabcut.ui.dialogs import ShortcutRow
 from napari_deeplabcut.ui.labels_and_dropdown import KeypointsDropdownMenu, LabelPair
-from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
+from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
 
 from .conftest import force_show
 
@@ -235,7 +235,7 @@ def test_color_scheme_display(qtbot):
 @pytest.mark.usefixtures("qtbot")
 def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     # Create the canvas widget
-    canvas = KeypointMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer)
     qtbot.add_widget(canvas)
 
     # Simulate adding a Points layer (triggers _load_dataframe)
@@ -289,7 +289,7 @@ def test_ensure_mpl_canvas_docked_already_docked(keypoint_controls, qtbot, monke
     # Ensure it wouldn't try to dock again
     monkeypatch.setattr(controls.viewer.window, "add_dock_widget", fake_add_dock_widget)
 
-    controls._ensure_mpl_canvas_docked()
+    controls._ensure_traj_canvas_docked()
     assert called["count"] == 0, "add_dock_widget should not be called when already docked"
     assert controls._mpl_docked is True  # stays docked
 
@@ -304,7 +304,7 @@ def test_ensure_mpl_canvas_docked_missing_window(keypoint_controls, qtbot):
     controls.viewer = types.SimpleNamespace()  # no 'window'
 
     controls._mpl_docked = False
-    controls._ensure_mpl_canvas_docked()
+    controls._ensure_traj_canvas_docked()
 
     # Nothing should change; crucially, no exceptions should be raised
     assert controls._mpl_docked is False
@@ -325,11 +325,11 @@ def test_trajectory_loader_ignores_invalid_properties(viewer, keypoint_controls,
 
     layer = viewer.add_points(np.array([[0.0, 10.0, 20.0]]), **md)
     assert layer is not None
-    assert keypoint_controls._matplotlib_canvas.df is None  # loader should have bailed out safely
+    assert keypoint_controls._traj_mpl_canvas.df is None  # loader should have bailed out safely
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_ensure_mpl_canvas_docked_missing_qt_window(keypoint_controls, qtbot):
+def test_ensure_traj_canvas_docked_missing_qt_window(keypoint_controls, qtbot):
     """If window._qt_window is None, method should safely no-op."""
     controls = keypoint_controls
     qtbot.add_widget(controls)
@@ -344,7 +344,7 @@ def test_ensure_mpl_canvas_docked_missing_qt_window(keypoint_controls, qtbot):
     controls.viewer = types.SimpleNamespace(window=DummyWindow())
 
     controls._mpl_docked = False
-    controls._ensure_mpl_canvas_docked()
+    controls._ensure_traj_canvas_docked()
 
     # Still undocked, no crash
     assert controls._mpl_docked is False
@@ -368,7 +368,7 @@ def test_ensure_mpl_canvas_docked_exception_during_docking(keypoint_controls, qt
     controls._mpl_docked = False
 
     # Should not raise
-    controls._ensure_mpl_canvas_docked()
+    controls._ensure_traj_canvas_docked()
 
     # Docking failed → remains undocked
     assert controls._mpl_docked is False

--- a/src/napari_deeplabcut/_tests/ui/test_cropping.py
+++ b/src/napari_deeplabcut/_tests/ui/test_cropping.py
@@ -514,3 +514,333 @@ def test_execute_frame_extraction_keeps_new_labels_row_on_duplicate_index(monkey
 
     df_written = pd.read_hdf(labels_path, key="df_with_missing")
     assert float(df_written.iloc[0]["bp1"]) == 222.0
+
+
+def test_ensure_dlc_crop_layer_reuses_existing(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    existing = FakeShapes(
+        data=[],
+        shape_type=[],
+        metadata={cropping_mod.DLC_CROP_LAYER_META_KEY: True},
+        name=cropping_mod.DLC_CROP_LAYER_NAME,
+    )
+    existing.visible = False
+    existing.mode = None
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([existing], active=None),
+    )
+
+    out = cropping_mod.ensure_dlc_crop_layer(viewer)
+
+    assert out is existing
+    assert existing.visible is True
+    assert existing.mode == "add_rectangle"
+    assert viewer.layers.selection.active is existing
+
+
+def test_ensure_dlc_crop_layer_creates_new(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    created = FakeShapes(data=[], shape_type=[], metadata={}, name="created")
+    created.mode = None
+
+    class Viewer:
+        def __init__(self):
+            self.layers = FakeLayerList([], active=None)
+
+        def add_shapes(self, name, metadata):
+            created.name = name
+            created.metadata = metadata
+            self.layers.append(created)
+            return created
+
+    viewer = Viewer()
+
+    out = cropping_mod.ensure_dlc_crop_layer(viewer)
+
+    assert out is created
+    assert out.name == cropping_mod.DLC_CROP_LAYER_NAME
+    assert out.metadata[cropping_mod.DLC_CROP_LAYER_META_KEY] is True
+    assert out.mode == "add_rectangle"
+    assert viewer.layers.selection.active is out
+
+
+def test_dlc_config_y_extent_falls_back_to_active_image(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Image", FakeImage)
+
+    image = FakeImage(data=np.zeros((5, 40, 70), dtype=np.uint8))
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(range=None),
+        layers=FakeLayerList([image], active=image),
+    )
+
+    assert cropping_mod._dlc_config_y_extent(viewer) == 40
+
+
+def test_dlc_config_y_extent_falls_back_to_last_image(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Image", FakeImage)
+
+    image = FakeImage(data=np.zeros((5, 55, 90), dtype=np.uint8))
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(range=None),
+        layers=FakeLayerList([image], active=None),
+    )
+
+    assert cropping_mod._dlc_config_y_extent(viewer) == 55
+
+
+def test_dlc_config_y_extent_returns_none_when_unavailable():
+    viewer = SimpleNamespace(
+        dims=SimpleNamespace(range=None),
+        layers=FakeLayerList([], active=None),
+    )
+
+    assert cropping_mod._dlc_config_y_extent(viewer) is None
+
+
+def test_find_rectangle_in_layer_falls_back_from_selected_to_last(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    bad_rect = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 20.0],
+            [0.0, 10.0, 20.0],
+        ],
+        dtype=float,
+    )
+    good_rect = np.array(
+        [
+            [0.0, 5.0, 10.0],
+            [0.0, 5.0, 20.0],
+            [0.0, 15.0, 20.0],
+            [0.0, 15.0, 10.0],
+        ],
+        dtype=float,
+    )
+
+    layer = FakeShapes(
+        data=[bad_rect, good_rect],
+        shape_type=["rectangle", "rectangle"],
+        selected_data={0},
+    )
+    viewer = SimpleNamespace(dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]))
+
+    spec = cropping_mod._find_rectangle_in_layer(viewer, layer, prefer_selected=True)
+    assert spec is not None
+    assert spec.viewer_crop.values == (10, 20, 5, 15)
+
+
+def test_get_crop_source_summary_uses_active_shapes_when_no_dedicated(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    rect = np.array(
+        [
+            [0.0, 5.0, 10.0],
+            [0.0, 5.0, 20.0],
+            [0.0, 15.0, 20.0],
+            [0.0, 15.0, 10.0],
+        ],
+        dtype=float,
+    )
+
+    active = FakeShapes(
+        data=[rect],
+        shape_type=["rectangle"],
+        metadata={},
+        name="manual",
+        selected_data={0},
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([active], active=active),
+        dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]),
+    )
+
+    source, spec = cropping_mod.get_crop_source_summary(viewer)
+    assert source == "active Shapes layer (manual)"
+    assert spec is not None
+
+
+def test_get_crop_source_summary_returns_none_when_no_valid_rectangles(monkeypatch):
+    monkeypatch.setattr(cropping_mod, "Shapes", FakeShapes)
+
+    poly = FakeShapes(
+        data=[np.array([[0, 1, 2], [0, 2, 3], [0, 3, 4]], dtype=float)],
+        shape_type=["polygon"],
+        metadata={},
+        name="poly",
+        selected_data={0},
+    )
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([poly], active=poly),
+        dims=SimpleNamespace(range=[(0, 10, 1), (0, 100, 1), (0, 200, 1)]),
+    )
+
+    source, spec = cropping_mod.get_crop_source_summary(viewer)
+    assert source == "none"
+    assert spec is None
+
+
+def test_plan_frame_extraction_rejects_missing_image_layer():
+    viewer = SimpleNamespace(dims=SimpleNamespace(current_step=(0,)))
+    plan, error = cropping_mod.plan_frame_extraction(viewer, image_layer=None)
+    assert plan is None
+    assert "No image/video layer is active" in error
+
+
+def test_plan_frame_extraction_rejects_missing_output_root():
+    image = FakeImage(data=np.zeros((3, 10, 10), dtype=np.uint8), metadata={})
+    viewer = SimpleNamespace(dims=SimpleNamespace(current_step=(0,)))
+
+    plan, error = cropping_mod.plan_frame_extraction(viewer, image_layer=image)
+    assert plan is None
+    assert "Could not determine the output folder" in error
+
+
+def test_plan_frame_extraction_requires_points_layer_for_label_export(tmp_path: Path):
+    image = FakeImage(
+        data=np.zeros((3, 10, 10), dtype=np.uint8),
+        metadata={"root": str(tmp_path)},
+    )
+    viewer = SimpleNamespace(dims=SimpleNamespace(current_step=(0,)))
+
+    plan, error = cropping_mod.plan_frame_extraction(
+        viewer,
+        image_layer=image,
+        export_labels=True,
+        points_layer=None,
+    )
+    assert plan is None
+    assert "no Points layer is available" in error
+
+
+def test_plan_frame_extraction_requires_rectangle_when_crop_enabled(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(cropping_mod, "find_crop_rectangle", lambda viewer, prefer_selected=True: None)
+
+    image = FakeImage(
+        data=np.zeros((3, 10, 10), dtype=np.uint8),
+        metadata={"root": str(tmp_path)},
+    )
+    viewer = SimpleNamespace(dims=SimpleNamespace(current_step=(0,)))
+
+    plan, error = cropping_mod.plan_frame_extraction(
+        viewer,
+        image_layer=image,
+        apply_crop=True,
+    )
+    assert plan is None
+    assert "no valid rectangle was found" in error
+
+
+def test_plan_crop_save_rejects_missing_project_context(monkeypatch):
+    monkeypatch.setattr(
+        cropping_mod,
+        "infer_dlc_project_from_image_layer",
+        lambda image_layer, prefer_project_root=True: SimpleNamespace(
+            config_path=None,
+            project_root=None,
+            root_anchor=None,
+        ),
+    )
+
+    image = FakeImage(data=np.zeros((3, 10, 10), dtype=np.uint8))
+    viewer = SimpleNamespace(layers=FakeLayerList([], active=None), dims=SimpleNamespace(range=[]))
+
+    plan, error = cropping_mod.plan_crop_save(viewer, image_layer=image)
+    assert plan is None
+    assert "Could not determine a DLC config.yaml" in error
+
+
+def test_plan_crop_save_rejects_missing_rectangle(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        cropping_mod,
+        "infer_dlc_project_from_image_layer",
+        lambda image_layer, prefer_project_root=True: SimpleNamespace(
+            config_path=tmp_path / "config.yaml",
+            project_root=tmp_path,
+            root_anchor=tmp_path,
+        ),
+    )
+    monkeypatch.setattr(cropping_mod, "find_crop_rectangle", lambda viewer, prefer_selected=True: None)
+
+    image = FakeImage(data=np.zeros((3, 10, 10), dtype=np.uint8), name="demo.mp4")
+    viewer = SimpleNamespace(layers=FakeLayerList([], active=None), dims=SimpleNamespace(range=[]))
+
+    plan, error = cropping_mod.plan_crop_save(viewer, image_layer=image)
+    assert plan is None
+    assert "No valid rectangle was found" in error
+
+
+def test_execute_crop_save_replaces_non_dict_video_set_entry(monkeypatch, tmp_path: Path):
+    cfg = {"video_sets": {"video.mp4": "old-value"}}
+
+    monkeypatch.setattr(cropping_mod.io, "load_config", lambda path: cfg)
+    written = {}
+
+    def fake_write_config(path, out_cfg):
+        written["path"] = path
+        written["cfg"] = out_cfg
+
+    monkeypatch.setattr(cropping_mod.io, "write_config", fake_write_config)
+
+    plan = cropping_mod.CropSavePlan(
+        config_path=tmp_path / "config.yaml",
+        project_root=tmp_path,
+        video_key="video.mp4",
+        config_crop=cropping_mod.DLCConfigCropCoords(values=(1, 10, 20, 30)),
+    )
+
+    msg = cropping_mod.execute_crop_save(plan)
+
+    assert "Saved crop" in msg
+    assert written["cfg"]["video_sets"]["video.mp4"]["crop"] == "1, 10, 20, 30"
+
+
+class HiddenPanel(DummyPanel):
+    def isVisible(self):
+        return False
+
+    def parentWidget(self):
+        return None
+
+
+class VisiblePanel(DummyPanel):
+    def isVisible(self):
+        return True
+
+    def parentWidget(self):
+        return None
+
+
+def test_update_video_panel_context_hidden_panel_detaches_and_returns(monkeypatch):
+    panel = HiddenPanel()
+    called = {"detach": 0}
+
+    monkeypatch.setattr(
+        cropping_mod, "_detach_crop_autorefresh", lambda p: called.__setitem__("detach", called["detach"] + 1)
+    )
+
+    viewer = SimpleNamespace(layers=FakeLayerList([], active=None), dims=SimpleNamespace(current_step=(0,)))
+
+    cropping_mod.update_video_panel_context(viewer, panel)
+
+    assert called["detach"] == 1
+    assert panel.text is None
+
+
+def test_update_video_panel_context_no_image_layer(monkeypatch):
+    panel = VisiblePanel()
+    monkeypatch.setattr(cropping_mod, "sync_crop_layer_autorefresh", lambda viewer, panel, refresh_callback: None)
+
+    viewer = SimpleNamespace(
+        layers=FakeLayerList([], active=None),
+        dims=SimpleNamespace(current_step=(0,)),
+    )
+
+    cropping_mod.update_video_panel_context(viewer, panel)
+    assert panel.text == "No active video/image layer."

--- a/src/napari_deeplabcut/_tests/ui/test_debug_window.py
+++ b/src/napari_deeplabcut/_tests/ui/test_debug_window.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
+
+from napari_deeplabcut.ui.debug_window import (
+    DebugTextWindow,
+    make_issue_report_provider,
+    make_log_text_provider,
+)
+
+
+class FakeRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def render_text(self, *, limit: int = 0) -> str:
+        self.calls.append(limit)
+        return f"rendered:{limit}"
+
+
+def test_make_log_text_provider_uses_recorder_limit():
+    recorder = FakeRecorder()
+    provider = make_log_text_provider(recorder=recorder, limit=123)
+
+    text = provider()
+
+    assert text == "rendered:123"
+    assert recorder.calls == [123]
+
+
+def test_make_log_text_provider_handles_missing_recorder():
+    provider = make_log_text_provider(recorder=None, limit=5)
+    assert provider() == "<debug recorder unavailable>"
+
+
+def test_make_issue_report_provider_calls_build_debug_report(monkeypatch):
+    calls = []
+
+    def fake_build_debug_report(*, viewer, recorder, log_limit):
+        calls.append((viewer, recorder, log_limit))
+        return "full-report"
+
+    monkeypatch.setattr(
+        "napari_deeplabcut.ui.debug_window.build_debug_report",
+        fake_build_debug_report,
+    )
+
+    viewer = object()
+    recorder = object()
+    provider = make_issue_report_provider(viewer=viewer, recorder=recorder, log_limit=77)
+
+    text = provider()
+
+    assert text == "full-report"
+    assert calls == [(viewer, recorder, 77)]
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_shows_initial_text(qtbot):
+    provider_calls = []
+
+    def provider():
+        provider_calls.append("called")
+        return "hello debug world"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+        initial_hint="hint",
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    assert provider_calls == ["called"]
+    assert window.windowTitle() == "Debug"
+    assert "hello debug world" in window._text_edit.toPlainText()
+    assert window._text_edit.isReadOnly()
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_refresh_reloads_text(qtbot):
+    state = {"n": 0}
+
+    def provider():
+        state["n"] += 1
+        return f"value:{state['n']}"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    assert window._text_edit.toPlainText() == "value:1"
+
+    qtbot.mouseClick(window._refresh_btn, Qt.LeftButton)
+    assert window._text_edit.toPlainText() == "value:2"
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_copy_to_clipboard(qtbot):
+    def provider():
+        return "copy me"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    qtbot.mouseClick(window._copy_btn, Qt.LeftButton)
+
+    assert QApplication.clipboard().text() == "copy me"
+    assert "Copied to clipboard" in window._status_label.text()
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_handles_provider_failure(qtbot):
+    def provider():
+        raise RuntimeError("provider failed")
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    text = window._text_edit.toPlainText()
+    assert "[debug-window] failed to build debug text" in text
+    assert "RuntimeError" in text
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_copy_shortcut_works(qtbot):
+    QApplication.clipboard().clear()
+
+    def provider():
+        return "shortcut copy"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+    window.raise_()
+    window.activateWindow()
+    window.setFocus()
+    qtbot.wait(50)
+
+    qtbot.keyClick(window, Qt.Key_C, modifier=Qt.ControlModifier)
+
+    assert QApplication.clipboard().text() == "shortcut copy"

--- a/src/napari_deeplabcut/_tests/ui/test_traj_select.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_select.py
@@ -17,14 +17,17 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
     canvas = TrajectoryMatplotlibCanvas(viewer)
     qtbot.add_widget(canvas)
 
+    # Force the visibility sync to use this test layer directly.
+    canvas._get_plot_points_layer = lambda: layer
+
     # Avoid relying on df creation for this focused visibility test
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
     qtbot.wait(0)  # ensure lines are fully initialized
     canvas._lines = {
-        "nose": [line_nose],
-        "tail": [line_tail],
+        ("", "nose"): [line_nose],
+        ("", "tail"): [line_tail],
     }
 
     layer.selected_data.clear()
@@ -36,22 +39,26 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
 
 @pytest.mark.e2e
 @pytest.mark.usefixtures("qtbot")
-def test_sync_visible_lines_to_points_selection_filters_by_selected_labels(viewer, qtbot):
+def test_sync_visible_lines_to_points_selection_filters_by_selected_labels_in_bodypart_mode(viewer, qtbot):
     layer = viewer.add_points(
         np.array([[0, 0], [1, 1], [2, 2]]),
         properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
     )
 
-    canvas = TrajectoryMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer, get_color_mode=lambda: "bodypart")
     qtbot.add_widget(canvas)
+
+    # Force the visibility sync to use this test layer directly.
+    canvas._get_plot_points_layer = lambda: layer
 
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
     qtbot.wait(0)  # ensure lines are fully initialized
+
     canvas._lines = {
-        "nose": [line_nose],
-        "tail": [line_tail],
+        ("", "nose"): [line_nose],
+        ("", "tail"): [line_tail],
     }
 
     # Select a point whose label is "tail"
@@ -64,22 +71,28 @@ def test_sync_visible_lines_to_points_selection_filters_by_selected_labels(viewe
 
 @pytest.mark.e2e
 @pytest.mark.usefixtures("qtbot")
-def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_point_has_that_label(viewer, qtbot):
+def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_point_has_that_label_in_bodypart_mode(
+    viewer, qtbot
+):
     layer = viewer.add_points(
         np.array([[0, 0], [1, 1], [2, 2]]),
         properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
     )
 
-    canvas = TrajectoryMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer, get_color_mode=lambda: "bodypart")
     qtbot.add_widget(canvas)
+
+    # Force the visibility sync to use this test layer directly.
+    canvas._get_plot_points_layer = lambda: layer
 
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
     qtbot.wait(0)  # ensure lines are fully initialized
+
     canvas._lines = {
-        "nose": [line_nose],
-        "tail": [line_tail],
+        ("", "nose"): [line_nose],
+        ("", "tail"): [line_tail],
     }
 
     # Select both nose points

--- a/src/napari_deeplabcut/_tests/ui/test_traj_select.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_select.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selected(viewer, qtbot):
+    layer = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    canvas = KeypointMatplotlibCanvas(viewer)
+    qtbot.addWidget(canvas)
+
+    # Avoid relying on df creation for this focused visibility test
+    canvas.df = object()
+    (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
+    (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    canvas._lines = {
+        "nose": [line_nose],
+        "tail": [line_tail],
+    }
+
+    layer.selected_data.clear()
+    canvas.sync_visible_lines_to_points_selection()
+
+    assert line_nose.get_visible() is True
+    assert line_tail.get_visible() is True
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_sync_visible_lines_to_points_selection_filters_by_selected_labels(viewer, qtbot):
+    layer = viewer.add_points(
+        np.array([[0, 0], [1, 1], [2, 2]]),
+        properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
+    )
+
+    canvas = KeypointMatplotlibCanvas(viewer)
+    qtbot.addWidget(canvas)
+
+    canvas.df = object()
+    (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
+    (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    canvas._lines = {
+        "nose": [line_nose],
+        "tail": [line_tail],
+    }
+
+    # Select a point whose label is "tail"
+    layer.selected_data.select_only(1)
+    canvas.sync_visible_lines_to_points_selection()
+
+    assert line_nose.get_visible() is False
+    assert line_tail.get_visible() is True
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_point_has_that_label(viewer, qtbot):
+    layer = viewer.add_points(
+        np.array([[0, 0], [1, 1], [2, 2]]),
+        properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
+    )
+
+    canvas = KeypointMatplotlibCanvas(viewer)
+    qtbot.addWidget(canvas)
+
+    canvas.df = object()
+    (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
+    (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    canvas._lines = {
+        "nose": [line_nose],
+        "tail": [line_tail],
+    }
+
+    # Select both nose points
+    layer.selected_data.update({0, 2})
+    canvas.sync_visible_lines_to_points_selection()
+
+    assert line_nose.get_visible() is True
+    assert line_tail.get_visible() is False

--- a/src/napari_deeplabcut/_tests/ui/test_traj_select.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_select.py
@@ -15,12 +15,13 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
     )
 
     canvas = TrajectoryMatplotlibCanvas(viewer)
-    qtbot.addWidget(canvas)
+    qtbot.add_widget(canvas)
 
     # Avoid relying on df creation for this focused visibility test
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    qtbot.wait(0)  # ensure lines are fully initialized
     canvas._lines = {
         "nose": [line_nose],
         "tail": [line_tail],
@@ -42,11 +43,12 @@ def test_sync_visible_lines_to_points_selection_filters_by_selected_labels(viewe
     )
 
     canvas = TrajectoryMatplotlibCanvas(viewer)
-    qtbot.addWidget(canvas)
+    qtbot.add_widget(canvas)
 
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    qtbot.wait(0)  # ensure lines are fully initialized
     canvas._lines = {
         "nose": [line_nose],
         "tail": [line_tail],
@@ -69,11 +71,12 @@ def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_poin
     )
 
     canvas = TrajectoryMatplotlibCanvas(viewer)
-    qtbot.addWidget(canvas)
+    qtbot.add_widget(canvas)
 
     canvas.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
     (line_tail,) = canvas.ax.plot([0, 1], [1, 0])
+    qtbot.wait(0)  # ensure lines are fully initialized
     canvas._lines = {
         "nose": [line_nose],
         "tail": [line_tail],

--- a/src/napari_deeplabcut/_tests/ui/test_traj_select.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_select.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
+from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
 
 
 @pytest.mark.e2e
@@ -14,7 +14,7 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
         properties={"label": np.array(["nose", "tail"], dtype=object)},
     )
 
-    canvas = KeypointMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer)
     qtbot.addWidget(canvas)
 
     # Avoid relying on df creation for this focused visibility test
@@ -41,7 +41,7 @@ def test_sync_visible_lines_to_points_selection_filters_by_selected_labels(viewe
         properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
     )
 
-    canvas = KeypointMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer)
     qtbot.addWidget(canvas)
 
     canvas.df = object()
@@ -68,7 +68,7 @@ def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_poin
         properties={"label": np.array(["nose", "tail", "nose"], dtype=object)},
     )
 
-    canvas = KeypointMatplotlibCanvas(viewer)
+    canvas = TrajectoryMatplotlibCanvas(viewer)
     qtbot.addWidget(canvas)
 
     canvas.df = object()

--- a/src/napari_deeplabcut/_tests/utils/test_debug.py
+++ b/src/napari_deeplabcut/_tests/utils/test_debug.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from napari_deeplabcut.utils.debug import (
+    InMemoryDebugRecorder,
+    _safe_tail,
+    collect_environment_summary,
+    format_debug_report,
+    get_debug_recorder,
+    install_debug_recorder,
+    summarize_layer,
+    summarize_viewer,
+)
+
+
+class _BrokenStr:
+    def __str__(self):
+        raise RuntimeError("boom")
+
+
+def _cleanup_logger(logger_name: str) -> None:
+    logger = logging.getLogger(logger_name)
+    recorder = get_debug_recorder(logger_name=logger_name)
+    if recorder is not None:
+        try:
+            logger.removeHandler(recorder)
+        except Exception:
+            pass
+        try:
+            delattr(logger, "_napari_dlc_debug_recorder")
+        except Exception:
+            pass
+
+
+def test_install_debug_recorder_is_idempotent():
+    logger_name = "napari-deeplabcut.test.idempotent"
+    _cleanup_logger(logger_name)
+
+    rec1 = install_debug_recorder(logger_name=logger_name, capacity=50)
+    rec2 = install_debug_recorder(logger_name=logger_name, capacity=999)
+
+    try:
+        assert rec1 is rec2
+        assert get_debug_recorder(logger_name=logger_name) is rec1
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_captures_debug_message():
+    logger_name = "napari-deeplabcut.test.capture"
+    _cleanup_logger(logger_name)
+
+    recorder = install_debug_recorder(logger_name=logger_name, capacity=50)
+    logger = logging.getLogger(logger_name)
+
+    try:
+        logger.debug("hello %s", "world")
+
+        records = recorder.snapshot()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.level == "DEBUG"
+        assert rec.logger_name == logger_name
+        assert rec.message == "hello world"
+        assert rec.exc_text is None
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_captures_exception_text():
+    logger_name = "napari-deeplabcut.test.exc"
+    _cleanup_logger(logger_name)
+
+    recorder = install_debug_recorder(logger_name=logger_name, capacity=50)
+    logger = logging.getLogger(logger_name)
+
+    try:
+        try:
+            raise ValueError("bad things")
+        except ValueError:
+            logger.exception("something failed")
+
+        records = recorder.snapshot()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.message == "something failed"
+        assert rec.exc_text is not None
+        assert "ValueError: bad things" in rec.exc_text
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_is_bounded():
+    recorder = InMemoryDebugRecorder(capacity=3)
+    logger = logging.getLogger("napari-deeplabcut.test.bounded")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        for i in range(10):
+            logger.debug("msg-%d", i)
+
+        records = recorder.snapshot()
+        assert len(records) == 3
+        assert [r.message for r in records] == ["msg-7", "msg-8", "msg-9"]
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_clear_resets_records_and_dropped_count():
+    recorder = InMemoryDebugRecorder(capacity=3)
+    logger = logging.getLogger("napari-deeplabcut.test.clear")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        logger.debug("before clear")
+        assert len(recorder.snapshot()) == 1
+
+        recorder.clear()
+
+        assert recorder.snapshot() == []
+        assert recorder.dropped_count == 0
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_render_text_includes_message_and_level():
+    recorder = InMemoryDebugRecorder(capacity=10)
+    logger = logging.getLogger("napari-deeplabcut.test.render")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        logger.info("hello render")
+        text = recorder.render_text(limit=10)
+
+        assert "INFO" in text
+        assert "hello render" in text
+        assert "napari-deeplabcut.test.render" in text
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_render_text_respects_limit():
+    recorder = InMemoryDebugRecorder(capacity=10)
+    logger = logging.getLogger("napari-deeplabcut.test.limit")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        for i in range(5):
+            logger.debug("line-%d", i)
+
+        text = recorder.render_text(limit=2)
+        assert "line-3" in text
+        assert "line-4" in text
+        assert "line-0" not in text
+        assert "line-1" not in text
+        assert "line-2" not in text
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_emit_handles_unrenderable_message_without_raising():
+    recorder = InMemoryDebugRecorder(capacity=10)
+
+    record = logging.LogRecord(
+        name="napari-deeplabcut.test.unrenderable",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=_BrokenStr(),
+        args=(),
+        exc_info=None,
+    )
+
+    # Should never raise
+    recorder.emit(record)
+
+    records = recorder.snapshot()
+    assert len(records) == 1
+    assert records[0].message == "<unrenderable log message>"
+
+
+class FakeLayer:
+    def __init__(
+        self,
+        *,
+        name="layer",
+        metadata=None,
+        properties=None,
+        data=None,
+        visible=True,
+    ):
+        self.name = name
+        self.metadata = metadata if metadata is not None else {}
+        self.properties = properties if properties is not None else {}
+        self.data = data
+        self.visible = visible
+
+
+class FakeSelection:
+    def __init__(self, active=None):
+        self.active = active
+
+
+class FakeViewerLayers(list):
+    def __init__(self, layers, active=None):
+        super().__init__(layers)
+        self.selection = FakeSelection(active=active)
+
+
+class FakeViewer:
+    def __init__(self, layers, active=None):
+        self.layers = FakeViewerLayers(layers, active=active)
+
+
+def test_safe_tail_redacts_to_last_two_parts():
+    assert _safe_tail("/a/b/c/d.txt").endswith("c/d.txt")
+    assert _safe_tail("single") == "single"
+
+
+def test_collect_environment_summary_contains_expected_keys():
+    env = collect_environment_summary()
+
+    expected = {
+        "python",
+        "platform",
+        "napari-deeplabcut",
+        "napari",
+        "qtpy",
+        "PySide6",
+        "PyQt6",
+        "shiboken6",
+        "numpy",
+        "pydantic",
+        "plugin_module_path",
+    }
+    assert expected.issubset(env.keys())
+
+
+def test_summarize_layer_basic_fields():
+    layer = FakeLayer(
+        name="points",
+        metadata={
+            "project": "/tmp/myproj",
+            "root": "/tmp/data/images",
+            "paths": ["a.png", "b.png"],
+            "header": {"dummy": True},
+            "tables": {"x": "y"},
+            "save_target": {"kind": "gt"},
+        },
+        properties={"label": ["nose"], "id": ["mouse1"]},
+        data=SimpleNamespace(shape=(12, 3)),
+        visible=False,
+    )
+
+    summary = summarize_layer(layer)
+
+    assert summary["name"] == "points"
+    assert summary["type"] == "FakeLayer"
+    assert summary["visible"] is False
+    assert summary["paths_count"] == 2
+    assert summary["has_header"] is True
+    assert summary["has_tables"] is True
+    assert summary["has_save_target"] is True
+    assert "project" in summary
+    assert "root" in summary
+    assert summary["property_keys"] == ["id", "label"]
+    assert summary["data_shape"] == (12, 3)
+
+
+def test_summarize_layer_handles_missing_or_weird_values():
+    layer = FakeLayer(
+        name="empty",
+        metadata=None,
+        properties=None,
+        data=None,
+        visible=True,
+    )
+
+    summary = summarize_layer(layer)
+
+    assert summary["name"] == "empty"
+    assert summary["metadata_keys"] == []
+    assert summary["property_keys"] == []
+    assert summary["data_shape"] is None
+    assert summary["has_header"] is False
+    assert summary["has_tables"] is False
+    assert summary["has_save_target"] is False
+
+
+def test_summarize_viewer_basic():
+    layer1 = FakeLayer(name="img")
+    layer2 = FakeLayer(name="pts")
+    viewer = FakeViewer([layer1, layer2], active=layer2)
+
+    summary = summarize_viewer(viewer)
+
+    assert summary["n_layers"] == 2
+    assert summary["active_layer"] == "pts"
+    assert len(summary["layers"]) == 2
+    assert summary["layers"][0]["name"] == "img"
+    assert summary["layers"][1]["name"] == "pts"
+
+
+def test_format_debug_report_contains_sections():
+    text = format_debug_report(
+        env={"python": "3.x", "platform": "test-os"},
+        viewer_summary={
+            "n_layers": 2,
+            "active_layer": "pts",
+            "layers": [
+                {
+                    "name": "pts",
+                    "type": "Points",
+                    "visible": True,
+                    "data_shape": (10, 3),
+                    "metadata_keys": ["header", "paths"],
+                    "property_keys": ["label"],
+                    "project": "proj/config",
+                    "root": "data/images",
+                    "paths_count": 2,
+                    "has_header": True,
+                    "has_tables": False,
+                    "has_save_target": False,
+                }
+            ],
+        },
+        logs_text="12:00:00 | DEBUG | napari-deeplabcut | hello",
+    )
+
+    assert "## Environment" in text
+    assert "## Viewer" in text
+    assert "## Layers" in text
+    assert "## Recent plugin logs" in text
+    assert "hello" in text
+    assert "pts" in text

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -3,10 +3,16 @@
 NOTE: This file is generally already too long. For future development, please consider:
 - Moving existing responsibilities out into separate modules (existing or new)
 - Avoiding adding anything that is not strictly related to :
-  - Building the final UI (blocks can be moved to ui/ for better organization)
-  - Wiring to the core plugin functionality (e.g. via signals/slots, method calls, etc.)
-  - Anything that requires the full widget+viewer+signal/event context to function properly
-  - Similarly, test_widgets.py is a bit of a default drawer right now, please create new tests in _tests/ui
+    - Building the final UI (blocks can be moved to ui/ for better organization)
+    - Wiring to the core plugin functionality (e.g. via signals/slots, method calls, etc.)
+    - Anything that requires the full widget+viewer+signal/event context to function properly
+    - Similarly, test_widgets.py is a bit of a default drawer right now, please create new tests in _tests/ui
+- Lifecycle of UI elements and Qt wiring should ideally:
+    - Use parent child widgets/controllers to KeypointControls
+    - Use child QTimers instead of fire-and-forget QTimer.singleShot for deferred UI work
+    - Use normal Qt signal connections for Qt-owned objects
+    - Keep explicit cleanup only for non-Qt subscriptions/resources
+    (e.g. napari event connections, observer install/uninstall, monkey-patch restoration)
 """
 
 # src/napari_deeplabcut/_widgets.py

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -204,7 +204,9 @@ class KeypointControls(QWidget):
         # for future-proofing
         def _close_event(event):
             self.on_close(event)
-            self._points_interactions.close()
+            points_inter = getattr(self, "_points_interactions", None)
+            if points_inter is not None:
+                points_inter.close()
             # if accepted, call original
             if event.isAccepted():
                 orig_close_event(event)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -266,7 +266,11 @@ class KeypointControls(QWidget):
         )
 
         self._mpl_docked = False
-        self._traj_mpl_canvas = TrajectoryMatplotlibCanvas(self.viewer)
+
+        self._traj_mpl_canvas = TrajectoryMatplotlibCanvas(
+            self.viewer,
+            get_color_mode=lambda: self.color_mode,
+        )
         self._show_traj_plot_cb = QCheckBox("Show trajectories", parent=self)
         self._show_traj_plot_cb.setToolTip("Toggle to see trajectories in a t-y plot outside of the main video viewer")
         self._show_traj_plot_cb.stateChanged.connect(self._show_traj_canvas)
@@ -1841,6 +1845,13 @@ class KeypointControls(QWidget):
             if btn.text().lower() == str(mode).lower():
                 btn.setChecked(True)
                 break
+
+        traj_canvas = self._safe_get_traj_canvas()
+        if traj_canvas is not None:
+            try:
+                traj_canvas.refresh_from_viewer_layers()
+            except Exception:
+                logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
 
         self._update_color_scheme()
         self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -125,7 +125,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
     KeypointsDropdownMenu,
 )
 from napari_deeplabcut.ui.layer_stats import LayerStatusPanel
-from napari_deeplabcut.ui.plots.trajectory import KeypointMatplotlibCanvas
+from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -257,10 +257,10 @@ class KeypointControls(QWidget):
         )
 
         self._mpl_docked = False
-        self._matplotlib_canvas = KeypointMatplotlibCanvas(self.viewer)
+        self._traj_mpl_canvas = TrajectoryMatplotlibCanvas(self.viewer)
         self._show_traj_plot_cb = QCheckBox("Show trajectories", parent=self)
         self._show_traj_plot_cb.setToolTip("Toggle to see trajectories in a t-y plot outside of the main video viewer")
-        self._show_traj_plot_cb.stateChanged.connect(self._show_matplotlib_canvas)
+        self._show_traj_plot_cb.stateChanged.connect(self._show_traj_canvas)
         self._show_traj_plot_cb.setChecked(False)
         self._show_traj_plot_cb.setEnabled(False)
         self._view_scheme_cb = QCheckBox("Show color scheme", parent=self)
@@ -363,7 +363,7 @@ class KeypointControls(QWidget):
         # NOTE while a timer may seem hacky, it is a simple, one-line solution that minimizes intrusion
         # There are to my knowledge no other way that is as concise and clean
         # (Of course this will be a problem if we start using it everywhere so do not reuse lightly)
-        QTimer.singleShot(10, self.silently_dock_matplotlib_canvas)
+        QTimer.singleShot(10, self.silently_dock_canvas)
 
         # If layers already exist (user loaded data before opening this widget),
         # adopt them so keypoint controls take ownership immediately.
@@ -654,7 +654,7 @@ class KeypointControls(QWidget):
 
         QTimer.singleShot(0, _do)
 
-    def _ensure_mpl_canvas_docked(self) -> None:
+    def _ensure_traj_canvas_docked(self) -> None:
         """
         Dock the Matplotlib canvas as a napari dock widget, exactly once,
         and only if the Qt window exists. Safe no-op in headless/proxy teardown.
@@ -670,34 +670,49 @@ class KeypointControls(QWidget):
             return
 
         try:
-            window.add_dock_widget(self._matplotlib_canvas, name="Trajectory plot", area="right", tabify=False)
-            self._matplotlib_canvas.canvas.draw_idle()
-            self._matplotlib_canvas.hide()
+            window.add_dock_widget(self._traj_mpl_canvas, name="Trajectory plot", area="right", tabify=False)
+            self._traj_mpl_canvas.canvas.draw_idle()
+            self._traj_mpl_canvas.hide()
             self._mpl_docked = True
         except Exception as e:
             logging.debug("Skipping docking KeypointMatplotlibCanvas (not ready / teardown): %r", e)
             return
 
-    def silently_dock_matplotlib_canvas(self) -> None:
-        """Dock the Matplotlib canvas without showing it."""
-        self._ensure_mpl_canvas_docked()
-        if self._mpl_docked:
-            self._matplotlib_canvas.hide()
+    def _safe_get_traj_canvas(self):
+        canvas = getattr(self, "_traj_mpl_canvas", None)
+        if canvas is None:
+            return None
 
-    def _show_matplotlib_canvas(self, state):
+        try:
+            # Any Qt call is enough to verify the underlying C++ object still exists
+            canvas.isVisible()
+        except RuntimeError:
+            # Underlying Qt object was already deleted
+            self._traj_mpl_canvas = None
+            return None
+
+        return canvas
+
+    def silently_dock_canvas(self) -> None:
+        """Dock the Matplotlib canvas without showing it."""
+        self._ensure_traj_canvas_docked()
+        if self._mpl_docked:
+            self._traj_mpl_canvas.hide()
+
+    def _show_traj_canvas(self, state):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
-            self._ensure_mpl_canvas_docked()
+            self._ensure_traj_canvas_docked()
             if self._mpl_docked:
-                self._matplotlib_canvas._apply_napari_theme()
-                self._matplotlib_canvas.update_plot_range(
+                self._traj_mpl_canvas._apply_napari_theme()
+                self._traj_mpl_canvas.update_plot_range(
                     Event(type_name="", value=[self.viewer.dims.current_step[0]]),
                     force=True,
                 )
-                self._matplotlib_canvas.sync_visible_lines_to_points_selection()
-                self._matplotlib_canvas.show()
+                self._traj_mpl_canvas.sync_visible_lines_to_points_selection()
+                self._traj_mpl_canvas.show()
         else:
             if self._mpl_docked:
-                self._matplotlib_canvas.hide()
+                self._traj_mpl_canvas.hide()
 
     def _on_points_interaction(self, event: PointsInteractionEvent) -> None:
         """
@@ -707,15 +722,11 @@ class KeypointControls(QWidget):
         - no selected points -> all trajectories
         - selected points    -> only selected labels' trajectories
         """
+        traj_canvas = self._safe_get_traj_canvas()
+        if traj_canvas is None or not traj_canvas.isVisible():
+            return
         if {"selection", "active_layer", "layers"} & set(event.reasons):
-            self._matplotlib_canvas.sync_visible_lines_to_points_selection()
-
-    # def _on_color_scheme_label_clicked(self, _text: str) -> None:
-    #     """
-    #     Let the color-scheme panel perform its normal point-selection logic first,
-    #     then sync the trajectory plot visibility to the resulting napari selection.
-    #     """
-    #     QTimer.singleShot(0, self._matplotlib_canvas.sync_visible_lines_to_points_selection)
+            traj_canvas.sync_visible_lines_to_points_selection()
 
     def _refresh_trajectory_plot_from_layers(self) -> None:
         """
@@ -723,7 +734,9 @@ class KeypointControls(QWidget):
 
         Deferred through QTimer so it runs after layer adoption/remap settles.
         """
-        QTimer.singleShot(0, self._matplotlib_canvas.refresh_from_viewer_layers)
+        traj_canvas = self._safe_get_traj_canvas()
+        if traj_canvas is not None:
+            QTimer.singleShot(0, traj_canvas.refresh_from_viewer_layers)
 
     def load_superkeypoints_diagram(self):
         points_layer = get_first_points_layer(self.viewer)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -204,6 +204,7 @@ class KeypointControls(QWidget):
         # for future-proofing
         def _close_event(event):
             self.on_close(event)
+            self._points_interactions.close()
             # if accepted, call original
             if event.isAccepted():
                 orig_close_event(event)
@@ -681,7 +682,7 @@ class KeypointControls(QWidget):
             self._traj_mpl_canvas.hide()
             self._mpl_docked = True
         except Exception as e:
-            logging.debug("Skipping docking KeypointMatplotlibCanvas (not ready / teardown): %r", e)
+            logging.debug("Skipping docking canvas (not ready / teardown): %r", e)
             return
 
     def _safe_get_traj_canvas(self):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -688,6 +688,7 @@ class KeypointControls(QWidget):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._ensure_mpl_canvas_docked()
             if self._mpl_docked:
+                self._matplotlib_canvas._apply_napari_theme()
                 self._matplotlib_canvas.update_plot_range(
                     Event(type_name="", value=[self.viewer.dims.current_step[0]]),
                     force=True,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -196,10 +196,11 @@ class KeypointControls(QWidget):
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
 
-        show_debug_action = QAction("&Generate debug log", self)
+        show_debug_action = QAction("&Generate napari-dlc log", self)
         show_debug_action.setToolTip("Show a debug report with recent plugin logs")
         show_debug_action.triggered.connect(self._show_debug_window)
         self.viewer.window.help_menu.addAction(show_debug_action)
+        ###########
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
         #     _get_and_try_preferred_reader,
@@ -367,12 +368,12 @@ class KeypointControls(QWidget):
                 self.viewer.window.file_menu.removeAction(action)
 
         # Add action to show the walkthrough again
-        launch_tutorial = QAction("&Launch Tutorial", self)
+        launch_tutorial = QAction("&Launch napari-dlc tutorial", self)
         launch_tutorial.triggered.connect(self.start_tutorial)
         self.viewer.window.view_menu.addAction(launch_tutorial)
 
         # Add action to view keyboard shortcuts
-        display_shortcuts_action = QAction("&Shortcuts", self)
+        display_shortcuts_action = QAction("&Show napari-dlc shortcuts", self)
         display_shortcuts_action.triggered.connect(self.display_shortcuts)
         self.viewer.window.help_menu.addAction(display_shortcuts_action)
         # Install global keybinds
@@ -501,7 +502,7 @@ class KeypointControls(QWidget):
                 self._debug_window = DebugTextWindow(
                     title="napari-deeplabcut debug info",
                     text_provider=provider,
-                    parent=self.viewer.window._qt_window,
+                    parent=self,
                     initial_hint="Read-only diagnostics. Paste this into a bug report if needed.",
                 )
                 self._debug_window.finished.connect(lambda _result: setattr(self, "_debug_window", None))

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -136,6 +136,7 @@ from napari_deeplabcut.ui.cropping import (
     run_store_crop_coordinates,
     update_video_panel_context,
 )
+from napari_deeplabcut.ui.debug_window import DebugTextWindow, make_issue_report_provider
 from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
 from napari_deeplabcut.ui.labels_and_dropdown import (
     DropdownMenu,
@@ -143,6 +144,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
 )
 from napari_deeplabcut.ui.layer_stats import LayerStatusPanel
 from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
+from napari_deeplabcut.utils.debug import get_debug_recorder, install_debug_recorder
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -189,6 +191,15 @@ class KeypointControls(QWidget):
 
         self.viewer.layers.events.inserted.connect(self.on_insert)
         self.viewer.layers.events.removed.connect(self.on_remove)
+
+        ## Debug ##
+        self._debug_recorder = install_debug_recorder()
+        self._debug_window = None
+
+        show_debug_action = QAction("&Generate debug log", self)
+        show_debug_action.setToolTip("Show a debug report with recent plugin logs")
+        show_debug_action.triggered.connect(self._show_debug_window)
+        self.viewer.window.help_menu.addAction(show_debug_action)
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
         #     _get_and_try_preferred_reader,
@@ -399,6 +410,109 @@ class KeypointControls(QWidget):
     @cached_property
     def settings(self):
         return QSettings()
+
+    @register_points_action("Change labeling mode")
+    def cycle_through_label_modes(self, *args):
+        self.label_mode = next(keypoints.LabelMode)
+
+    @register_points_action("Change color mode")
+    def cycle_through_color_modes(self, *args):
+        if self._active_layer_is_multianimal() or self.color_mode != str(keypoints.ColorMode.BODYPART):
+            self.color_mode = next(keypoints.ColorMode)
+
+    @property
+    def label_mode(self):
+        return str(self._label_mode)
+
+    @label_mode.setter
+    def label_mode(self, mode: str | keypoints.LabelMode):
+        self._label_mode = keypoints.LabelMode(mode)
+        self.viewer.status = self.label_mode
+        mode_ = str(mode).lower()
+        if mode_ == keypoints.LabelMode.LOOP.value.lower():
+            for menu in self._menus:
+                menu._locked = True
+        else:
+            for menu in self._menus:
+                menu._locked = False
+        for btn in self._radio_group.buttons():
+            if btn.text().lower() == mode_:
+                btn.setChecked(True)
+                break
+
+    @property
+    def color_mode(self):
+        return str(self._color_mode)
+
+    @color_mode.setter
+    def color_mode(self, mode: str | keypoints.ColorMode):
+        self._color_mode = keypoints.ColorMode(mode)
+
+        for layer in list(self._stores.keys()):
+            if isinstance(layer, Points) and layer.metadata:
+                self._apply_points_coloring_from_metadata(layer)
+
+        for btn in self._color_mode_selector.buttons():
+            if btn.text().lower() == str(mode).lower():
+                btn.setChecked(True)
+                break
+
+        traj_canvas = self._safe_get_traj_canvas()
+        if traj_canvas is not None:
+            try:
+                traj_canvas.refresh_from_viewer_layers()
+            except Exception:
+                logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
+
+        self._update_color_scheme()
+        self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
+
+    def _is_multianimal(self, layer) -> bool:
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        md = layer.metadata or {}
+        hdr = self._get_header_model_from_metadata(md)
+        if hdr is None:
+            return False
+
+        try:
+            inds = hdr.individuals
+            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+        except Exception:
+            return False
+
+    def _active_layer_is_multianimal(self) -> bool:
+        """Returns: whether the active layer is a multi-animal points layer"""
+        for layer in self.viewer.layers.selection:
+            if self._is_multianimal(layer):
+                return True
+
+        return False
+
+    def _show_debug_window(self) -> None:
+        try:
+            if self._debug_window is None:
+                provider = make_issue_report_provider(
+                    viewer=self.viewer,
+                    recorder=get_debug_recorder(),
+                    log_limit=300,
+                )
+                self._debug_window = DebugTextWindow(
+                    title="napari-deeplabcut debug info",
+                    text_provider=provider,
+                    parent=self.viewer.window._qt_window,
+                    initial_hint="Read-only diagnostics. Paste this into a bug report if needed.",
+                )
+                self._debug_window.finished.connect(lambda _result: setattr(self, "_debug_window", None))
+
+            self._debug_window.show()
+            self._debug_window.raise_()
+            self._debug_window.activateWindow()
+
+        except Exception:
+            logger.debug("Failed to open debug window", exc_info=True)
+            self.viewer.status = "Could not open debug window"
 
     # ######################## #
     # Layer setup core methods #
@@ -1802,85 +1916,6 @@ class KeypointControls(QWidget):
 
             self._update_color_scheme()
             self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
-
-    @register_points_action("Change labeling mode")
-    def cycle_through_label_modes(self, *args):
-        self.label_mode = next(keypoints.LabelMode)
-
-    @register_points_action("Change color mode")
-    def cycle_through_color_modes(self, *args):
-        if self._active_layer_is_multianimal() or self.color_mode != str(keypoints.ColorMode.BODYPART):
-            self.color_mode = next(keypoints.ColorMode)
-
-    @property
-    def label_mode(self):
-        return str(self._label_mode)
-
-    @label_mode.setter
-    def label_mode(self, mode: str | keypoints.LabelMode):
-        self._label_mode = keypoints.LabelMode(mode)
-        self.viewer.status = self.label_mode
-        mode_ = str(mode).lower()
-        if mode_ == keypoints.LabelMode.LOOP.value.lower():
-            for menu in self._menus:
-                menu._locked = True
-        else:
-            for menu in self._menus:
-                menu._locked = False
-        for btn in self._radio_group.buttons():
-            if btn.text().lower() == mode_:
-                btn.setChecked(True)
-                break
-
-    @property
-    def color_mode(self):
-        return str(self._color_mode)
-
-    @color_mode.setter
-    def color_mode(self, mode: str | keypoints.ColorMode):
-        self._color_mode = keypoints.ColorMode(mode)
-
-        for layer in list(self._stores.keys()):
-            if isinstance(layer, Points) and layer.metadata:
-                self._apply_points_coloring_from_metadata(layer)
-
-        for btn in self._color_mode_selector.buttons():
-            if btn.text().lower() == str(mode).lower():
-                btn.setChecked(True)
-                break
-
-        traj_canvas = self._safe_get_traj_canvas()
-        if traj_canvas is not None:
-            try:
-                traj_canvas.refresh_from_viewer_layers()
-            except Exception:
-                logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
-
-        self._update_color_scheme()
-        self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
-
-    def _is_multianimal(self, layer) -> bool:
-        if layer is None or not isinstance(layer, Points):
-            return False
-
-        md = layer.metadata or {}
-        hdr = self._get_header_model_from_metadata(md)
-        if hdr is None:
-            return False
-
-        try:
-            inds = hdr.individuals
-            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
-        except Exception:
-            return False
-
-    def _active_layer_is_multianimal(self) -> bool:
-        """Returns: whether the active layer is a multi-animal points layer"""
-        for layer in self.viewer.layers.selection:
-            if self._is_multianimal(layer):
-                return True
-
-        return False
 
     def _resolved_cycle_for_layer(self, layer: Points) -> dict:
         """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1091,15 +1091,7 @@ class KeypointControls(QWidget):
         self._layer_status_panel.set_point_size(get_uniform_point_size(active_dlc_points))
 
         progress = compute_label_progress(active_dlc_points, fallback_paths=self._image_meta.paths)
-        self._layer_status_panel.set_progress_summary(
-            labeled_percent=progress.labeled_percent,
-            remaining_percent=progress.remaining_percent,
-            labeled_points=progress.labeled_points,
-            total_points=progress.total_points,
-            frame_count=progress.frame_count,
-            bodypart_count=progress.bodypart_count,
-            individual_count=progress.individual_count,
-        )
+        self._layer_status_panel.set_progress_summary(progress=progress)
 
     def _on_active_points_size_changed(self, size: int) -> None:
         layer = self._current_dlc_points_layer()
@@ -1269,7 +1261,7 @@ class KeypointControls(QWidget):
         layout = QHBoxLayout()
         group = QButtonGroup(self)
         for i, mode in enumerate(keypoints.ColorMode.__members__, start=1):
-            btn = QRadioButton(mode.lower())
+            btn = QRadioButton(mode.capitalize())
             group.addButton(btn, i)
             layout.addWidget(btn)
         group.button(1).setChecked(True)
@@ -1277,7 +1269,7 @@ class KeypointControls(QWidget):
         self._layout.addWidget(group_box)
 
         def _func():
-            self.color_mode = group.checkedButton().text()
+            self.color_mode = group.checkedButton().text().lower()
 
         group.buttonClicked.connect(_func)
         return group_box, group

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -13,6 +13,17 @@ NOTE: This file is generally already too long. For future development, please co
     - Use normal Qt signal connections for Qt-owned objects
     - Keep explicit cleanup only for non-Qt subscriptions/resources
     (e.g. napari event connections, observer install/uninstall, monkey-patch restoration)
+
+TODO: And general dev notes:
+- The saving workflow is crammed into save_layers_dialog() right now,
+  and should move to a dedicated  e.g. PointsLayerSaveFactory class in a dedicated file.
+- Project/root/paths/image-meta/points-meta synchronization should be centralized.
+  It is too distributed right now, and it can be unclear "which truth" is authoritative.
+  Some sort of context-manager class would likely help.
+- Maybe a dedicated layer lifecycle system would help, for layer adoption and setup.
+- Something that owns UI sync state (what to refresh, why, when) could help with the heavy wiring.
+- I'd suggest keeping in this file:
+    - color/label mode, menu/help actions, widget visibility and user interaction hooks.
 """
 
 # src/napari_deeplabcut/_widgets.py

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -542,15 +542,30 @@ class KeypointControls(QWidget):
 
         self._sync_points_layers_from_image_meta()
         self._refresh_video_panel_context()
+        logger.debug(
+            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r",
+            getattr(layer, "name", layer),
+            index,
+            reorder,
+            len(md.get("paths") or []),
+            md.get("root"),
+        )
 
         if reorder and index is not None:
             QTimer.singleShot(10, partial(self._move_image_layer_to_bottom, index))
 
     def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
-        if not layer.metadata.get("project", "") or not self._stores:
+        md = layer.metadata or {}
+        logger.debug(
+            "Maybe merge config points layer=%r project=%r stores=%d",
+            getattr(layer, "name", layer),
+            md.get("project"),
+            len(self._stores),
+        )
+        if not md.get("project", "") or not self._stores:
             return False
 
-        new_metadata = layer.metadata.copy()
+        new_metadata = md.copy()
 
         keypoints_menu = self._menus[0].menus["label"]
         current_keypoint_set = {keypoints_menu.itemText(i) for i in range(keypoints_menu.count())}
@@ -564,6 +579,11 @@ class KeypointControls(QWidget):
             answer = QMessageBox.question(self, "", "Do you want to display the new keypoints only?")
             if answer == QMessageBox.Yes:
                 self.viewer.layers[-2].shown = False
+                logger.debug(
+                    "Merging config points layer=%r new_keypoints=%s",
+                    getattr(layer, "name", layer),
+                    sorted(diff),
+                )
 
             self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
             for _layer, store in self._stores.items():
@@ -704,6 +724,16 @@ class KeypointControls(QWidget):
         self._trail_cb.setEnabled(True)
         self._show_traj_plot_cb.setEnabled(True)
 
+        md = layer.metadata or {}
+        logger.debug(
+            "Wire points layer=%r existing_store=%s project=%s root=%s len_paths=%s",
+            getattr(layer, "name", layer),
+            getattr(layer, "_dlc_store", None) is not None,
+            md.get("project"),
+            md.get("root"),
+            len(md.get("paths", [])),
+        )
+
         return store
 
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
@@ -728,6 +758,12 @@ class KeypointControls(QWidget):
                 pass
 
         self._update_color_scheme()
+        logger.debug(
+            "Setup points layer=%r allow_merge=%s metadata_keys=%s",
+            getattr(layer, "name", layer),
+            allow_merge,
+            sorted((layer.metadata or {}).keys()),
+        )
 
     def _adopt_existing_layers(self) -> None:
         """
@@ -735,6 +771,7 @@ class KeypointControls(QWidget):
         run the same initialization as if they had been inserted.
         """
         # Iterate over a snapshot, because on_insert may modify layer order
+        logger.debug("Adopting existing layers count=%d", len(self.viewer.layers))
         layers_snapshot = list(self.viewer.layers)
 
         for idx, layer in enumerate(layers_snapshot):
@@ -759,6 +796,12 @@ class KeypointControls(QWidget):
         Run the relevant portion of on_insert() for an already-existing layer.
         This avoids duplicating your logic and prevents reliance on napari's Event object.
         """
+        logger.debug(
+            "Adopt layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            index,
+        )
         if isinstance(layer, Image):
             self._setup_image_layer(layer, index, reorder=True)
         elif isinstance(layer, Points):
@@ -1556,6 +1599,12 @@ class KeypointControls(QWidget):
 
     def on_insert(self, event):
         layer = event.source[-1]
+        logger.debug(
+            "on_insert layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            getattr(event, "index", None),
+        )
         if isinstance(layer, Image):
             self._setup_image_layer(layer, event.index, reorder=True)
         elif isinstance(layer, Points):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -61,6 +61,8 @@ from napari_deeplabcut.core.config_sync import (
 from napari_deeplabcut.core.conflicts import compute_overwrite_report_for_points_save
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
 from napari_deeplabcut.core.layers import (
+    PointsInteractionEvent,
+    PointsInteractionObserver,
     compute_label_progress,
     find_relevant_image_layer,
     get_first_points_layer,
@@ -299,9 +301,17 @@ class KeypointControls(QWidget):
         self._view_scheme_cb.setChecked(True)
         self._view_scheme_cb.toggled.connect(self._show_color_scheme)
         self._show_color_scheme()
-        self._color_scheme_panel.display.added.connect(
-            lambda w: w.part_label.clicked.connect(self._matplotlib_canvas._toggle_line_visibility),
+        # self._color_scheme_panel.display.added.connect(
+        #     lambda w: w.part_label.clicked.connect(self._on_color_scheme_label_clicked),
+        # )
+
+        self._points_interactions = PointsInteractionObserver(
+            self.viewer,
+            self._on_points_interaction,
+            debounce_ms=0,
+            watch_content=False,
         )
+        self._points_interactions.install()
         ### UI setup ends here
 
         # Modes init
@@ -361,6 +371,10 @@ class KeypointControls(QWidget):
 
         # Refresh layers stats widget
         QTimer.singleShot(0, self._refresh_layer_status_panel)
+
+    @cached_property
+    def settings(self):
+        return QSettings()
 
     # ######################## #
     # Layer setup core methods #
@@ -596,6 +610,11 @@ class KeypointControls(QWidget):
         except Exception:
             pass
 
+        # Important: refresh the trajectory plot from the final adopted state.
+        # This fixes the case where layers were loaded before the plugin opened
+        # (e.g. drag-and-drop DLC data triggering the reader automatically).
+        self._refresh_trajectory_plot_from_layers()
+
     def _adopt_layer(self, layer, index: int) -> None:
         """
         Run the relevant portion of on_insert() for an already-existing layer.
@@ -647,10 +666,7 @@ class KeypointControls(QWidget):
         if window is None:
             return
 
-        # If napari hasn't materialized its Qt window yet, skip (safe no-op).
         if getattr(window, "_qt_window", None) is None:
-            # In normal UI runs this won't happen when the user hits the checkbox.
-            # In tests/headless it may—so just do nothing.
             return
 
         try:
@@ -672,14 +688,41 @@ class KeypointControls(QWidget):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._ensure_mpl_canvas_docked()
             if self._mpl_docked:
+                self._matplotlib_canvas.update_plot_range(
+                    Event(type_name="", value=[self.viewer.dims.current_step[0]]),
+                    force=True,
+                )
+                self._matplotlib_canvas.sync_visible_lines_to_points_selection()
                 self._matplotlib_canvas.show()
         else:
             if self._mpl_docked:
                 self._matplotlib_canvas.hide()
 
-    @cached_property
-    def settings(self):
-        return QSettings()
+    def _on_points_interaction(self, event: PointsInteractionEvent) -> None:
+        """
+        Keep the trajectory plot in sync with the active points-layer selection.
+
+        This is intentionally selection-driven:
+        - no selected points -> all trajectories
+        - selected points    -> only selected labels' trajectories
+        """
+        if {"selection", "active_layer", "layers"} & set(event.reasons):
+            self._matplotlib_canvas.sync_visible_lines_to_points_selection()
+
+    # def _on_color_scheme_label_clicked(self, _text: str) -> None:
+    #     """
+    #     Let the color-scheme panel perform its normal point-selection logic first,
+    #     then sync the trajectory plot visibility to the resulting napari selection.
+    #     """
+    #     QTimer.singleShot(0, self._matplotlib_canvas.sync_visible_lines_to_points_selection)
+
+    def _refresh_trajectory_plot_from_layers(self) -> None:
+        """
+        Refresh trajectory plot from the current viewer state.
+
+        Deferred through QTimer so it runs after layer adoption/remap settles.
+        """
+        QTimer.singleShot(0, self._matplotlib_canvas.refresh_from_viewer_layers)
 
     def load_superkeypoints_diagram(self):
         points_layer = get_first_points_layer(self.viewer)

--- a/src/napari_deeplabcut/config/_autostart.py
+++ b/src/napari_deeplabcut/config/_autostart.py
@@ -50,6 +50,9 @@ def _ensure_keypoint_controls_open(viewer) -> None:
         )
     except Exception:
         logger.debug("Failed to open Keypoint controls dock widget.", exc_info=True)
+        napari.utils.notifications.show_info(
+            "Failed to open Keypoint controls. Please open manually from the Plugins menu.",
+        )
 
 
 def _maybe_open_for_inserted_layer(viewer, layer) -> None:

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -10,6 +10,8 @@ from typing import Any
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+# TODO @C-Achard: move to core/
+
 
 def unsorted_unique(array: Sequence) -> np.ndarray:
     """Return the unsorted unique elements of an array."""

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -445,10 +445,16 @@ def capture_points_state(
     This is intentionally separate from the observer so callers can choose
     whether they want lightweight interaction events or heavier snapshots.
     """
+    data = getattr(layer, "data", None)
+    try:
+        n_points = 0 if data is None else len(data)
+    except Exception:
+        n_points = 0
+
     state: dict[str, Any] = {
         "name": getattr(layer, "name", None),
         "selected_data": tuple(sorted(int(i) for i in getattr(layer, "selected_data", set()) or set())),
-        "n_points": len(getattr(layer, "data", []) or []),
+        "n_points": n_points,
     }
 
     if include_data:

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -8,6 +8,7 @@ from typing import Any, TypeVar
 
 import numpy as np
 from napari.layers import Image, Points, Shapes, Tracks
+from qtpy.QtCore import QTimer
 
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel
 from napari_deeplabcut.core.keypoints import build_color_cycles
@@ -390,3 +391,228 @@ def find_relevant_image_layer(viewer) -> Image | None:
             return layer
 
     return None
+
+
+# -----------------------------------------------
+#  Points interaction observer
+# -----------------------------------------------
+
+
+@dataclass(frozen=True)
+class PointsInteractionEvent:
+    """
+    Structured points-layer interaction event.
+
+    Parameters
+    ----------
+    viewer:
+        The napari viewer.
+    layer:
+        The active Points layer at the time the event flushes, or None.
+    reasons:
+        A normalized set of reasons that triggered the event. Typical values:
+        {"selection"}, {"active_layer"}, {"layers"}, {"data"}, {"properties"}.
+    """
+
+    viewer: Any
+    layer: Points | None
+    reasons: frozenset[str]
+
+
+def _iter_event_emitters(event_group: Any, names: tuple[str, ...]):
+    """
+    Yield (name, emitter) pairs for names that exist on an event group.
+    """
+    if event_group is None:
+        return
+    for name in names:
+        emitter = getattr(event_group, name, None)
+        if emitter is not None:
+            yield name, emitter
+
+
+def capture_points_state(
+    layer: Points,
+    *,
+    include_data: bool = False,
+    include_properties: bool = False,
+) -> dict[str, Any]:
+    """
+    Best-effort snapshot helper for future history/undo systems.
+
+    This is intentionally separate from the observer so callers can choose
+    whether they want lightweight interaction events or heavier snapshots.
+    """
+    state: dict[str, Any] = {
+        "name": getattr(layer, "name", None),
+        "selected_data": tuple(sorted(int(i) for i in getattr(layer, "selected_data", set()) or set())),
+        "n_points": len(getattr(layer, "data", []) or []),
+    }
+
+    if include_data:
+        try:
+            state["data"] = getattr(layer, "data", None).copy()
+        except Exception:
+            state["data"] = None
+
+    if include_properties:
+        try:
+            props = getattr(layer, "properties", {}) or {}
+            state["properties"] = {k: v.copy() if hasattr(v, "copy") else v for k, v in dict(props).items()}
+        except Exception:
+            state["properties"] = None
+
+    return state
+
+
+class PointsInteractionObserver:
+    """
+    Observe the active napari Points layer and emit coalesced interaction events.
+
+    Public / stable anchors used
+    ----------------------------
+    - viewer.layers.selection.events.active
+    - layer.selected_data.events.changed / active
+    - layer.selected_data.events.items_changed (if present; useful in practice)
+    - viewer.layers.events.inserted / removed / reordered (if present)
+
+    Notes
+    -----
+    This is intentionally conservative:
+    - it avoids private napari APIs
+    - it tolerates event-name differences by connecting only to emitters that exist
+    - it coalesces bursts of events into one callback using a QTimer
+    """
+
+    def __init__(
+        self,
+        viewer: Any,
+        callback: Callable[[PointsInteractionEvent], None],
+        *,
+        debounce_ms: int = 0,
+        watch_content: bool = False,
+    ) -> None:
+        self.viewer = viewer
+        self.callback = callback
+        self.debounce_ms = max(0, int(debounce_ms))
+        self.watch_content = watch_content
+
+        self._active_layer: Points | None = None
+        self._viewer_connections: list[tuple[Any, Callable]] = []
+        self._layer_connections: list[tuple[Any, Callable]] = []
+        self._pending_reasons: set[str] = set()
+
+        self._timer = QTimer()
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._flush)
+
+    # ------------------------------------------------------------------
+    # Public lifecycle
+    # ------------------------------------------------------------------
+
+    def install(self) -> None:
+        """
+        Install the observer onto the viewer.
+        """
+        self._connect_viewer_events()
+        self._rebind_active_points_layer()
+        self._schedule("install")
+
+    def close(self) -> None:
+        """
+        Disconnect all emitters and stop the timer.
+        """
+        self._timer.stop()
+        self._disconnect_all(self._layer_connections)
+        self._disconnect_all(self._viewer_connections)
+        self._active_layer = None
+        self._pending_reasons.clear()
+
+    # ------------------------------------------------------------------
+    # Internal connection helpers
+    # ------------------------------------------------------------------
+
+    def _connect(self, emitter: Any, callback: Callable, bucket: list[tuple[Any, Callable]]) -> None:
+        emitter.connect(callback)
+        bucket.append((emitter, callback))
+
+    def _disconnect_all(self, bucket: list[tuple[Any, Callable]]) -> None:
+        while bucket:
+            emitter, callback = bucket.pop()
+            try:
+                emitter.disconnect(callback)
+            except Exception:
+                pass
+
+    def _connect_viewer_events(self) -> None:
+        # Active layer changes are the most important public hook.
+        active_emitter = getattr(self.viewer.layers.selection.events, "active", None)
+        if active_emitter is not None:
+            self._connect(active_emitter, self._on_active_layer_changed, self._viewer_connections)
+
+        layer_events = getattr(self.viewer.layers, "events", None)
+        for _name, emitter in _iter_event_emitters(layer_events, ("inserted", "removed", "reordered")):
+            self._connect(emitter, self._on_layers_changed, self._viewer_connections)
+
+    def _rebind_active_points_layer(self) -> None:
+        self._disconnect_all(self._layer_connections)
+
+        active = getattr(self.viewer.layers.selection, "active", None)
+        if not isinstance(active, Points):
+            self._active_layer = None
+            return
+
+        self._active_layer = active
+
+        # Primary selection hooks: Selection model events
+        selection = getattr(active, "selected_data", None)
+        selection_events = getattr(selection, "events", None)
+
+        for _name, emitter in _iter_event_emitters(selection_events, ("changed", "active", "items_changed")):
+            self._connect(emitter, self._on_selection_changed, self._layer_connections)
+
+        # Optional content hooks, useful for future history/versioning use cases.
+        if self.watch_content:
+            layer_events = getattr(active, "events", None)
+            for event_name in ("data", "properties", "current_properties", "mode"):
+                for _name, emitter in _iter_event_emitters(layer_events, (event_name,)):
+                    self._connect(emitter, self._on_content_changed, self._layer_connections)
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    def _on_active_layer_changed(self, event=None) -> None:
+        self._rebind_active_points_layer()
+        self._schedule("active_layer")
+
+    def _on_layers_changed(self, event=None) -> None:
+        # The active layer may or may not have changed, but rebinding is cheap and safe.
+        self._rebind_active_points_layer()
+        self._schedule("layers")
+
+    def _on_selection_changed(self, event=None) -> None:
+        self._schedule("selection")
+
+    def _on_content_changed(self, event=None) -> None:
+        self._schedule("content")
+
+    # ------------------------------------------------------------------
+    # Coalescing
+    # ------------------------------------------------------------------
+
+    def _schedule(self, reason: str) -> None:
+        self._pending_reasons.add(reason)
+        if not self._timer.isActive():
+            self._timer.start(self.debounce_ms)
+
+    def _flush(self) -> None:
+        reasons = frozenset(self._pending_reasons)
+        self._pending_reasons.clear()
+
+        event = PointsInteractionEvent(
+            viewer=self.viewer,
+            layer=self._active_layer,
+            reasons=reasons,
+        )
+        self.callback(event)

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -219,6 +219,11 @@ class LabelProgress:
     frame_count: int
     bodypart_count: int
     individual_count: int
+    completed_frames: int
+    completed_percent: float
+    incomplete_frames: tuple[int, ...]
+    incomplete_frames_by_individual: dict[str, int]
+    missing_points_by_individual: dict[str, int]
 
 
 def _get_header_model_from_metadata(md: dict) -> DLCHeaderModel | None:
@@ -312,13 +317,124 @@ def infer_individual_count(layer: Points) -> int:
         return 1
 
 
+def _normalized_slot_id(value) -> str:
+    if value in ("", None):
+        return ""
+    try:
+        if np.isnan(value):
+            return ""
+    except Exception:
+        pass
+    text = str(value)
+    return "" if text.lower() == "nan" else text
+
+
+def infer_observed_bodypart_names(layer: Points) -> list[str]:
+    """
+    Ordered unique bodypart labels actually present in the active napari layer.
+    """
+    props = getattr(layer, "properties", {}) or {}
+    labels = np.asarray(props.get("label", []), dtype=object).ravel()
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in labels:
+        if v in ("", None):
+            continue
+        text = str(v)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def infer_observed_individual_names(layer: Points) -> list[str]:
+    """
+    Ordered unique individual ids actually present in the active napari layer.
+
+    Single-animal convention:
+    - no ids / blank ids -> ['']
+    """
+    props = getattr(layer, "properties", {}) or {}
+    ids_raw = props.get("id", None)
+    if ids_raw is None:
+        return [""]
+
+    ids = np.asarray(ids_raw, dtype=object).ravel()
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for v in ids:
+        text = _normalized_slot_id(v)
+        if text == "":
+            continue
+        if text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+
+    return out if out else [""]
+
+
+def _iter_labeled_slots(layer: Points):
+    """
+    Yield unique annotatable slots currently represented in the active napari layer.
+
+    Each slot is keyed by:
+    - frame index
+    - individual id ('' for single-animal / blank ids)
+    - bodypart label
+    """
+    data = np.asarray(getattr(layer, "data", []))
+    if data.ndim < 2 or data.shape[1] == 0:
+        return
+
+    props = getattr(layer, "properties", {}) or {}
+    labels = np.asarray(props.get("label", []), dtype=object).ravel()
+    ids_raw = props.get("id", None)
+
+    if ids_raw is None:
+        ids = np.array([""] * len(labels), dtype=object)
+    else:
+        ids = np.asarray(ids_raw, dtype=object).ravel()
+
+    n = min(len(data), len(labels), len(ids))
+    for i in range(n):
+        try:
+            frame = int(data[i, 0])
+        except Exception:
+            continue
+
+        label_val = labels[i]
+        if label_val in ("", None):
+            continue
+        label = str(label_val)
+        if not label:
+            continue
+
+        id_text = _normalized_slot_id(ids[i])
+        yield (frame, id_text, label)
+
+
 def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = None) -> LabelProgress:
+    """
+    Compute progress for the active napari layer.
+
+    Semantics:
+    - Main percentage remains theoretical:
+        labeled_points / (frame_count * bodypart_count * individual_count)
+    - Richer frame-completion details are computed from the observed slot universe
+      currently represented in napari:
+        observed_ids × observed_labels
+    """
     frame_count = infer_frame_count(layer, preferred_paths=fallback_paths)
     bodypart_count = infer_bodypart_count(layer)
     individual_count = infer_individual_count(layer)
 
     total_points = frame_count * bodypart_count * individual_count
 
+    # Keep the top-line point percentage as before.
     data = np.asarray(getattr(layer, "data", []))
     labeled_points = int(data.shape[0]) if data.ndim >= 2 else 0
 
@@ -330,6 +446,57 @@ def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = 
 
     remaining_percent = max(0.0, 100.0 - labeled_percent)
 
+    # Richer completion details based on what is actually represented in napari.
+    slots = set(_iter_labeled_slots(layer) or [])
+
+    observed_labels = infer_observed_bodypart_names(layer)
+    observed_ids = infer_observed_individual_names(layer)
+    expected_ids = observed_ids if observed_ids else [""]
+
+    expected_pairs = {(id_text, label) for id_text in expected_ids for label in observed_labels}
+    expected_per_frame = len(expected_pairs)
+
+    frame_to_pairs: dict[int, set[tuple[str, str]]] = {}
+    for frame, id_text, label in slots:
+        frame_to_pairs.setdefault(frame, set()).add((id_text, label))
+
+    # Count-based frame completion: match the diagnostic / user-facing intuition.
+    frame_slot_counts: dict[int, int] = {frame: len(pairs) for frame, pairs in frame_to_pairs.items()}
+
+    completed_frames = 0
+    incomplete_frames: list[int] = []
+    incomplete_frames_by_individual: dict[str, int] = {id_text: 0 for id_text in expected_ids}
+    missing_points_by_individual: dict[str, int] = {id_text: 0 for id_text in expected_ids}
+
+    if frame_count > 0 and expected_per_frame > 0:
+        for frame in range(frame_count):
+            present = frame_to_pairs.get(frame, set())
+            present_count = frame_slot_counts.get(frame, 0)
+
+            # A frame is considered complete if it has the expected number of unique slots.
+            if present_count >= expected_per_frame:
+                completed_frames += 1
+                continue
+
+            incomplete_frames.append(frame)
+
+            # Still compute missing details by comparing against expected pairs.
+            # This is now only used for richer tooltip details on frames that are
+            # count-incomplete, which keeps the user-facing summary intuitive.
+            missing = expected_pairs - present
+
+            missing_by_individual: dict[str, int] = {}
+            for id_text, _label in missing:
+                missing_by_individual[id_text] = missing_by_individual.get(id_text, 0) + 1
+
+            for id_text, missing_count in missing_by_individual.items():
+                incomplete_frames_by_individual[id_text] = incomplete_frames_by_individual.get(id_text, 0) + 1
+                missing_points_by_individual[id_text] = missing_points_by_individual.get(id_text, 0) + missing_count
+
+        completed_percent = 100.0 * completed_frames / frame_count
+    else:
+        completed_percent = 0.0
+
     return LabelProgress(
         labeled_points=labeled_points,
         total_points=total_points,
@@ -338,6 +505,11 @@ def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = 
         frame_count=frame_count,
         bodypart_count=bodypart_count,
         individual_count=individual_count,
+        completed_frames=completed_frames,
+        completed_percent=completed_percent,
+        incomplete_frames=tuple(incomplete_frames),
+        incomplete_frames_by_individual=incomplete_frames_by_individual,
+        missing_points_by_individual=missing_points_by_individual,
     )
 
 

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -263,10 +263,10 @@ def set_uniform_point_size(layer: Points, size: int) -> None:
     layer.size = float(size)
 
 
-def infer_frame_count(layer: Points, *, fallback_paths: list[str] | None = None) -> int:
+def infer_frame_count(layer: Points, *, preferred_paths: list[str] | None = None) -> int:
     md = getattr(layer, "metadata", {}) or {}
 
-    paths = md.get("paths") or fallback_paths or []
+    paths = preferred_paths or md.get("paths") or []
     if paths:
         return len(paths)
 
@@ -313,7 +313,7 @@ def infer_individual_count(layer: Points) -> int:
 
 
 def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = None) -> LabelProgress:
-    frame_count = infer_frame_count(layer, fallback_paths=fallback_paths)
+    frame_count = infer_frame_count(layer, preferred_paths=fallback_paths)
     bodypart_count = infer_bodypart_count(layer)
     individual_count = infer_individual_count(layer)
 

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -411,8 +411,9 @@ class PointsInteractionEvent:
     layer:
         The active Points layer at the time the event flushes, or None.
     reasons:
-        A normalized set of reasons that triggered the event. Typical values:
-        {"selection"}, {"active_layer"}, {"layers"}, {"data"}, {"properties"}.
+        A normalized set of reasons that triggered the event. Typical values
+        include {"install"}, {"selection"}, {"active_layer"}, {"layers"},
+        and {"content"}, depending on which observer hooks fired.
     """
 
     viewer: Any

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/core/layers.py
 from __future__ import annotations
 
 import logging

--- a/src/napari_deeplabcut/napari.yaml
+++ b/src/napari_deeplabcut/napari.yaml
@@ -1,5 +1,5 @@
 name: napari-deeplabcut
-display_name: napari DeepLabCut
+display_name: napari-deeplabcut
 contributions:
   commands:
     - id: napari-deeplabcut.get_hdf_reader

--- a/src/napari_deeplabcut/napari_compat/color.py
+++ b/src/napari_deeplabcut/napari_compat/color.py
@@ -19,18 +19,18 @@ def patch_color_manager_guess_continuous() -> None:
     try:
         import numpy as np
         from napari.layers.utils import color_manager
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         logger.debug("Skipping color_manager patch (napari import failed): %r", e)
         return
 
     def guess_continuous(property_):
         try:
             return issubclass(property_.dtype.type, np.floating)
-        except Exception:
+        except Exception:  # pragma: no cover
             return False
 
     try:
         color_manager.guess_continuous = guess_continuous
-    except Exception as e:
+    except Exception as e:  # pragma: no cover
         logger.debug("Skipping color_manager patch (assignment failed): %r", e)
         return

--- a/src/napari_deeplabcut/napari_compat/points_layer.py
+++ b/src/napari_deeplabcut/napari_compat/points_layer.py
@@ -228,8 +228,6 @@ def _offset_pasted_data(
 
 def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> object | None:
     """
-    Best-effort private napari UI wiring.
-
     Returns
     -------
     object | None
@@ -239,6 +237,7 @@ def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> 
         controls = viewer.window.qt_viewer.dockLayerControls
         point_controls = controls.widget().widgets[layer]
     except Exception:
+        logger.debug("Failed to resolve point controls for layer UI tweaks", exc_info=True)
         return None
 
     widgets_to_hide = [
@@ -256,15 +255,24 @@ def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> 
             widget = getattr(parent, widget_attr)
             widget.hide()
         except Exception:
-            pass
+            logger.debug(
+                "Failed to hide widget %s.%s in point controls",
+                parent_attr,
+                widget_attr,
+                exc_info=True,
+            )
 
     try:
         cmap_source = plt_module.colormaps
         if callable(cmap_source):
             cmap_source = cmap_source()
 
-        colormap_selector = dropdown_cls(cmap_source, point_controls)
-        colormap_selector.update_to(layer.metadata.get("colormap_name", "viridis"))
+        # Normalize explicitly to strings for safety/readability.
+        cmap_names = [str(name) for name in cmap_source]
+
+        colormap_selector = dropdown_cls(cmap_names, point_controls)
+        if hasattr(colormap_selector, "update_to"):
+            colormap_selector.update_to(layer.metadata.get("colormap_name", "viridis"))
         point_controls.layout().addRow("colormap", colormap_selector)
         return colormap_selector
     except Exception as e:

--- a/src/napari_deeplabcut/ui/debug_window.py
+++ b/src/napari_deeplabcut/ui/debug_window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QAction, QFontDatabase, QKeySequence
+from qtpy.QtGui import QAction, QFontDatabase, QKeySequence, QTextCursor
 from qtpy.QtWidgets import (
     QApplication,
     QDialog,
@@ -128,7 +128,7 @@ class DebugTextWindow(QDialog):
             text = f"[debug-window] failed to build debug text\n\n{exc!r}"
 
         self._text_edit.setPlainText(text or "<no debug text available>")
-        self._text_edit.moveCursor(self._text_edit.textCursor().Start)
+        self._text_edit.moveCursor(QTextCursor.MoveOperation.Start)
         self._status_label.setText("")
 
     def copy_to_clipboard(self) -> None:

--- a/src/napari_deeplabcut/ui/debug_window.py
+++ b/src/napari_deeplabcut/ui/debug_window.py
@@ -1,0 +1,140 @@
+# src/napari_deeplabcut/ui/debug_window.py
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QAction, QFontDatabase, QKeySequence
+from qtpy.QtWidgets import (
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from napari_deeplabcut.utils.debug import InMemoryDebugRecorder, build_debug_report
+
+
+def make_log_text_provider(
+    *,
+    recorder: InMemoryDebugRecorder | None,
+    limit: int = 300,
+) -> Callable[[], str]:
+    def _provider() -> str:
+        if recorder is None:
+            return "<debug recorder unavailable>"
+        return recorder.render_text(limit=limit)
+
+    return _provider
+
+
+def make_issue_report_provider(
+    *,
+    viewer,
+    recorder: InMemoryDebugRecorder | None,
+    log_limit: int = 300,
+) -> Callable[[], str]:
+    def _provider() -> str:
+        return build_debug_report(viewer=viewer, recorder=recorder, log_limit=log_limit)
+
+    return _provider
+
+
+class DebugTextWindow(QDialog):
+    """
+    Minimal, shape-agnostic debug text viewer.
+
+    This widget only knows how to:
+    - fetch text from a callable
+    - display it read-only
+    - copy it to clipboard
+    - refresh it on demand
+
+    It intentionally knows nothing about:
+    - log recorder internals
+    - napari viewer internals
+    - environment/report formatting
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        text_provider: Callable[[], str],
+        parent: QWidget | None = None,
+        initial_hint: str = "Read-only diagnostic output",
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setWindowTitle(title)
+        self.setModal(False)
+        self.resize(900, 650)
+
+        self._text_provider = text_provider
+
+        self._build_ui(initial_hint=initial_hint)
+        self.refresh_text()
+
+    def _build_ui(self, *, initial_hint: str) -> None:
+        layout = QVBoxLayout(self)
+
+        self._hint_label = QLabel(initial_hint, self)
+        self._hint_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        layout.addWidget(self._hint_label)
+
+        self._text_edit = QPlainTextEdit(self)
+        self._text_edit.setReadOnly(True)
+        self._text_edit.setLineWrapMode(QPlainTextEdit.NoWrap)
+
+        # Use a fixed-width system font for logs / reports
+        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        self._text_edit.setFont(font)
+
+        layout.addWidget(self._text_edit, stretch=1)
+
+        button_row = QHBoxLayout()
+
+        self._status_label = QLabel("", self)
+        self._status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        button_row.addWidget(self._status_label, stretch=1)
+
+        self._refresh_btn = QPushButton("Refresh", self)
+        self._refresh_btn.clicked.connect(self.refresh_text)
+        button_row.addWidget(self._refresh_btn)
+
+        self._copy_btn = QPushButton("Copy to clipboard", self)
+        self._copy_btn.clicked.connect(self.copy_to_clipboard)
+        button_row.addWidget(self._copy_btn)
+
+        self._close_btn = QPushButton("Close", self)
+        self._close_btn.clicked.connect(self.close)
+        button_row.addWidget(self._close_btn)
+
+        layout.addLayout(button_row)
+
+        # Optional keyboard shortcut
+        copy_action = QAction(self)
+        copy_action.setShortcut(QKeySequence.Copy)
+        copy_action.triggered.connect(self.copy_to_clipboard)
+        self.addAction(copy_action)
+
+    def refresh_text(self) -> None:
+        try:
+            text = self._text_provider()
+        except Exception as exc:
+            text = f"[debug-window] failed to build debug text\n\n{exc!r}"
+
+        self._text_edit.setPlainText(text or "<no debug text available>")
+        self._text_edit.moveCursor(self._text_edit.textCursor().Start)
+        self._status_label.setText("")
+
+    def copy_to_clipboard(self) -> None:
+        try:
+            text = self._text_edit.toPlainText()
+            QApplication.clipboard().setText(text)
+            self._status_label.setText("Copied to clipboard")
+        except Exception:
+            self._status_label.setText("Could not copy to clipboard")

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QMenu,
     QSlider,
+    QToolButton,
     QVBoxLayout,
     QWidget,
 )
@@ -39,10 +40,46 @@ class LayerStatusPanel(QGroupBox):
 
         self._progress_value = QLabel("No active keypoints layer")
         self._progress_value.setWordWrap(True)
+        self._progress_value.setCursor(Qt.WhatsThisCursor)
         self._progress_value.setTextInteractionFlags(Qt.TextSelectableByMouse)
+
+        # self._progress_info = QLabel("ℹ")
+        self._progress_info = QToolButton(self)
+        self._progress_info.setText("ℹ")
+        self._progress_info.setAutoRaise(True)
+        self._progress_info.setCursor(Qt.WhatsThisCursor)
+        # self._progress_info.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxInformation))
+        # self._progress_info.setAlignment(Qt.AlignCenter)
+        self._progress_info.setStyleSheet(
+            """
+            QToolButton {
+                color: #414851;
+                background: transparent;
+                border: 1px solid #414851;
+                border-radius: 8px;
+                padding: 0px 4px;
+                font-weight: bold;
+            }
+            QToolButton:hover {
+                background: rgba(65, 72, 81, 0.08);
+            }
+            """
+        )
+        self._progress_info.setToolTip("Hover for more details")
+
         self._progress_details_text = ""
+
         self._progress_value.setContextMenuPolicy(Qt.CustomContextMenu)
         self._progress_value.customContextMenuRequested.connect(self._show_progress_context_menu)
+        self._progress_info.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._progress_info.customContextMenuRequested.connect(self._show_progress_context_menu)
+
+        self._progress_container = QWidget(self)
+        progress_row = QHBoxLayout(self._progress_container)
+        progress_row.setContentsMargins(0, 0, 0, 0)
+        progress_row.setSpacing(4)
+        progress_row.addWidget(self._progress_value, stretch=1)
+        progress_row.addWidget(self._progress_info, stretch=0, alignment=Qt.AlignTop)
 
         self._size_slider = QSlider(Qt.Horizontal, self)
         self._size_slider.setRange(1, 100)
@@ -70,7 +107,7 @@ class LayerStatusPanel(QGroupBox):
 
         form = QFormLayout()
         form.addRow("Folder", self._folder_value)
-        form.addRow("Progress", self._progress_value)
+        form.addRow("Progress", self._progress_container)
         form.addRow("Point size", self._size_controls)
 
         wrapper = QVBoxLayout(self)
@@ -170,14 +207,14 @@ class LayerStatusPanel(QGroupBox):
         first_incomplete = list(p.incomplete_frames[:10])
 
         details_lines = [
-            f"{p.labeled_percent:.1f}% labeled, {p.remaining_percent:.1f}% remaining",
+            f"{p.labeled_percent:.1f}% fully labeled, {p.remaining_percent:.1f}% remaining",
             f"{p.labeled_points}/{p.total_points} possible keypoint slots currently labeled • {breakdown}",
-            f"{p.completed_frames}/{p.frame_count} frames complete ({p.completed_percent:.1f}%)",
-            f"{incomplete_count} incomplete frames",
+            f"{p.completed_frames}/{p.frame_count} frames fully labeled ({p.completed_percent:.1f}%)",
+            f"{incomplete_count} non fully labeled frames",
         ]
 
         if first_incomplete:
-            details_lines.append("First incomplete frames: " + ", ".join(str(int(f)) for f in first_incomplete))
+            details_lines.append("First non fully labeled frames: " + ", ".join(str(int(f)) for f in first_incomplete))
 
         if p.individual_count > 1:
             # Keep individual rows stable and compact
@@ -185,9 +222,10 @@ class LayerStatusPanel(QGroupBox):
             for individual, n_frames in sorted(p.incomplete_frames_by_individual.items()):
                 if individual == "":
                     continue
-                missing_points = int(p.missing_points_by_individual.get(individual, 0))
+                int(p.missing_points_by_individual.get(individual, 0))
                 per_individual_lines.append(
-                    f"- {individual}: incomplete on {int(n_frames)} frame(s), {missing_points} missing keypoint(s)"
+                    f"- {individual}: non fully labeled on {int(n_frames)} frame(s), "
+                    "{missing_points} missing keypoint(s)"
                 )
 
             if per_individual_lines:
@@ -196,20 +234,32 @@ class LayerStatusPanel(QGroupBox):
                 details_lines.extend(per_individual_lines)
 
         details_lines.append("")
-        details_lines.append("Tip: right-click this progress label to copy the full summary.")
+        details_lines.append(
+            "Tip: right-click this progress label to copy the full summary.\n"
+            "Please note that actual visibility of keypoints in the video cannot"
+            " be determined automatically.\nTherefore, not having all frames be fully labeled"
+            " does not necessarily imply the labeling is incomplete."
+            " Please treat it as a relative progress estimate based on the maximum possible keypoints"
+        )
 
         details_text = "\n".join(details_lines)
         self._progress_details_text = details_text
         self._progress_value.setToolTip(details_text)
+        self._progress_info.setToolTip(details_text)
+        self._progress_container.setToolTip(details_text)
 
     def set_no_active_points_layer(self) -> None:
         self._progress_value.setText("No active keypoints layer")
         self._progress_value.setToolTip("")
+        self._progress_info.setToolTip("")
+        self._progress_container.setToolTip("")
         self._progress_details_text = ""
         self.set_point_size_enabled(False, reason="Select a DLC keypoints layer to edit point size.")
 
     def set_invalid_points_layer(self) -> None:
         self._progress_value.setText("Active layer is not a DLC keypoints layer")
         self._progress_value.setToolTip("")
+        self._progress_info.setToolTip("")
+        self._progress_container.setToolTip("")
         self._progress_details_text = ""
         self.set_point_size_enabled(False, reason="This control only works for DLC keypoints layers.")

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -225,7 +225,7 @@ class LayerStatusPanel(QGroupBox):
                 int(p.missing_points_by_individual.get(individual, 0))
                 per_individual_lines.append(
                     f"- {individual}: non fully labeled on {int(n_frames)} frame(s), "
-                    "{missing_points} missing keypoint(s)"
+                    f"{int(p.missing_points_by_individual.get(individual, 0))} missing keypoint(s)"
                 )
 
             if per_individual_lines:
@@ -238,8 +238,8 @@ class LayerStatusPanel(QGroupBox):
             "Tip: right-click this progress label to copy the full summary.\n"
             "Please note that actual visibility of keypoints in the video cannot"
             " be determined automatically.\nTherefore, not having all frames be fully labeled"
-            " does not necessarily imply the labeling is incomplete."
-            " Please treat it as a relative progress estimate based on the maximum possible keypoints"
+            " does not necessarily imply the labeling is incomplete.\n"
+            "Please treat it as a relative progress estimate based on the maximum possible keypoints"
         )
 
         details_text = "\n".join(details_lines)

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -1,16 +1,23 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from qtpy.QtCore import QSignalBlocker, Qt, Signal
 from qtpy.QtWidgets import (
+    QApplication,
     QFormLayout,
     QGraphicsOpacityEffect,
     QGroupBox,
     QHBoxLayout,
     QLabel,
+    QMenu,
     QSlider,
     QVBoxLayout,
     QWidget,
 )
+
+if TYPE_CHECKING:
+    from napari_deeplabcut.core.layers import LabelProgress
 
 
 class LayerStatusPanel(QGroupBox):
@@ -33,6 +40,9 @@ class LayerStatusPanel(QGroupBox):
         self._progress_value = QLabel("No active keypoints layer")
         self._progress_value.setWordWrap(True)
         self._progress_value.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._progress_details_text = ""
+        self._progress_value.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._progress_value.customContextMenuRequested.connect(self._show_progress_context_menu)
 
         self._size_slider = QSlider(Qt.Horizontal, self)
         self._size_slider.setRange(1, 100)
@@ -119,43 +129,87 @@ class LayerStatusPanel(QGroupBox):
     def set_folder_name(self, folder_name: str) -> None:
         self._folder_value.setText(folder_name or "—")
 
+    def _show_progress_context_menu(self, pos) -> None:
+        if not self._progress_details_text:
+            return
+
+        menu = QMenu(self)
+        copy_action = menu.addAction("Copy progress details")
+        chosen = menu.exec_(self._progress_value.mapToGlobal(pos))
+        if chosen is copy_action:
+            self._copy_progress_details_to_clipboard()
+
+    def _copy_progress_details_to_clipboard(self) -> None:
+        text = self._progress_details_text or self._progress_value.toolTip() or ""
+        if not text:
+            return
+        QApplication.clipboard().setText(text)
+
     def set_progress_summary(
         self,
         *,
-        labeled_percent: float,
-        remaining_percent: float,
-        labeled_points: int,
-        total_points: int,
-        frame_count: int,
-        bodypart_count: int,
-        individual_count: int,
+        progress: LabelProgress,
     ) -> None:
-        if total_points <= 0:
+
+        p = progress
+
+        if p.total_points <= 0:
             self._progress_value.setText("Not enough metadata to estimate progress yet")
             self._progress_value.setToolTip("")
+            self._progress_details_text = ""
             return
 
-        if individual_count <= 1:
-            breakdown = f"{frame_count} frames × {bodypart_count} bodyparts"
+        if p.individual_count <= 1:
+            breakdown = f"{p.frame_count} frames × {p.bodypart_count} bodyparts"
         else:
-            breakdown = f"{frame_count} frames × {bodypart_count} bodyparts × {individual_count} individuals"
+            breakdown = f"{p.frame_count} frames × {p.bodypart_count} bodyparts × {p.individual_count} individuals"
 
-        self._progress_value.setText(f"{labeled_percent:.1f}% labeled")
-        self._progress_value.setToolTip(
-            f"{labeled_percent:.1f}% labeled, {remaining_percent:.1f}% remaining\n"
-            f"{labeled_points}/{total_points} of all possible points labeled • {breakdown}\n"
-            "NOTE: percentages are calculated assuming all keypoints are visible "
-            "on every frame and represent only a theoretical maximum.\n"
-            "Actual progress may be higher if some keypoints are not visible on all frames, "
-            "or lower if some keypoints are missing from the dataset.\n"
-        )
+        self._progress_value.setText(f"{p.labeled_percent:.1f}% labeled")
+
+        incomplete_count = max(0, p.frame_count - p.completed_frames)
+        first_incomplete = list(p.incomplete_frames[:10])
+
+        details_lines = [
+            f"{p.labeled_percent:.1f}% labeled, {p.remaining_percent:.1f}% remaining",
+            f"{p.labeled_points}/{p.total_points} possible keypoint slots currently labeled • {breakdown}",
+            f"{p.completed_frames}/{p.frame_count} frames complete ({p.completed_percent:.1f}%)",
+            f"{incomplete_count} incomplete frames",
+        ]
+
+        if first_incomplete:
+            details_lines.append("First incomplete frames: " + ", ".join(str(int(f)) for f in first_incomplete))
+
+        if p.individual_count > 1:
+            # Keep individual rows stable and compact
+            per_individual_lines = []
+            for individual, n_frames in sorted(p.incomplete_frames_by_individual.items()):
+                if individual == "":
+                    continue
+                missing_points = int(p.missing_points_by_individual.get(individual, 0))
+                per_individual_lines.append(
+                    f"- {individual}: incomplete on {int(n_frames)} frame(s), {missing_points} missing keypoint(s)"
+                )
+
+            if per_individual_lines:
+                details_lines.append("")
+                details_lines.append("By individual:")
+                details_lines.extend(per_individual_lines)
+
+        details_lines.append("")
+        details_lines.append("Tip: right-click this progress label to copy the full summary.")
+
+        details_text = "\n".join(details_lines)
+        self._progress_details_text = details_text
+        self._progress_value.setToolTip(details_text)
 
     def set_no_active_points_layer(self) -> None:
         self._progress_value.setText("No active keypoints layer")
         self._progress_value.setToolTip("")
+        self._progress_details_text = ""
         self.set_point_size_enabled(False, reason="Select a DLC keypoints layer to edit point size.")
 
     def set_invalid_points_layer(self) -> None:
         self._progress_value.setText("Active layer is not a DLC keypoints layer")
         self._progress_value.setToolTip("")
+        self._progress_details_text = ""
         self.set_point_size_enabled(False, reason="This control only works for DLC keypoints layers.")

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -143,7 +143,11 @@ class LayerStatusPanel(QGroupBox):
         self._progress_value.setText(f"{labeled_percent:.1f}% labeled")
         self._progress_value.setToolTip(
             f"{labeled_percent:.1f}% labeled, {remaining_percent:.1f}% remaining\n"
-            f"{labeled_points}/{total_points} of all possible points labeled • {breakdown}"
+            f"{labeled_points}/{total_points} of all possible points labeled • {breakdown}\n"
+            "NOTE: percentages are calculated assuming all keypoints are visible "
+            "on every frame and represent only a theoretical maximum.\n"
+            "Actual progress may be higher if some keypoints are not visible on all frames, "
+            "or lower if some keypoints are missing from the dataset.\n"
         )
 
     def set_no_active_points_layer(self) -> None:

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from qtpy.QtCore import QSignalBlocker, Qt, Signal
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QApplication,
     QFormLayout,
@@ -47,24 +48,8 @@ class LayerStatusPanel(QGroupBox):
         self._progress_info = QToolButton(self)
         self._progress_info.setText("ℹ")
         self._progress_info.setAutoRaise(True)
+        self._progress_info.setIcon(QIcon.fromTheme("help-about"))
         self._progress_info.setCursor(Qt.WhatsThisCursor)
-        # self._progress_info.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxInformation))
-        # self._progress_info.setAlignment(Qt.AlignCenter)
-        self._progress_info.setStyleSheet(
-            """
-            QToolButton {
-                color: #414851;
-                background: transparent;
-                border: 1px solid #414851;
-                border-radius: 8px;
-                padding: 0px 4px;
-                font-weight: bold;
-            }
-            QToolButton:hover {
-                background: rgba(65, 72, 81, 0.08);
-            }
-            """
-        )
         self._progress_info.setToolTip("Hover for more details")
 
         self._progress_details_text = ""

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -134,7 +134,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         slider_row.addWidget(self.slider_value, stretch=0)
         layout.addLayout(slider_row, stretch=0)
 
-        self.setLayout(layout)
+        # self.setLayout(layout)
 
         self.frames = []
         self.keypoints = []
@@ -295,10 +295,10 @@ class TrajectoryMatplotlibCanvas(QWidget):
                 action.setToolTip("Zoom to rectangle; Click once to activate; Click again to deactivate")
             if text:
                 icon_path = Path(icon_dir) / f"{text}.png"
-                try:
-                    action.setIcon(self.toolbar._qicon(icon_path))
-                except AttributeError:
-                    logger.debug(f"Failed to set toolbar icon from {icon_path}", exc_info=True)
+                if icon_path.is_file():
+                    action.setIcon(QIcon(str(icon_path)))
+                else:
+                    logger.debug(f"Failed to set toolbar icon from {icon_path}: file does not exist")
 
     def _load_dataframe(self, event=None) -> None:
         with mplstyle.context(self.mpl_style_sheet_path):
@@ -466,20 +466,23 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
     def _selected_bodyparts_from_points_layer(self) -> set[str]:
         """
-        Return the set of selected bodypart labels from the active Points layer.
+        Return the set of selected bodypart labels from the Points layer used
+        to build the trajectory plot.
 
         Notes
         -----
         - We intentionally key visibility by `label` because this plot currently
         groups trajectories by bodypart name.
-        - If the active layer is not a Points layer, we fall back to the first
-        Points layer for backward compatibility.
+        - We use the same Points layer selection policy as the plotting code so
+        selection-driven visibility cannot drift out of sync with the plotted
+        dataframe.
         - If nothing is selected, returns an empty set.
         """
-        active_layer = getattr(self.viewer.layers.selection, "active", None)
-        if isinstance(active_layer, Points):
-            points_layer = active_layer
-        else:
+        points_layer = None
+        get_plot_points_layer = getattr(self, "_get_plot_points_layer", None)
+        if callable(get_plot_points_layer):
+            points_layer = get_plot_points_layer()
+        if points_layer is None:
             points_layer = get_first_points_layer(self.viewer)
         if points_layer is None:
             return set()

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -97,7 +97,7 @@ class KeypointMatplotlibCanvas(QWidget):
         # self.toolbar = NapariNavigationToolbar(self.canvas, parent=self)
         self.toolbar = NavigationToolbar2QT(self.canvas, parent=self)
         self.toolbar.setIconSize(QSize(28, 28))
-        self._replace_toolbar_icons()
+        self._set_toolbar_tooltips()
         self.canvas.mpl_connect("button_press_event", self.on_doubleclick)
 
         self.slider = QSlider(Qt.Horizontal)
@@ -139,6 +139,8 @@ class KeypointMatplotlibCanvas(QWidget):
         self.viewer.dims.events.range.connect(self._update_slider_max)
         self._lines: dict[str, list] = {}
 
+        self._apply_napari_theme()
+        self._connect_theme_events()
         # If layers already existed before this widget was created
         # (e.g. drag-and-drop load before opening the plugin), populate
         # the plot from the current viewer state on the next event-loop turn.
@@ -259,7 +261,7 @@ class KeypointMatplotlibCanvas(QWidget):
             self.ax.set_xlabel("Frame")
             self.ax.set_ylabel("Y position")
             self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
-            self._apply_axis_theme()
+            self._apply_napari_theme()
 
             height = None
             if image_layer is not None:
@@ -443,3 +445,114 @@ class KeypointMatplotlibCanvas(QWidget):
             return
 
         self._set_visible_keypoints(visible)
+
+    def _set_toolbar_tooltips(self) -> None:
+        """Set clearer tooltips for the stock matplotlib toolbar."""
+        for action in self.toolbar.actions():
+            text = action.text()
+            if text == "Pan":
+                action.setToolTip(
+                    "Pan/Zoom: Left button pans; Right button zooms; Click once to activate; Click again to deactivate"
+                )
+            elif text == "Zoom":
+                action.setToolTip("Zoom to rectangle; Click once to activate; Click again to deactivate")
+
+    # def _apply_toolbar_icons(self) -> None:
+    #     """
+    #     Apply static black/white toolbar icons based on the current napari theme.
+
+    #     This does not override toolbar behavior; it only replaces the displayed icons.
+    #     """
+    #     icon_dir = self._get_path_to_icon()
+    #     for action in self.toolbar.actions():
+    #         text = action.text()
+    #         if not text:
+    #             continue
+
+    #         icon_path = Path(icon_dir) / f"{text}.png"
+    #         if icon_path.exists():
+    #             action.setIcon(QIcon(str(icon_path)))
+
+    def _apply_toolbar_stylesheet(self) -> None:
+        """
+        Apply a minimal Qt stylesheet so the toolbar background has enough contrast.
+
+        In light mode:
+        - toolbar background becomes light gray
+        - buttons remain mostly transparent until hover/checked
+
+        In dark mode:
+        - keep a subtle dark/transparent look
+        """
+        is_light = self._napari_theme_has_light_bg()
+
+        if is_light:
+            fg = "#202020"
+            toolbar_bg = "#ececec"  # light gray background for the whole toolbar
+            hover = "rgba(0, 0, 0, 0.06)"
+            pressed = "rgba(0, 0, 0, 0.12)"
+            border = "rgba(0, 0, 0, 0.10)"
+        else:
+            fg = "#f2f2f2"
+            toolbar_bg = "transparent"
+            hover = "rgba(255, 255, 255, 0.10)"
+            pressed = "rgba(255, 255, 255, 0.18)"
+            border = "rgba(255, 255, 255, 0.12)"
+
+        self.toolbar.setStyleSheet(
+            f"""
+            QToolBar {{
+                background: {toolbar_bg};
+                border: none;
+                spacing: 2px;
+                padding: 2px;
+            }}
+            QToolButton {{
+                color: {fg};
+                background: transparent;
+                border: 1px solid transparent;
+                border-radius: 4px;
+                padding: 2px;
+                margin: 1px;
+            }}
+            QToolButton:hover {{
+                background: {hover};
+                border: 1px solid {border};
+            }}
+            QToolButton:pressed {{
+                background: {pressed};
+            }}
+            QToolButton:checked {{
+                background: {pressed};
+                border: 1px solid {border};
+            }}
+            """
+        )
+
+    def _apply_label_styles(self) -> None:
+        """Apply light/dark text color to simple Qt labels in this widget."""
+        fg = "black" if self._napari_theme_has_light_bg() else "white"
+        self.slider_value.setStyleSheet(f"color: {fg};")
+
+    def _apply_napari_theme(self) -> None:
+        """
+        Re-apply all napari-dependent styling.
+
+        Safe to call repeatedly.
+        """
+        self._apply_axis_theme()
+        # self._apply_toolbar_icons()
+        self._apply_toolbar_stylesheet()
+        self._apply_label_styles()
+        self.canvas.draw_idle()
+
+    def _connect_theme_events(self) -> None:
+        """
+        Re-apply theme when the viewer theme changes, if the event exists.
+
+        Safe across versions: if the event is absent, this becomes a no-op.
+        """
+        viewer_events = getattr(self.viewer, "events", None)
+        theme_emitter = getattr(viewer_events, "theme", None)
+        if theme_emitter is not None:
+            theme_emitter.connect(lambda event=None: self._apply_napari_theme())

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -466,15 +466,21 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
     def _selected_bodyparts_from_points_layer(self) -> set[str]:
         """
-        Return the set of selected bodypart labels from the first Points layer.
+        Return the set of selected bodypart labels from the active Points layer.
 
         Notes
         -----
         - We intentionally key visibility by `label` because this plot currently
         groups trajectories by bodypart name.
+        - If the active layer is not a Points layer, we fall back to the first
+        Points layer for backward compatibility.
         - If nothing is selected, returns an empty set.
         """
-        points_layer = get_first_points_layer(self.viewer)
+        active_layer = getattr(self.viewer.layers.selection, "active", None)
+        if isinstance(active_layer, Points):
+            points_layer = active_layer
+        else:
+            points_layer = get_first_points_layer(self.viewer)
         if points_layer is None:
             return set()
 

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -15,6 +15,7 @@ import matplotlib.style as mplstyle
 import napari
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvas, NavigationToolbar2QT
+from napari.layers import Points
 from napari.utils.events import Event
 from qtpy.QtCore import QSize, Qt, QTimer
 from qtpy.QtGui import QIcon
@@ -190,16 +191,6 @@ class KeypointMatplotlibCanvas(QWidget):
     def refresh_from_viewer_layers(self) -> None:
         """
         Refresh the trajectory plot from the current viewer state.
-
-        This is safe to call:
-        - after drag/drop loads that happened before the widget was opened
-        - after layer adoption / remap
-        - after later explicit layer changes
-
-        It intentionally:
-        1) reloads the dataframe from the current Points layer
-        2) updates the slider max from the current Image/Video layer
-        3) re-syncs visible lines to current point selection
         """
         try:
             self._load_dataframe()
@@ -215,6 +206,53 @@ class KeypointMatplotlibCanvas(QWidget):
             self.sync_visible_lines_to_points_selection()
         except Exception:
             logger.debug("Trajectory plot: failed to sync visible lines to point selection", exc_info=True)
+
+    def _get_plot_points_layer(self):
+        """
+        Return the first Points layer that looks plottable for DLC trajectories.
+
+        A generic napari Points layer may not have the DLC header required by io.form_df.
+        """
+        for layer in self.viewer.layers:
+            if not isinstance(layer, Points):
+                continue
+
+            md = getattr(layer, "metadata", None) or {}
+            data = getattr(layer, "data", None)
+
+            if md.get("header") is None:
+                continue
+            if data is None or len(data) == 0:
+                continue
+
+            return layer
+
+        return None
+
+    def _clear_plot(self) -> None:
+        """Clear plotted trajectories and reset axes."""
+        self.df = None
+        self._lines = {}
+
+        self.ax.clear()
+        self.ax.set_xlabel("Frame")
+        self.ax.set_ylabel("Y position")
+        self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
+        self._apply_napari_theme()
+
+    def _has_refreshable_df(self) -> bool:
+        """
+        Return True if self.df looks like something we can safely use with len(...).
+
+        This keeps selection-only tests and partial UI states from crashing.
+        """
+        if self.df is None:
+            return False
+        try:
+            len(self.df)
+        except Exception:
+            return False
+        return True
 
     def _apply_axis_theme(self) -> None:
         """Force axis/text colors to match napari theme."""
@@ -263,10 +301,10 @@ class KeypointMatplotlibCanvas(QWidget):
 
     def _load_dataframe(self, event=None) -> None:
         with mplstyle.context(self.mpl_style_sheet_path):
-            points_layer = get_first_points_layer(self.viewer)
-            data = getattr(points_layer, "data", None)
-
-            if points_layer is None or data is None or len(data) == 0:
+            points_layer = self._get_plot_points_layer()
+            if points_layer is None:
+                # No plottable DLC points layer present -> clear the plot quietly.
+                self._clear_plot()
                 return
 
             # Silly hack so the window does not hang the first time it is shown
@@ -279,8 +317,14 @@ class KeypointMatplotlibCanvas(QWidget):
                     layer_metadata=points_layer.metadata,
                     layer_properties=points_layer.properties,
                 )
+            except KeyError as e:
+                # Generic / incomplete points layer: not an error for the UI, just skip plotting.
+                logger.debug("Trajectory plot skipped for non-DLC/incomplete points layer: %r", e)
+                self._clear_plot()
+                return
             except Exception as e:
                 logger.error("Failed to form DataFrame from points layer: %r", e, exc_info=True)
+                self._clear_plot()
                 return
 
             image_layer = get_first_video_image_layer(self.viewer)
@@ -306,20 +350,21 @@ class KeypointMatplotlibCanvas(QWidget):
                     height = None
 
             for keypoint in self.df.columns.get_level_values("bodyparts").unique():
-                y = (
-                    self.df.xs(
-                        (keypoint, "y"),
-                        axis=1,
-                        level=["bodyparts", "coords"],
-                    )
-                    .to_numpy()
-                    .squeeze()
-                )
-                x = np.arange(len(y))
+                y = self.df.xs(
+                    (keypoint, "y"),
+                    axis=1,
+                    level=["bodyparts", "coords"],
+                ).to_numpy()
+
+                # Important: a single-row dataframe can squeeze to a scalar.
+                y = np.atleast_1d(np.asarray(y).squeeze())
+                x = np.arange(y.shape[0])
+
                 try:
                     color = points_layer.metadata["face_color_cycles"]["label"][keypoint]
                 except Exception:
                     color = "C0"
+
                 lines = self.ax.plot(x, y, color=color, label=str(keypoint))
                 self._lines[str(keypoint)] = lines
 
@@ -350,7 +395,8 @@ class KeypointMatplotlibCanvas(QWidget):
         self._set_visible_keypoints({keypoint})
 
     def _refresh_canvas(self, value: int) -> None:
-        if self.df is None:
+        if not self._has_refreshable_df():
+            self.canvas.draw_idle()
             return
 
         with mplstyle.context(self.mpl_style_sheet_path):
@@ -402,7 +448,8 @@ class KeypointMatplotlibCanvas(QWidget):
             for artist in artists:
                 artist.set_visible(show)
 
-        self._refresh_canvas(value=self._n)
+        if self.isVisible():
+            self._refresh_canvas(value=self._n)
 
     def _show_all_keypoints(self) -> None:
         """Show all trajectories."""
@@ -413,7 +460,8 @@ class KeypointMatplotlibCanvas(QWidget):
             for artist in artists:
                 artist.set_visible(True)
 
-        self._refresh_canvas(value=self._n)
+        if self.isVisible():
+            self._refresh_canvas(value=self._n)
 
     def _selected_bodyparts_from_points_layer(self) -> set[str]:
         """

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -292,23 +292,34 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
     def _get_plot_points_layer(self):
         """
-        Return the first Points layer that looks plottable for DLC trajectories.
+        Return the active plottable Points layer for DLC trajectories when possible.
 
         A generic napari Points layer may not have the DLC header required by io.form_df.
+        If the active layer is not a suitable DLC Points layer, fall back to the first
+        plottable Points layer in the viewer.
         """
-        for layer in self.viewer.layers:
+
+        def _is_plottable_points_layer(layer) -> bool:
             if not isinstance(layer, Points):
-                continue
+                return False
 
             md = getattr(layer, "metadata", None) or {}
             data = getattr(layer, "data", None)
 
             if md.get("header") is None:
-                continue
+                return False
             if data is None or len(data) == 0:
-                continue
+                return False
 
-            return layer
+            return True
+
+        active_layer = getattr(getattr(self.viewer.layers, "selection", None), "active", None)
+        if _is_plottable_points_layer(active_layer):
+            return active_layer
+
+        for layer in self.viewer.layers:
+            if _is_plottable_points_layer(layer):
+                return layer
 
         return None
 

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -4,7 +4,6 @@ This module intentionally does not make decisions about what constitutes
 valid DLC points metadata; it only reads what it needs (face_color_cycles).
 """
 
-# src/napari_deeplabcut/ui/plots/trajectory.py
 from __future__ import annotations
 
 import logging
@@ -17,22 +16,25 @@ import napari
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvas, NavigationToolbar2QT
 from napari.utils.events import Event
-from qtpy.QtCore import QSize, Qt
+from qtpy.QtCore import QSize, Qt, QTimer
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QSlider, QVBoxLayout, QWidget
 
 import napari_deeplabcut.core.io as io
-from napari_deeplabcut.core.layers import get_first_points_layer, get_first_video_image_layer
+from napari_deeplabcut.core.layers import (
+    get_first_image_layer,
+    get_first_points_layer,
+    get_first_video_image_layer,
+)
+from napari_deeplabcut.utils.deprecations import deprecated
 
 logger = logging.getLogger(__name__)
-
 
 _PACKAGE = "napari_deeplabcut"
 
 
 @lru_cache(maxsize=1)
 def _pkg_root():
-    # Traversable root of the package
     return files(_PACKAGE)
 
 
@@ -52,6 +54,11 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
         super().__init__(*args, **kwargs)
         self.setIconSize(QSize(28, 28))
 
+    @staticmethod
+    def _qicon(pathlike) -> QIcon:
+        """Build a QIcon safely from any path-like object."""
+        return QIcon(str(pathlike))
+
     def _update_buttons_checked(self) -> None:
         """Update toggle tool icons when selected/unselected."""
         super()._update_buttons_checked()
@@ -59,39 +66,39 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
 
         if "pan" in self._actions:
             if self._actions["pan"].isChecked():
-                self._actions["pan"].setIcon(QIcon(Path(icon_dir) / "Pan_checked.png"))
+                self._actions["pan"].setIcon(self._qicon(Path(icon_dir) / "Pan_checked.png"))
             else:
-                self._actions["pan"].setIcon(QIcon(Path(icon_dir) / "Pan.png"))
+                self._actions["pan"].setIcon(self._qicon(Path(icon_dir) / "Pan.png"))
 
         if "zoom" in self._actions:
             if self._actions["zoom"].isChecked():
-                self._actions["zoom"].setIcon(QIcon(Path(icon_dir) / "Zoom_checked.png"))
+                self._actions["zoom"].setIcon(self._qicon(Path(icon_dir) / "Zoom_checked.png"))
             else:
-                self._actions["zoom"].setIcon(QIcon(Path(icon_dir) / "Zoom.png"))
+                self._actions["zoom"].setIcon(self._qicon(Path(icon_dir) / "Zoom.png"))
 
 
 class KeypointMatplotlibCanvas(QWidget):
     """Trajectory plot using matplotlib for keypoints (t-y plot)."""
 
-    # FIXME: y axis should be reversed due to napari using top-left as origin
-
     def __init__(self, napari_viewer, parent=None):
         super().__init__(parent=parent)
 
         self.viewer = napari_viewer
+
         with mplstyle.context(self.mpl_style_sheet_path):
             self.canvas = FigureCanvas()
             self.canvas.figure.set_size_inches(4, 2, forward=True)
             self.canvas.figure.set_layout_engine("constrained")
             self.ax = self.canvas.figure.subplots()
+            self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
+            self.ax.set_xlabel("Frame")
+            self.ax.set_ylabel("Y position")
 
-        self.toolbar = NapariNavigationToolbar(self.canvas, parent=self)
+        # self.toolbar = NapariNavigationToolbar(self.canvas, parent=self)
+        self.toolbar = NavigationToolbar2QT(self.canvas, parent=self)
+        self.toolbar.setIconSize(QSize(28, 28))
         self._replace_toolbar_icons()
         self.canvas.mpl_connect("button_press_event", self.on_doubleclick)
-
-        self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
-        self.ax.set_xlabel("Frame")
-        self.ax.set_ylabel("Y position")
 
         self.slider = QSlider(Qt.Horizontal)
         self.slider.setMinimum(50)
@@ -122,11 +129,20 @@ class KeypointMatplotlibCanvas(QWidget):
 
         self.viewer.dims.events.current_step.connect(self.update_plot_range)
         self._n = 0
-        self.update_plot_range(Event(type_name="", value=[self.viewer.dims.current_step[0]]))
+        self.update_plot_range(
+            Event(type_name="", value=[self.viewer.dims.current_step[0]]),
+            force=True,
+        )
+        self._apply_axis_theme()
 
         self.viewer.layers.events.inserted.connect(self._load_dataframe)
         self.viewer.dims.events.range.connect(self._update_slider_max)
         self._lines: dict[str, list] = {}
+
+        # If layers already existed before this widget was created
+        # (e.g. drag-and-drop load before opening the plugin), populate
+        # the plot from the current viewer state on the next event-loop turn.
+        QTimer.singleShot(0, self.refresh_from_viewer_layers)
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):
@@ -134,9 +150,49 @@ class KeypointMatplotlibCanvas(QWidget):
                 return
             show = list(self._lines.values())[0][0].get_visible()
             for lines in self._lines.values():
-                for l in lines:
-                    l.set_visible(not show)
+                for line in lines:
+                    line.set_visible(not show)
             self._refresh_canvas(value=self._n)
+
+    def refresh_from_viewer_layers(self) -> None:
+        """
+        Refresh the trajectory plot from the current viewer state.
+
+        This is safe to call:
+        - after drag/drop loads that happened before the widget was opened
+        - after layer adoption / remap
+        - after later explicit layer changes
+
+        It intentionally:
+        1) reloads the dataframe from the current Points layer
+        2) updates the slider max from the current Image/Video layer
+        3) re-syncs visible lines to current point selection
+        """
+        try:
+            self._load_dataframe()
+        except Exception:
+            logger.debug("Trajectory plot: failed to load dataframe from viewer layers", exc_info=True)
+
+        try:
+            self._update_slider_max()
+        except Exception:
+            logger.debug("Trajectory plot: failed to update slider max", exc_info=True)
+
+        try:
+            self.sync_visible_lines_to_points_selection()
+        except Exception:
+            logger.debug("Trajectory plot: failed to sync visible lines to point selection", exc_info=True)
+
+    def _apply_axis_theme(self) -> None:
+        """Force axis/text colors to match napari theme."""
+        is_light = self._napari_theme_has_light_bg()
+        fg = "black" if is_light else "white"
+
+        self.ax.tick_params(axis="both", colors=fg, which="both")
+        self.ax.xaxis.label.set_color(fg)
+        self.ax.yaxis.label.set_color(fg)
+        self.ax.title.set_color(fg)
+        self.vline.set_color(fg)
 
     def _napari_theme_has_light_bg(self) -> bool:
         theme = napari.utils.theme.get_theme(self.viewer.theme)
@@ -147,15 +203,13 @@ class KeypointMatplotlibCanvas(QWidget):
     def mpl_style_sheet_path(self) -> Path:
         if self._napari_theme_has_light_bg():
             return _styles_traversable() / "light.mplstyle"
-        else:
-            return _styles_traversable() / "dark.mplstyle"
+        return _styles_traversable() / "dark.mplstyle"
 
     def _get_path_to_icon(self) -> Path:
         icon_root = _assets_traversable() / "icons"
         if self._napari_theme_has_light_bg():
             return icon_root / "black"
-        else:
-            return icon_root / "white"
+        return icon_root / "white"
 
     def _replace_toolbar_icons(self) -> None:
         icon_dir = self._get_path_to_icon()
@@ -167,53 +221,87 @@ class KeypointMatplotlibCanvas(QWidget):
                 )
             if text == "Zoom":
                 action.setToolTip("Zoom to rectangle; Click once to activate; Click again to deactivate")
-            if len(text) > 0:
-                icon_path = icon_dir / (text + ".png")
-                action.setIcon(QIcon(str(icon_path)))
+            if text:
+                icon_path = Path(icon_dir) / f"{text}.png"
+                try:
+                    action.setIcon(self.toolbar._qicon(icon_path))
+                except AttributeError:
+                    logger.debug(f"Failed to set toolbar icon from {icon_path}", exc_info=True)
 
     def _load_dataframe(self, event=None) -> None:
-        points_layer = get_first_points_layer(self.viewer)
-        if points_layer is None:
-            return
-        # Preserve existing semantics (numpy bool inversion) from original code
-        try:
-            if ~np.any(points_layer.data):
+        with mplstyle.context(self.mpl_style_sheet_path):
+            points_layer = get_first_points_layer(self.viewer)
+            data = getattr(points_layer, "data", None)
+
+            if points_layer is None or data is None or len(data) == 0:
                 return
-        except Exception:
-            return
 
-        # Silly hack so the window does not hang the first time it is shown
-        self.show()
-        self.hide()
+            # Silly hack so the window does not hang the first time it is shown
+            self.show()
+            self.hide()
 
-        try:
-            self.df = io.form_df(
-                points_layer.data,
-                layer_metadata=points_layer.metadata,
-                layer_properties=points_layer.properties,
-            )
-        except Exception as e:
-            logger.error("Failed to form DataFrame from points layer: %r", e, exc_info=True)
-            return
-
-        self._lines.clear()
-        self.ax.clear()
-        self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
-        self.ax.set_xlabel("Frame")
-        self.ax.set_ylabel("Y position")
-
-        for keypoint in self.df.columns.get_level_values("bodyparts").unique():
-            y = self.df.xs((keypoint, "y"), axis=1, level=["bodyparts", "coords"])
-            x = np.arange(len(y))
             try:
-                color = points_layer.metadata["face_color_cycles"]["label"][keypoint]
-            except Exception:
-                color = "C0"
-            lines = self.ax.plot(x, y, color=color, label=str(keypoint))
-            self._lines[str(keypoint)] = lines
+                self.df = io.form_df(
+                    points_layer.data,
+                    layer_metadata=points_layer.metadata,
+                    layer_properties=points_layer.properties,
+                )
+            except Exception as e:
+                logger.error("Failed to form DataFrame from points layer: %r", e, exc_info=True)
+                return
 
-        self._refresh_canvas(value=self._n)
+            image_layer = get_first_video_image_layer(self.viewer)
+            if image_layer is None:
+                image_layer = get_first_image_layer(self.viewer)
 
+            self._lines = {}
+            self.ax.clear()
+            self.ax.set_xlabel("Frame")
+            self.ax.set_ylabel("Y position")
+            self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
+            self._apply_axis_theme()
+
+            height = None
+            if image_layer is not None:
+                try:
+                    img_data = image_layer.data
+                    if getattr(image_layer, "rgb", False):
+                        height = img_data.shape[-3]
+                    else:
+                        height = img_data.shape[-2]
+                except Exception:
+                    height = None
+
+            for keypoint in self.df.columns.get_level_values("bodyparts").unique():
+                y = (
+                    self.df.xs(
+                        (keypoint, "y"),
+                        axis=1,
+                        level=["bodyparts", "coords"],
+                    )
+                    .to_numpy()
+                    .squeeze()
+                )
+                x = np.arange(len(y))
+                try:
+                    color = points_layer.metadata["face_color_cycles"]["label"][keypoint]
+                except Exception:
+                    color = "C0"
+                lines = self.ax.plot(x, y, color=color, label=str(keypoint))
+                self._lines[str(keypoint)] = lines
+
+            # Match napari image coordinates: y increases downward
+            if height is not None:
+                self.ax.set_ylim(height, 0)
+            else:
+                self.ax.invert_yaxis()
+
+            self._refresh_canvas(value=self._n)
+
+    @deprecated(
+        details="No longer used, instead visibility is based on napari Points selection.",
+        replacement="sync_visible_lines_to_points_selection",
+    )
     def _toggle_line_visibility(self, keypoint: str) -> None:
         if keypoint not in self._lines:
             return
@@ -221,31 +309,46 @@ class KeypointMatplotlibCanvas(QWidget):
             artist.set_visible(not artist.get_visible())
         self._refresh_canvas(value=self._n)
 
+    def show_only_keypoint(self, keypoint: str) -> None:
+        """Show only one keypoint trajectory; if unknown, show all."""
+        if keypoint not in self._lines:
+            self._show_all_keypoints()
+            return
+        self._set_visible_keypoints({keypoint})
+
     def _refresh_canvas(self, value: int) -> None:
         if self.df is None:
             return
-        start = max(0, value - self._window // 2)
-        end = min(value + self._window // 2, len(self.df))
-        self.ax.set_xlim(start, end)
-        self.vline.set_xdata([value])
-        self.canvas.draw()
+
+        with mplstyle.context(self.mpl_style_sheet_path):
+            start = max(0, value - self._window // 2)
+            end = min(value + self._window // 2, len(self.df))
+            self.ax.set_xlim(start, end)
+            self.vline.set_xdata([value])
+            self.canvas.draw()
 
     def set_window(self, value: int) -> None:
         self._window = value
         self.slider_value.setText(str(value))
         self.update_plot_range(Event(type_name="", value=[self._n]))
 
-    def update_plot_range(self, event) -> None:
+    def update_plot_range(self, event, force: bool = False) -> None:
+        if not self.isVisible() and not force:
+            return
+
         value = event.value[0]
         self._n = value
+
         if self.df is None:
             return
+
         self._refresh_canvas(value)
 
     def _update_slider_max(self, event=None) -> None:
         img = get_first_video_image_layer(self.viewer)
         if img is None:
             return
+
         try:
             n_frames = img.data.shape[0]
         except Exception:
@@ -255,3 +358,88 @@ class KeypointMatplotlibCanvas(QWidget):
             self.slider.setMaximum(self.slider.minimum())
         else:
             self.slider.setMaximum(n_frames - 1)
+
+    def _set_visible_keypoints(self, visible_keypoints: set[str]) -> None:
+        """Show only the given keypoint trajectories."""
+        if not self._lines:
+            return
+
+        for keypoint, artists in self._lines.items():
+            show = keypoint in visible_keypoints
+            for artist in artists:
+                artist.set_visible(show)
+
+        self._refresh_canvas(value=self._n)
+
+    def _show_all_keypoints(self) -> None:
+        """Show all trajectories."""
+        if not self._lines:
+            return
+
+        for artists in self._lines.values():
+            for artist in artists:
+                artist.set_visible(True)
+
+        self._refresh_canvas(value=self._n)
+
+    def _selected_bodyparts_from_points_layer(self) -> set[str]:
+        """
+        Return the set of selected bodypart labels from the first Points layer.
+
+        Notes
+        -----
+        - We intentionally key visibility by `label` because this plot currently
+        groups trajectories by bodypart name.
+        - If nothing is selected, returns an empty set.
+        """
+        points_layer = get_first_points_layer(self.viewer)
+        if points_layer is None:
+            return set()
+
+        selected = getattr(points_layer, "selected_data", None)
+        if not selected:
+            return set()
+
+        props = getattr(points_layer, "properties", {}) or {}
+        labels = props.get("label", None)
+        if labels is None:
+            return set()
+
+        try:
+            labels_arr = np.asarray(labels, dtype=object).ravel()
+        except Exception:
+            return set()
+
+        visible: set[str] = set()
+        for idx in selected:
+            try:
+                i = int(idx)
+            except Exception:
+                continue
+            if 0 <= i < len(labels_arr):
+                val = labels_arr[i]
+                if val is None:
+                    continue
+                text = str(val)
+                if text:
+                    visible.add(text)
+
+        return visible
+
+    def sync_visible_lines_to_points_selection(self) -> None:
+        """
+        Sync trajectory visibility to the current napari Points selection.
+
+        Behavior:
+        - no selected points -> show all trajectories
+        - selected points    -> show only trajectories whose bodypart label is selected
+        """
+        if not self._lines:
+            return
+
+        visible = self._selected_bodyparts_from_points_layer()
+        if not visible:
+            self._show_all_keypoints()
+            return
+
+        self._set_visible_keypoints(visible)

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -4,6 +4,7 @@ This module intentionally does not make decisions about what constitutes
 valid DLC points metadata; it only reads what it needs (face_color_cycles).
 """
 
+# src/napari_deeplabcut/ui/plots/trajectory.py
 from __future__ import annotations
 
 import logging
@@ -78,7 +79,7 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
                 self._actions["zoom"].setIcon(self._qicon(Path(icon_dir) / "Zoom.png"))
 
 
-class KeypointMatplotlibCanvas(QWidget):
+class TrajectoryMatplotlibCanvas(QWidget):
     """Trajectory plot using matplotlib for keypoints (t-y plot)."""
 
     def __init__(self, napari_viewer, parent=None):

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -18,7 +18,7 @@ from matplotlib.backends.backend_qtagg import FigureCanvas, NavigationToolbar2QT
 from napari.utils.events import Event
 from qtpy.QtCore import QSize, Qt, QTimer
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QHBoxLayout, QLabel, QSlider, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayout, QWidget
 
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut.core.layers import (
@@ -87,7 +87,7 @@ class KeypointMatplotlibCanvas(QWidget):
 
         with mplstyle.context(self.mpl_style_sheet_path):
             self.canvas = FigureCanvas()
-            self.canvas.figure.set_size_inches(4, 2, forward=True)
+            # self.canvas.figure.set_size_inches(4, 2, forward=True)
             self.canvas.figure.set_layout_engine("constrained")
             self.ax = self.canvas.figure.subplots()
             self.vline = self.ax.axvline(0, 0, 1, color="k", linestyle="--")
@@ -111,21 +111,33 @@ class KeypointMatplotlibCanvas(QWidget):
         self._window = self.slider.value()
         self.slider.valueChanged.connect(self.set_window)
 
-        layout = QVBoxLayout()
-        layout.addWidget(self.canvas)
-        layout.addWidget(self.toolbar)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        self.canvas.updateGeometry()
 
-        layout2 = QHBoxLayout()
-        layout2.addWidget(self.slider)
-        layout2.addWidget(self.slider_value)
-        layout.addLayout(layout2)
+        self.toolbar.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.slider.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.slider_value.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(4, 4, 4, 4)
+        layout.setSpacing(4)
+
+        # Give almost all vertical stretch to the plot canvas
+        layout.addWidget(self.canvas, stretch=1)
+        layout.addWidget(self.toolbar, stretch=0)
+
+        slider_row = QHBoxLayout()
+        slider_row.addWidget(self.slider, stretch=1)
+        slider_row.addWidget(self.slider_value, stretch=0)
+        layout.addLayout(slider_row, stretch=0)
 
         self.setLayout(layout)
 
         self.frames = []
         self.keypoints = []
         self.df = None
-        self.setMinimumHeight(300)
+        self.setMinimumSize(280, 350)
 
         self.viewer.dims.events.current_step.connect(self.update_plot_range)
         self._n = 0
@@ -145,6 +157,25 @@ class KeypointMatplotlibCanvas(QWidget):
         # (e.g. drag-and-drop load before opening the plugin), populate
         # the plot from the current viewer state on the next event-loop turn.
         QTimer.singleShot(0, self.refresh_from_viewer_layers)
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        self.canvas.draw_idle()
+
+    def sizeHint(self) -> QSize:
+        """
+        Preferred initial size for the trajectory plot dock widget.
+
+        Wide enough for the toolbar + slider, and tall enough that the plot
+        is useful by default without preventing later resizing.
+        """
+        return QSize(480, 340)
+
+    def minimumSizeHint(self) -> QSize:
+        """
+        Smallest comfortable size before the widget becomes cramped.
+        """
+        return QSize(280, 440)
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -23,6 +23,12 @@ from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayout, QWidget
 
 import napari_deeplabcut.core.io as io
+from napari_deeplabcut.config.models import DLCHeaderModel
+from napari_deeplabcut.config.settings import (
+    DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP,
+    DEFAULT_SINGLE_ANIMAL_CMAP,
+)
+from napari_deeplabcut.core.keypoints import build_color_cycles
 from napari_deeplabcut.core.layers import (
     get_first_image_layer,
     get_first_video_image_layer,
@@ -81,11 +87,11 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
 class TrajectoryMatplotlibCanvas(QWidget):
     """Trajectory plot using matplotlib for keypoints (t-y plot)."""
 
-    def __init__(self, napari_viewer, parent=None, get_color_mode=None):
+    def __init__(self, napari_viewer, parent=None, get_color_mode: callable = None):
         super().__init__(parent=parent)
 
         self.viewer = napari_viewer
-        self._get_color_mode = get_color_mode
+        self._get_color_mode = get_color_mode or (lambda: "bodypart")
 
         with mplstyle.context(self.mpl_style_sheet_path):
             self.canvas = FigureCanvas()
@@ -179,6 +185,54 @@ class TrajectoryMatplotlibCanvas(QWidget):
         """
         return QSize(280, 340)
 
+    def _get_header_model_from_metadata(self, md: dict) -> DLCHeaderModel | None:
+        """Return DLCHeaderModel from metadata['header'] when possible.
+        TODO: Check codebase for duplicate logic and centralize if needed.
+        """
+        if not isinstance(md, dict):
+            return None
+
+        hdr = md.get("header", None)
+        if hdr is None:
+            return None
+
+        if isinstance(hdr, DLCHeaderModel):
+            return hdr
+
+        if isinstance(hdr, dict):
+            try:
+                return DLCHeaderModel.model_validate(hdr)
+            except Exception:
+                return None
+
+        try:
+            return DLCHeaderModel(columns=hdr)
+        except Exception:
+            return None
+
+    def _is_multianimal_layer(self, layer: Points) -> bool:
+        """TODO: Check codebase for duplicate logic and centralize if needed."""
+        md = getattr(layer, "metadata", None) or {}
+        header = self._get_header_model_from_metadata(md)
+        if header is None:
+            return False
+
+        try:
+            inds = getattr(header, "individuals", None)
+            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+        except Exception:
+            return False
+
+    def _get_config_colormap(self, layer: Points) -> str:
+        """Return the colormap for the given layer based on its metadata.
+        TODO: Check codebase for duplicate logic and centralize if needed.
+        """
+        md = getattr(layer, "metadata", None) or {}
+        cmap = md.get("config_colormap")
+        if isinstance(cmap, str) and cmap:
+            return cmap
+        return DEFAULT_SINGLE_ANIMAL_CMAP
+
     def _plot_mode(self) -> str:
         try:
             mode = str(self._get_color_mode()).lower()
@@ -188,6 +242,24 @@ class TrajectoryMatplotlibCanvas(QWidget):
         if "individual" in mode:
             return "individual"
         return "bodypart"
+
+    @staticmethod
+    def _normalized_cycle(mapping) -> dict[str, object]:
+        """Return a cycle mapping with string keys for robust lookups."""
+        try:
+            return {str(k): v for k, v in (mapping or {}).items()}
+        except Exception:
+            return {}
+
+    @staticmethod
+    def _normalized_individual_name(value) -> str:
+        """Best-effort normalization for individual/id values used as cycle keys."""
+        if value is None:
+            return ""
+        text = str(value)
+        if not text or text.lower() == "nan":
+            return ""
+        return text
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):
@@ -319,8 +391,10 @@ class TrajectoryMatplotlibCanvas(QWidget):
                 return
 
             # Silly hack so the window does not hang the first time it is shown
+            was_visible = self.isVisible()
             self.show()
-            self.hide()
+            if not was_visible:
+                self.hide()
 
             try:
                 self.df = io.form_df(
@@ -567,20 +641,71 @@ class TrajectoryMatplotlibCanvas(QWidget):
         except Exception:
             return False
 
-    def _line_color_for(self, points_layer: Points, individual: str, bodypart: str):
-        cycles = (getattr(points_layer, "metadata", None) or {}).get("face_color_cycles", {}) or {}
-        mode = self._plot_mode()
+    def _resolved_face_color_cycles(self, layer: Points) -> dict[str, dict]:
+        """
+        Resolve the same label/id color cycles as ColorSchemeResolver.
 
-        if mode == "individual" and individual:
-            try:
-                return cycles.get("id", {})[individual]
-            except Exception:
-                pass
+        - label cycle uses the current config colormap
+        - id cycle uses DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP for multi-animal
+        - single-animal falls back to the bodypart cycle for both
+        """
+        md = getattr(layer, "metadata", None) or {}
+        header = self._get_header_model_from_metadata(md)
+        if header is None:
+            return {}
+
+        config_cmap = self._get_config_colormap(layer)
 
         try:
-            return cycles.get("label", {})[bodypart]
+            bodypart_cycles = build_color_cycles(header, config_cmap) or {}
         except Exception:
+            logger.debug("Trajectory plot: failed to build bodypart color cycles", exc_info=True)
+            bodypart_cycles = {}
+
+        if self._is_multianimal_layer(layer):
+            try:
+                individual_cycles = build_color_cycles(header, DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP) or {}
+            except Exception:
+                logger.debug("Trajectory plot: failed to build individual color cycles", exc_info=True)
+                individual_cycles = {}
+        else:
+            individual_cycles = bodypart_cycles
+
+        return {
+            "label": self._normalized_cycle(bodypart_cycles.get("label", {})),
+            "id": self._normalized_cycle(individual_cycles.get("id", {})),
+        }
+
+    def _line_color_for(self, points_layer: Points, individual: str, bodypart: str):
+        """
+        Resolve line color from the same logic as ColorSchemeResolver.
+
+        - individual mode -> prefer id cycle
+        - bodypart mode   -> prefer label cycle
+        - fallback        -> whichever exists
+        - final fallback  -> Matplotlib default
+        """
+        cycles = self._resolved_face_color_cycles(points_layer)
+        mode = self._plot_mode()
+
+        id_cycle = cycles.get("id", {}) or {}
+        label_cycle = cycles.get("label", {}) or {}
+
+        individual_key = self._normalized_individual_name(individual)
+        bodypart_key = str(bodypart)
+
+        if mode == "individual" and self._is_multianimal_layer(points_layer):
+            if individual_key and individual_key in id_cycle:
+                return id_cycle[individual_key]
+            if bodypart_key in label_cycle:
+                return label_cycle[bodypart_key]
             return "C0"
+
+        if bodypart_key in label_cycle:
+            return label_cycle[bodypart_key]
+        if individual_key and individual_key in id_cycle:
+            return id_cycle[individual_key]
+        return "C0"
 
     def _legend_text_for(self, individual: str, bodypart: str) -> str:
         if self._plot_mode() == "individual" and individual:
@@ -595,7 +720,13 @@ class TrajectoryMatplotlibCanvas(QWidget):
         names = list(cols.names)
 
         has_inds = "individuals" in names
-        individuals = list(cols.get_level_values("individuals").unique()) if has_inds else [""]
+        if has_inds:
+            individuals = [self._normalized_individual_name(v) for v in cols.get_level_values("individuals").unique()]
+            # preserve order while removing duplicates
+            seen = set()
+            individuals = [v for v in individuals if not (v in seen or seen.add(v))]
+        else:
+            individuals = [""]
 
         for individual in individuals:
             for bodypart in cols.get_level_values("bodyparts").unique():
@@ -613,7 +744,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
                 if y.size == 0:
                     continue
 
-                yield str(individual), str(bodypart), y
+                yield self._normalized_individual_name(individual), str(bodypart), y
 
     def _apply_toolbar_stylesheet(self) -> None:
         """

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -25,7 +25,6 @@ from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayou
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut.core.layers import (
     get_first_image_layer,
-    get_first_points_layer,
     get_first_video_image_layer,
 )
 from napari_deeplabcut.utils.deprecations import deprecated
@@ -82,10 +81,11 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
 class TrajectoryMatplotlibCanvas(QWidget):
     """Trajectory plot using matplotlib for keypoints (t-y plot)."""
 
-    def __init__(self, napari_viewer, parent=None):
+    def __init__(self, napari_viewer, parent=None, get_color_mode=None):
         super().__init__(parent=parent)
 
         self.viewer = napari_viewer
+        self._get_color_mode = get_color_mode
 
         with mplstyle.context(self.mpl_style_sheet_path):
             self.canvas = FigureCanvas()
@@ -151,7 +151,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
         self.viewer.layers.events.inserted.connect(self._load_dataframe)
         self.viewer.dims.events.range.connect(self._update_slider_max)
-        self._lines: dict[str, list] = {}
+        self._lines: dict[tuple[str, str], list] = {}
 
         self._apply_napari_theme()
         self._connect_theme_events()
@@ -178,6 +178,16 @@ class TrajectoryMatplotlibCanvas(QWidget):
         Smallest comfortable size before the widget becomes cramped.
         """
         return QSize(280, 340)
+
+    def _plot_mode(self) -> str:
+        try:
+            mode = str(self._get_color_mode()).lower()
+        except Exception:
+            mode = "bodypart"
+
+        if "individual" in mode:
+            return "individual"
+        return "bodypart"
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):
@@ -350,24 +360,14 @@ class TrajectoryMatplotlibCanvas(QWidget):
                 except Exception:
                     height = None
 
-            for keypoint in self.df.columns.get_level_values("bodyparts").unique():
-                y = self.df.xs(
-                    (keypoint, "y"),
-                    axis=1,
-                    level=["bodyparts", "coords"],
-                ).to_numpy()
+            self._lines = {}
 
-                # Important: a single-row dataframe can squeeze to a scalar.
-                y = np.atleast_1d(np.asarray(y).squeeze())
+            for individual, bodypart, y in self._iter_series():
                 x = np.arange(y.shape[0])
-
-                try:
-                    color = points_layer.metadata["face_color_cycles"]["label"][keypoint]
-                except Exception:
-                    color = "C0"
-
-                lines = self.ax.plot(x, y, color=color, label=str(keypoint))
-                self._lines[str(keypoint)] = lines
+                color = self._line_color_for(points_layer, individual, bodypart)
+                label = self._legend_text_for(individual, bodypart)
+                artists = self.ax.plot(x, y, color=color, label=label)
+                self._lines[(individual, bodypart)] = artists
 
             # Match napari image coordinates: y increases downward
             if height is not None:
@@ -389,11 +389,12 @@ class TrajectoryMatplotlibCanvas(QWidget):
         self._refresh_canvas(value=self._n)
 
     def show_only_keypoint(self, keypoint: str) -> None:
-        """Show only one keypoint trajectory; if unknown, show all."""
-        if keypoint not in self._lines:
+        """Show all trajectories matching one bodypart; if unknown, show all."""
+        matches = {k for k in self._lines if k[1] == keypoint}
+        if not matches:
             self._show_all_keypoints()
             return
-        self._set_visible_keypoints({keypoint})
+        self._set_visible_keypoints(matches)
 
     def _refresh_canvas(self, value: int) -> None:
         if not self._has_refreshable_df():
@@ -439,13 +440,18 @@ class TrajectoryMatplotlibCanvas(QWidget):
         else:
             self.slider.setMaximum(n_frames - 1)
 
-    def _set_visible_keypoints(self, visible_keypoints: set[str]) -> None:
-        """Show only the given keypoint trajectories."""
+    def _set_visible_keypoints(self, visible_keys: set) -> None:
         if not self._lines:
             return
 
-        for keypoint, artists in self._lines.items():
-            show = keypoint in visible_keypoints
+        mode = self._plot_mode()
+
+        for (individual, bodypart), artists in self._lines.items():
+            if mode == "individual":
+                show = (individual, bodypart) in visible_keys
+            else:
+                show = bodypart in visible_keys
+
             for artist in artists:
                 artist.set_visible(show)
 
@@ -464,26 +470,8 @@ class TrajectoryMatplotlibCanvas(QWidget):
         if self.isVisible():
             self._refresh_canvas(value=self._n)
 
-    def _selected_bodyparts_from_points_layer(self) -> set[str]:
-        """
-        Return the set of selected bodypart labels from the Points layer used
-        to build the trajectory plot.
-
-        Notes
-        -----
-        - We intentionally key visibility by `label` because this plot currently
-        groups trajectories by bodypart name.
-        - We use the same Points layer selection policy as the plotting code so
-        selection-driven visibility cannot drift out of sync with the plotted
-        dataframe.
-        - If nothing is selected, returns an empty set.
-        """
-        points_layer = None
-        get_plot_points_layer = getattr(self, "_get_plot_points_layer", None)
-        if callable(get_plot_points_layer):
-            points_layer = get_plot_points_layer()
-        if points_layer is None:
-            points_layer = get_first_points_layer(self.viewer)
+    def _selected_line_keys_from_points_layer(self) -> set:
+        points_layer = self._get_plot_points_layer()
         if points_layer is None:
             return set()
 
@@ -493,6 +481,8 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
         props = getattr(points_layer, "properties", {}) or {}
         labels = props.get("label", None)
+        ids = props.get("id", None)
+
         if labels is None:
             return set()
 
@@ -501,19 +491,38 @@ class TrajectoryMatplotlibCanvas(QWidget):
         except Exception:
             return set()
 
-        visible: set[str] = set()
+        try:
+            ids_arr = np.asarray(ids, dtype=object).ravel() if ids is not None else None
+        except Exception:
+            ids_arr = None
+
+        mode = self._plot_mode()
+        visible = set()
+
         for idx in selected:
             try:
                 i = int(idx)
             except Exception:
                 continue
-            if 0 <= i < len(labels_arr):
-                val = labels_arr[i]
-                if val is None:
-                    continue
-                text = str(val)
-                if text:
-                    visible.add(text)
+            if not (0 <= i < len(labels_arr)):
+                continue
+
+            label = str(labels_arr[i])
+            if not label:
+                continue
+
+            if mode == "individual":
+                individual = ""
+                if ids_arr is not None and i < len(ids_arr):
+                    val = ids_arr[i]
+                    if val is not None:
+                        text = str(val)
+                        if text and text.lower() != "nan":
+                            individual = text
+                visible.add((individual, label))
+            else:
+                # bodypart mode -> show all series with this bodypart
+                visible.add(label)
 
         return visible
 
@@ -523,12 +532,12 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
         Behavior:
         - no selected points -> show all trajectories
-        - selected points    -> show only trajectories whose bodypart label is selected
+        - selected points    -> show only trajectories for the selected (id, label) pairs
         """
         if not self._lines:
             return
 
-        visible = self._selected_bodyparts_from_points_layer()
+        visible = self._selected_line_keys_from_points_layer()
         if not visible:
             self._show_all_keypoints()
             return
@@ -546,21 +555,65 @@ class TrajectoryMatplotlibCanvas(QWidget):
             elif text == "Zoom":
                 action.setToolTip("Zoom to rectangle; Click once to activate; Click again to deactivate")
 
-    # def _apply_toolbar_icons(self) -> None:
-    #     """
-    #     Apply static black/white toolbar icons based on the current napari theme.
+    def _df_has_individuals(self) -> bool:
+        if self.df is None:
+            return False
+        try:
+            cols = self.df.columns
+            if "individuals" not in cols.names:
+                return False
+            vals = [str(v) for v in cols.get_level_values("individuals").unique()]
+            return any(v != "" for v in vals)
+        except Exception:
+            return False
 
-    #     This does not override toolbar behavior; it only replaces the displayed icons.
-    #     """
-    #     icon_dir = self._get_path_to_icon()
-    #     for action in self.toolbar.actions():
-    #         text = action.text()
-    #         if not text:
-    #             continue
+    def _line_color_for(self, points_layer: Points, individual: str, bodypart: str):
+        cycles = (getattr(points_layer, "metadata", None) or {}).get("face_color_cycles", {}) or {}
+        mode = self._plot_mode()
 
-    #         icon_path = Path(icon_dir) / f"{text}.png"
-    #         if icon_path.exists():
-    #             action.setIcon(QIcon(str(icon_path)))
+        if mode == "individual" and individual:
+            try:
+                return cycles.get("id", {})[individual]
+            except Exception:
+                pass
+
+        try:
+            return cycles.get("label", {})[bodypart]
+        except Exception:
+            return "C0"
+
+    def _legend_text_for(self, individual: str, bodypart: str) -> str:
+        if self._plot_mode() == "individual" and individual:
+            return f"{individual} • {bodypart}"
+        return bodypart
+
+    def _iter_series(self):
+        if self.df is None:
+            return
+
+        cols = self.df.columns
+        names = list(cols.names)
+
+        has_inds = "individuals" in names
+        individuals = list(cols.get_level_values("individuals").unique()) if has_inds else [""]
+
+        for individual in individuals:
+            for bodypart in cols.get_level_values("bodyparts").unique():
+                mask = cols.get_level_values("bodyparts") == bodypart
+                mask &= cols.get_level_values("coords") == "y"
+
+                if has_inds:
+                    mask &= cols.get_level_values("individuals") == individual
+
+                y_df = self.df.loc[:, mask]
+                if y_df.shape[1] == 0:
+                    continue
+
+                y = np.asarray(y_df.iloc[:, 0].to_numpy(), dtype=float).ravel()
+                if y.size == 0:
+                    continue
+
+                yield str(individual), str(bodypart), y
 
     def _apply_toolbar_stylesheet(self) -> None:
         """

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -177,7 +177,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         """
         Smallest comfortable size before the widget becomes cramped.
         """
-        return QSize(280, 440)
+        return QSize(280, 340)
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import logging
+import platform
+import sys
+import threading
+import traceback
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from importlib import metadata
+from pathlib import Path
+
+_DEBUG_HANDLER_ATTR = "_napari_dlc_debug_recorder"
+LOG_QUEUE_MAXLEN = 1000
+
+
+def install_debug_recorder(
+    *,
+    logger_name: str = "napari-deeplabcut",
+    capacity: int = LOG_QUEUE_MAXLEN,
+) -> InMemoryDebugRecorder:
+    """
+    Attach a single in-memory recorder to the plugin logger namespace.
+    Idempotent: repeated calls return the same recorder.
+    """
+    root_logger = logging.getLogger(logger_name)
+
+    existing = getattr(root_logger, _DEBUG_HANDLER_ATTR, None)
+    if isinstance(existing, InMemoryDebugRecorder):
+        return existing
+
+    recorder = InMemoryDebugRecorder(capacity=capacity, level=logging.DEBUG)
+    recorder.set_name("napari-deeplabcut-debug-recorder")
+
+    # Important:
+    # - attach only to plugin namespace, not global root logger
+    # - set logger level to DEBUG so plugin debug calls are emitted
+    # - keep propagation unchanged
+    root_logger.addHandler(recorder)
+    root_logger.setLevel(logging.DEBUG)
+
+    setattr(root_logger, _DEBUG_HANDLER_ATTR, recorder)
+    return recorder
+
+
+def get_debug_recorder(
+    *,
+    logger_name: str = "napari-deeplabcut",
+) -> InMemoryDebugRecorder | None:
+    logger = logging.getLogger(logger_name)
+    recorder = getattr(logger, _DEBUG_HANDLER_ATTR, None)
+    return recorder if isinstance(recorder, InMemoryDebugRecorder) else None
+
+
+# --------------------------
+#  Debug infrastructure
+# --------------------------
+
+# Recorder
+
+
+@dataclass(frozen=True)
+class RecordedLog:
+    created: float
+    level: str
+    logger_name: str
+    message: str
+    exc_text: str | None = None
+
+
+class InMemoryDebugRecorder(logging.Handler):
+    """
+    Lightweight, fail-open in-memory log recorder.
+
+    Safety properties:
+    - bounded memory via deque(maxlen=...)
+    - no file/network I/O
+    - swallow-all-errors in emit()
+    - does not log from inside itself
+    - stores only small text snapshots
+    """
+
+    def __init__(self, *, capacity: int = LOG_QUEUE_MAXLEN, level: int = logging.DEBUG):
+        super().__init__(level=level)
+        self._records: deque[RecordedLog] = deque(maxlen=max(10, int(capacity)))
+        self._lock = threading.Lock()
+        self._dropped = 0
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            # Never call logging from here.
+            # Never inspect plugin objects.
+            msg = self._safe_message(record)
+            exc_text = self._safe_exception_text(record)
+
+            snap = RecordedLog(
+                created=float(getattr(record, "created", 0.0) or 0.0),
+                level=str(getattr(record, "levelname", "UNKNOWN")),
+                logger_name=str(getattr(record, "name", "")),
+                message=msg,
+                exc_text=exc_text,
+            )
+
+            with self._lock:
+                self._records.append(snap)
+
+        except Exception:
+            # Fail open: never let diagnostics interfere with runtime behavior.
+            try:
+                self._dropped += 1
+            except Exception:
+                pass
+
+    def clear(self) -> None:
+        try:
+            with self._lock:
+                self._records.clear()
+                self._dropped = 0
+        except Exception:
+            pass
+
+    def snapshot(self) -> list[RecordedLog]:
+        try:
+            with self._lock:
+                return list(self._records)
+        except Exception:
+            return []
+
+    def render_text(self, *, limit: int = 200) -> str:
+        lines: list[str] = []
+        try:
+            records = self.snapshot()[-max(1, int(limit)) :]
+            for rec in records:
+                ts = datetime.fromtimestamp(rec.created).strftime("%H:%M:%S")
+                lines.append(f"{ts} | {rec.level:<8} | {rec.logger_name} | {rec.message}")
+                if rec.exc_text:
+                    lines.append(rec.exc_text.rstrip())
+            if self._dropped:
+                lines.append(f"[debug-recorder] dropped internal failures: {self._dropped}")
+        except Exception:
+            return "[debug-recorder] failed to render logs"
+        return "\n".join(lines)
+
+    @staticmethod
+    def _safe_message(record: logging.LogRecord) -> str:
+        try:
+            return record.getMessage()
+        except Exception:
+            try:
+                return str(record.msg)
+            except Exception:
+                return "<unrenderable log message>"
+
+    @staticmethod
+    def _safe_exception_text(record: logging.LogRecord) -> str | None:
+        try:
+            if not record.exc_info:
+                return None
+            return "".join(traceback.format_exception(*record.exc_info))
+        except Exception:
+            return "<exception details unavailable>"
+
+
+# Env info
+
+
+def _version(dist_name: str) -> str:
+    try:
+        return metadata.version(dist_name)
+    except Exception:
+        return "not-installed"
+
+
+def _module_path(module_name: str) -> str:
+    try:
+        mod = __import__(module_name)
+        p = getattr(mod, "__file__", None)
+        return str(Path(p).resolve()) if p else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _safe_tail(pathlike) -> str:
+    """
+    Redact user-specific absolute paths:
+    keep only the last 2 path components when possible.
+    """
+    try:
+        p = Path(str(pathlike))
+        parts = p.parts
+        if len(parts) >= 2:
+            return str(Path(*parts[-2:]))
+        return str(p)
+    except Exception:
+        return str(pathlike)
+
+
+def collect_environment_summary() -> dict[str, str]:
+    return {
+        "python": sys.version.replace("\n", " "),
+        "platform": platform.platform(),
+        "napari-deeplabcut": _version("napari-deeplabcut"),
+        "napari": _version("napari"),
+        "qtpy": _version("QtPy"),
+        "PySide6": _version("PySide6"),
+        "PyQt6": _version("PyQt6"),
+        "shiboken6": _version("shiboken6"),
+        "numpy": _version("numpy"),
+        "pydantic": _version("pydantic"),
+        "plugin_module_path": _module_path("napari_deeplabcut"),
+    }
+
+
+def summarize_layer(layer) -> dict[str, object]:
+    try:
+        md = dict(getattr(layer, "metadata", {}) or {})
+    except Exception:
+        md = {}
+
+    def _len_or_none(x):
+        try:
+            return len(x)
+        except Exception:
+            return None
+
+    summary = {
+        "name": getattr(layer, "name", "<unnamed>"),
+        "type": type(layer).__name__,
+        "visible": bool(getattr(layer, "visible", True)),
+        "metadata_keys": sorted(md.keys()),
+        "project": _safe_tail(md.get("project")) if md.get("project") else None,
+        "root": _safe_tail(md.get("root")) if md.get("root") else None,
+        "paths_count": _len_or_none(md.get("paths")),
+        "has_header": md.get("header") is not None,
+        "has_tables": bool(md.get("tables")),
+        "has_save_target": md.get("save_target") is not None,
+    }
+
+    # Optional lightweight properties summary
+    try:
+        props = getattr(layer, "properties", {}) or {}
+        summary["property_keys"] = sorted(props.keys())
+    except Exception:
+        summary["property_keys"] = []
+
+    # Optional lightweight data shape
+    try:
+        data = getattr(layer, "data", None)
+        summary["data_shape"] = getattr(data, "shape", None)
+    except Exception:
+        summary["data_shape"] = None
+
+    return summary
+
+
+def summarize_viewer(viewer) -> dict[str, object]:
+    try:
+        layers = list(viewer.layers)
+    except Exception:
+        layers = []
+
+    try:
+        active = viewer.layers.selection.active
+        active_name = getattr(active, "name", None) if active is not None else None
+    except Exception:
+        active_name = None
+
+    return {
+        "n_layers": len(layers),
+        "active_layer": active_name,
+        "layers": [summarize_layer(layer) for layer in layers],
+    }
+
+
+def format_debug_report(
+    *,
+    env: dict[str, str],
+    viewer_summary: dict[str, object],
+    logs_text: str,
+) -> str:
+    lines: list[str] = []
+
+    lines.append("## Environment")
+    for k, v in env.items():
+        lines.append(f"- {k}: {v}")
+
+    lines.append("")
+    lines.append("## Viewer")
+    lines.append(f"- n_layers: {viewer_summary.get('n_layers')}")
+    lines.append(f"- active_layer: {viewer_summary.get('active_layer')}")
+
+    lines.append("")
+    lines.append("## Layers")
+    for idx, layer in enumerate(viewer_summary.get("layers", []), start=1):
+        lines.append(f"- [{idx}] name={layer.get('name')!r}, type={layer.get('type')}, visible={layer.get('visible')}")
+        lines.append(f"  - data_shape: {layer.get('data_shape')}")
+        lines.append(f"  - metadata_keys: {layer.get('metadata_keys')}")
+        lines.append(f"  - property_keys: {layer.get('property_keys')}")
+        lines.append(f"  - project: {layer.get('project')}")
+        lines.append(f"  - root: {layer.get('root')}")
+        lines.append(f"  - paths_count: {layer.get('paths_count')}")
+        lines.append(f"  - has_header: {layer.get('has_header')}")
+        lines.append(f"  - has_tables: {layer.get('has_tables')}")
+        lines.append(f"  - has_save_target: {layer.get('has_save_target')}")
+
+    lines.append("")
+    lines.append("## Recent plugin logs")
+    lines.append("```text")
+    lines.append(logs_text or "<no captured logs>")
+    lines.append("```")
+
+    return "\n".join(lines)

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -84,7 +84,7 @@ class InMemoryDebugRecorder(logging.Handler):
 
     def __init__(self, *, capacity: int = LOG_QUEUE_MAXLEN, level: int = logging.DEBUG):
         super().__init__(level=level)
-        self._records: deque[RecordedLog] = deque(maxlen=max(10, int(capacity)))
+        self._records: deque[RecordedLog] = deque(maxlen=max(1, int(capacity)))
         self._lock = threading.Lock()
         self._dropped = 0
 
@@ -195,8 +195,8 @@ def _safe_tail(pathlike) -> str:
         p = Path(str(pathlike))
         parts = p.parts
         if len(parts) >= 2:
-            return str(Path(*parts[-2:]))
-        return str(p)
+            return str(Path(*parts[-2:]).as_posix())
+        return str(p.as_posix())
     except Exception:
         return str(pathlike)
 

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/utils/debug.py
 from __future__ import annotations
 
 import logging
@@ -315,3 +316,21 @@ def format_debug_report(
     lines.append("```")
 
     return "\n".join(lines)
+
+
+def build_debug_report(
+    *,
+    viewer,
+    recorder: InMemoryDebugRecorder | None,
+    log_limit: int = 300,
+) -> str:
+    logs_text = recorder.render_text(limit=log_limit) if recorder is not None else "<debug recorder unavailable>"
+
+    env = collect_environment_summary()
+    viewer_summary = summarize_viewer(viewer)
+
+    return format_debug_report(
+        env=env,
+        viewer_summary=viewer_summary,
+        logs_text=logs_text,
+    )


### PR DESCRIPTION
## Automated summary

This pull request refactors the trajectory plotting and points layer selection synchronization in the napari-deeplabcut plugin. 
It introduces a new `TrajectoryMatplotlibCanvas`, replaces the old keypoint plot canvas, and adds robust synchronization between the points layer selection and trajectory plot visibility. 
The changes also include new end-to-end and UI tests to verify the improved behavior.

---

## Key changes:

### Trajectory Plot Refactor & Synchronization

* Replaces `KeypointMatplotlibCanvas` with `TrajectoryMatplotlibCanvas` throughout the codebase, updating all references, tests, and widget logic for clarity and maintainability. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L126-R128) [[2]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L19-R19) [[3]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L238-R238)
* Plot now updates based on individual/bodypart color mode selection : in individual mode, lines are colored using the correct colormap.
* Refactors the widget logic to use new methods (`_traj_mpl_canvas`, `_ensure_traj_canvas_docked`, `_show_traj_canvas`, etc.) and ensures that the trajectory plot is properly docked, shown, or hidden as needed. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L258-R263) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L638-R657) [[3]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L650-R739) [[4]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L289-R292) [[5]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L304-R307) [[6]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L344-R347) [[7]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L368-R371)
* Adds `_refresh_trajectory_plot_from_layers` to update the trajectory plot when layers are adopted, fixing issues when data is loaded before the plugin UI is opened.

### Points Layer Selection Synchronization

* Introduces `PointsInteractionObserver` and `PointsInteractionEvent` to observe and respond to selection changes in points layers, keeping the trajectory plot in sync with the current selection. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R64-R65) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L302-R314) [[3]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L650-R739)
* Implements the `_on_points_interaction` method to update trajectory plot visibility based on the selection state of the active points layer.

### Testing Improvements

* Adds new end-to-end and UI tests for the trajectory plot and points selection synchronization, ensuring correct behavior when selecting/deselecting points and switching layers. [[1]](diffhunk://#diff-d8b6bdf943c5c8f86b24bcc143cf30435e2dd1daa7a17f204badfdcbc335bae7R244-R311) [[2]](diffhunk://#diff-d48350f0a69f7c399282b7b0433fb4f56f72b8a6f19c835910d468aadaa09069R1-R87)
* Updates existing tests to use the new `TrajectoryMatplotlibCanvas` and related methods. [[1]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L257-R261) [[2]](diffhunk://#diff-d6a21a285e1e0ab9f289eeb2b79ad12196c03d708d45e07b8defe57e2bd22547L325-R332)

### Minor Codebase Cleanups

* Adds missing future imports and minor docstring/compatibility improvements. [[1]](diffhunk://#diff-d8b6bdf943c5c8f86b24bcc143cf30435e2dd1daa7a17f204badfdcbc335bae7R1-R7) [[2]](diffhunk://#diff-f59d8b7376b8305457ab6d2c68c4900132efd221b061b7ee63216ce716b1c757R1) [[3]](diffhunk://#diff-f59d8b7376b8305457ab6d2c68c4900132efd221b061b7ee63216ce716b1c757R12)

These changes improve the user experience of trajectory visualization and interaction within the plugin.