### PR TITLE
Plugin refactor [8]: Improve layer management/lifecycle

### DIFF
--- a/src/napari_deeplabcut/_reader.py
+++ b/src/napari_deeplabcut/_reader.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from pathlib import Path
 
 from napari_deeplabcut.config._autostart import maybe_install_keypoint_controls_autostart
+from napari_deeplabcut.config.models import DLCProjectContext
 from napari_deeplabcut.core.discovery import discover_annotations
 from napari_deeplabcut.core.io import (
     SUPPORTED_IMAGES,
@@ -17,9 +19,39 @@ from napari_deeplabcut.core.io import (
     read_images,
     read_video,
 )
-from napari_deeplabcut.core.project_paths import looks_like_dlc_labeled_folder
+from napari_deeplabcut.core.project_paths import (
+    infer_dlc_project_from_labeled_folder,
+    infer_dlc_project_from_video_path,
+    looks_like_dlc_labeled_folder,
+    session_key_from_project_context,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _build_dlc_layer_meta(
+    *,
+    session_role: str | None,
+    project_context: DLCProjectContext | None,
+) -> dict:
+    """
+    Build explicit DLC lifecycle metadata for image/video layers.
+
+    If session_role is None or project_context is None, the layer should be
+    treated as a non-session image/video by lifecycle code.
+    """
+    if session_role is None or project_context is None:
+        return {
+            "session_role": None,
+            "project_context": None,
+            "session_key": None,
+        }
+
+    return {
+        "session_role": session_role,
+        "project_context": project_context.model_dump(mode="python", exclude_none=True),
+        "session_key": session_key_from_project_context(project_context),
+    }
 
 
 def get_hdf_reader(path):
@@ -40,9 +72,28 @@ def get_image_reader(path):
 
 
 def get_video_reader(path):
-    if isinstance(path, str) and any(path.lower().endswith(ext) for ext in SUPPORTED_VIDEOS):
-        return read_video
-    return None
+    if not isinstance(path, str) or not any(path.lower().endswith(ext) for ext in SUPPORTED_VIDEOS):
+        return None
+
+    ctx = infer_dlc_project_from_video_path(path)
+    if ctx is None:
+        # Generic non-DLC video layer: allowed, but ignored by lifecycle session context.
+        return partial(
+            read_video,
+            dlc_meta=_build_dlc_layer_meta(
+                session_role=None,
+                project_context=None,
+            ),
+        )
+
+    maybe_install_keypoint_controls_autostart()
+    return partial(
+        read_video,
+        dlc_meta=_build_dlc_layer_meta(
+            session_role="video",
+            project_context=ctx,
+        ),
+    )
 
 
 def get_config_reader(path):
@@ -87,7 +138,17 @@ def get_folder_parser(path):
             )
         return None
 
-    layers.extend(read_images(images))
+    ctx = infer_dlc_project_from_labeled_folder(path)
+
+    layers.extend(
+        read_images(
+            images,
+            dlc_meta=_build_dlc_layer_meta(
+                session_role="image",
+                project_context=ctx,
+            ),
+        )
+    )
 
     # Deterministic discovery: load ALL H5 artifacts
     artifacts = discover_annotations(path)

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -8,6 +8,7 @@ import cv2
 import numpy as np
 import pandas as pd
 import pytest
+from napari.utils.events import Event
 from qtpy.QtWidgets import QApplication, QDockWidget
 from skimage.io import imsave
 
@@ -199,9 +200,43 @@ def images(tmp_path_factory, viewer, fake_image):
     return viewer.open(output_path, plugin="napari-deeplabcut")[0]
 
 
+class DummyDimsForStore:
+    def __init__(self, nsteps=5, current_step=0):
+        self.nsteps = (nsteps,)
+        self.current_step = (current_step,)
+        self.set_calls = []
+
+    def set_current_step(self, axis, value):
+        self.set_calls.append((axis, value))
+        steps = list(self.current_step)
+        while len(steps) <= axis:
+            steps.append(0)
+        steps[axis] = value
+        self.current_step = tuple(steps)
+
+
+class DummyViewerForStore:
+    def __init__(self, nsteps=5, current_step=0):
+        self.dims = DummyDimsForStore(nsteps=nsteps, current_step=current_step)
+
+
 @pytest.fixture
-def store(viewer, points):
-    return keypoints.KeypointStore(viewer, points)
+def store(points):
+    try:
+        data = np.asarray(points.data)
+        nsteps = int(np.nanmax(data[:, 0])) + 1 if data.size else 1
+    except Exception:
+        nsteps = 1
+
+    viewer = DummyViewerForStore(nsteps=nsteps)
+    store = keypoints.KeypointStore(viewer, points)
+
+    # Mimic the minimal runtime wiring used by LOOP mode
+    if not hasattr(points.events, "query_next_frame"):
+        points.events.add(query_next_frame=Event)
+    points.events.query_next_frame.connect(store._advance_step)
+
+    return store
 
 
 @pytest.fixture

--- a/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
@@ -29,7 +29,7 @@ def _write_h5_single_animal(
     )
     df = pd.DataFrame([values], index=list(index), columns=cols)
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_hdf(path, key="keypoints", mode="w")
+    df.to_hdf(path, key="df_with_missing", mode="w")
     return df
 
 

--- a/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
@@ -18,7 +18,7 @@ def test_resolve_output_path_returns_none_for_machine_without_save_target():
                 "project_root": str(Path.cwd()),
                 "source_relpath_posix": "machinelabels-iter0.h5",
                 "kind": AnnotationKind.MACHINE,
-                "dataset_key": "keypoints",
+                "dataset_key": "df_with_missing",
             }
         }
     }
@@ -39,7 +39,7 @@ def test_write_hdf_refuses_machine_without_promotion(tmp_path: Path):
                 "project_root": str(tmp_path),
                 "source_relpath_posix": "machinelabels-iter0.h5",
                 "kind": AnnotationKind.MACHINE,
-                "dataset_key": "keypoints",
+                "dataset_key": "df_with_missing",
             },
             # header is required by writer
             "header": {
@@ -84,7 +84,7 @@ def test_write_hdf_aborts_machine_without_promotion_target(tmp_path: Path):
                 "project_root": str(tmp_path),
                 "source_relpath_posix": "machinelabels-iter0.h5",
                 "kind": AnnotationKind.MACHINE,
-                "dataset_key": "keypoints",
+                "dataset_key": "df_with_missing",
             },
             "header": {"columns": [("S", "", "bp1", "x"), ("S", "", "bp1", "y")]},
         },

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from napari.layers import Image, Points
+
+from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
+
+
+class DummySignal:
+    def __init__(self):
+        self._callbacks = []
+
+    def connect(self, callback):
+        if callback not in self._callbacks:
+            self._callbacks.append(callback)
+
+    def disconnect(self, callback):
+        if callback in self._callbacks:
+            self._callbacks.remove(callback)
+
+    @property
+    def callbacks(self):
+        return list(self._callbacks)
+
+
+class DummyLayerEvents:
+    def __init__(self):
+        self.inserted = DummySignal()
+        self.removed = DummySignal()
+
+
+class DummyLayerList(list):
+    def __init__(self, layers=()):
+        super().__init__(layers)
+        self.events = DummyLayerEvents()
+
+
+class DummyViewer:
+    def __init__(self, layers=()):
+        self.layers = DummyLayerList(layers)
+
+
+class DummyOwner:
+    def __init__(self, viewer):
+        self.viewer = viewer
+        self.calls = []
+
+    def _setup_image_layer(self, layer, index, reorder=True):
+        self.calls.append(("setup_image", layer, index, reorder))
+
+    def _setup_points_layer(self, layer, allow_merge=True):
+        self.calls.append(("setup_points", layer, allow_merge))
+
+    def _remap_frame_indices(self, layer):
+        self.calls.append(("remap", layer))
+
+    def _refresh_video_panel_context(self):
+        self.calls.append(("refresh_video",))
+
+    def _refresh_layer_status_panel(self):
+        self.calls.append(("refresh_status",))
+
+    def _handle_removed_layer(self, layer):
+        self.calls.append(("handle_removed", layer))
+
+
+def make_image(name="img"):
+    layer = Image(np.zeros((5, 5)))
+    layer.name = name
+    return layer
+
+
+def make_points(name="pts"):
+    layer = Points(np.zeros((0, 3)))
+    layer.name = name
+    return layer
+
+
+def test_manager_attach_and_detach_are_idempotent(qtbot):
+    viewer = DummyViewer()
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    manager.attach()
+    manager.attach()
+
+    assert viewer.layers.events.inserted.callbacks == [manager.on_insert]
+    assert viewer.layers.events.removed.callbacks == [manager.on_remove]
+
+    manager.detach()
+    manager.detach()
+
+    assert viewer.layers.events.inserted.callbacks == []
+    assert viewer.layers.events.removed.callbacks == []
+
+
+def test_manager_register_and_query_managed_points(qtbot):
+    viewer = DummyViewer()
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    pts = make_points()
+    store = object()
+
+    assert manager.has_managed_points() is False
+    assert manager.managed_points_count() == 0
+    assert manager.managed_points_layers() == ()
+
+    manager.register_managed_points_layer(pts, store)
+
+    assert manager.is_managed(pts) is True
+    assert manager.has_managed_points() is True
+    assert manager.managed_points_count() == 1
+    assert manager.managed_points_layers() == (pts,)
+    assert list(manager.iter_managed_points()) == [(pts, store)]
+
+    removed = manager.unregister_managed_layer(pts)
+    assert removed is store
+    assert manager.has_managed_points() is False
+
+
+def test_manager_on_insert_points_delegates_to_owner_and_remaps_non_images(qtbot):
+    img = make_image()
+    pts_existing = make_points("existing")
+    pts_inserted = make_points("inserted")
+
+    viewer = DummyViewer([img, pts_existing, pts_inserted])
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    event = SimpleNamespace(value=pts_inserted, index=2, source=viewer.layers)
+
+    manager.on_insert(event)
+
+    assert ("setup_points", pts_inserted, True) in owner.calls
+    assert ("remap", pts_existing) in owner.calls
+    assert ("remap", pts_inserted) in owner.calls
+    assert ("refresh_video",) in owner.calls
+    assert ("refresh_status",) in owner.calls
+
+
+def test_manager_on_insert_image_delegates_to_owner(qtbot):
+    img = make_image("inserted-image")
+    pts = make_points()
+
+    viewer = DummyViewer([img, pts])
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    event = SimpleNamespace(value=img, index=0, source=viewer.layers)
+
+    manager.on_insert(event)
+
+    assert ("setup_image", img, 0, True) in owner.calls
+    assert ("remap", pts) in owner.calls
+    assert ("refresh_video",) in owner.calls
+    assert ("refresh_status",) in owner.calls
+
+
+def test_manager_adopt_existing_layers_skips_already_managed_points(qtbot):
+    img = make_image()
+    pts_managed = make_points("managed")
+    pts_unmanaged = make_points("unmanaged")
+
+    viewer = DummyViewer([img, pts_managed, pts_unmanaged])
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    manager.register_managed_points_layer(pts_managed, object())
+
+    manager.adopt_existing_layers()
+
+    assert ("setup_image", img, 0, True) in owner.calls
+    assert ("setup_points", pts_unmanaged, False) in owner.calls
+    assert ("setup_points", pts_managed, False) not in owner.calls
+    assert ("remap", pts_managed) in owner.calls
+    assert ("remap", pts_unmanaged) in owner.calls
+
+
+def test_manager_on_remove_delegates_to_owner(qtbot):
+    pts = make_points()
+    viewer = DummyViewer([pts])
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    event = SimpleNamespace(value=pts)
+
+    manager.on_remove(event)
+
+    assert owner.calls == [("handle_removed", pts)]
+
+
+@pytest.mark.parametrize(
+    ("event_factory", "expected_name"),
+    [
+        (lambda viewer, img, pts: SimpleNamespace(value=pts, index=1, source=viewer.layers), "pts"),
+        (lambda viewer, img, pts: SimpleNamespace(index=1, source=viewer.layers), "pts"),
+        (lambda viewer, img, pts: SimpleNamespace(source=[img, pts]), "pts"),
+    ],
+)
+def test_manager_resolve_inserted_layer_prefers_value_then_index_then_source(qtbot, event_factory, expected_name):
+    img = make_image("img")
+    pts = make_points("pts")
+
+    viewer = DummyViewer([img, pts])
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    event = event_factory(viewer, img, pts)
+
+    layer = manager._resolve_inserted_layer(event)
+
+    assert layer is pts
+    assert layer.name == expected_name

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 from types import SimpleNamespace
 
 import numpy as np
@@ -108,6 +109,9 @@ def test_manager_register_and_query_managed_points(qtbot):
     assert manager.has_managed_points() is False
     assert manager.managed_points_count() == 0
     assert manager.managed_points_layers() == ()
+    assert manager.resolve_live_layer(pts) is None
+    assert manager.get_live_runtime(pts) is None
+    assert manager.get_store(pts) is None
 
     manager.register_managed_points_layer(pts, store)
 
@@ -117,9 +121,24 @@ def test_manager_register_and_query_managed_points(qtbot):
     assert manager.managed_points_layers() == (pts,)
     assert list(manager.iter_managed_points()) == [(pts, store)]
 
+    assert manager.resolve_live_layer(pts) is pts
+    runtime = manager.get_live_runtime(pts)
+    assert runtime is not None
+    assert runtime.layer_id == id(pts)
+    assert runtime.store is store
+    assert manager.get_store(pts) is store
+    assert manager.require_store(pts) is store
+
     removed = manager.unregister_managed_layer(pts)
     assert removed is store
+
+    assert manager.is_managed(pts) is False
     assert manager.has_managed_points() is False
+    assert manager.managed_points_count() == 0
+    assert manager.managed_points_layers() == ()
+    assert manager.resolve_live_layer(pts) is None
+    assert manager.get_live_runtime(pts) is None
+    assert manager.get_store(pts) is None
 
 
 def test_manager_on_insert_points_delegates_to_owner_and_remaps_non_images(qtbot):
@@ -215,3 +234,49 @@ def test_manager_resolve_inserted_layer_prefers_value_then_index_then_source(qtb
 
     assert layer is pts
     assert layer.name == expected_name
+
+
+def test_manager_reap_dead_entries_removes_stale_entry(qtbot):
+    viewer = DummyViewer()
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    pts = make_points()
+    store = object()
+
+    manager.register_managed_points_layer(pts, store)
+
+    layer_id = id(pts)
+    del pts
+    gc.collect()
+
+    # Before reaping, the entry may still exist by id but not be live.
+    report_before = manager.audit_registry()
+    assert report_before.dead_count == 1
+    assert any(issue.code == "dead-entry" and issue.layer_id == layer_id for issue in report_before.issues)
+
+    reaped = manager.reap_dead_entries(log=False)
+
+    assert len(reaped) == 1
+    assert reaped[0].layer_id == layer_id
+    assert reaped[0].runtime.store is store
+
+    report_after = manager.audit_registry()
+    assert report_after.dead_count == 0
+    assert report_after.issues == ()
+
+
+def test_manager_unregister_by_layer_id_returns_store(qtbot):
+    viewer = DummyViewer()
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    pts = make_points()
+    store = object()
+
+    manager.register_managed_points_layer(pts, store)
+
+    removed = manager.unregister_managed_layer(id(pts))
+
+    assert removed is store
+    assert manager.has_managed_points() is False

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -413,6 +413,10 @@ def test_manager_on_remove_triggers_ui_cleanup_and_refresh(qtbot):
         pts,
         remaining_points_layers=1,
     )
+
+    # Let the deferred QTimer(0) refresh run
+    qtbot.wait(1)
+
     owner._refresh_video_panel_context.assert_called()
     owner._refresh_layer_status_panel.assert_called()
 

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import gc
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 from napari.layers import Image, Points
 
-from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
-from napari_deeplabcut.core.layer_lifecycle.registry import PointsRuntimeResources
+from napari_deeplabcut.core.layer_lifecycle import LayerLifecycleManager
 
 
 def mark_as_dlc_session_image(layer, *, role="image"):
@@ -73,47 +71,47 @@ class DummyImageMeta:
         return {}
 
 
-# ---------------------------------------------------------------------------
-# Transitional owner stub matching the current manager boundary
-# ---------------------------------------------------------------------------
-class DummyOwner:
-    """Owner stub for the refactored lifecycle manager.
+class SignalRecorder:
+    def __init__(self):
+        self.calls = []
 
-    The owner provides:
-    - small validation/context hooks
-    - UI completion hooks
-    - refresh hooks
-    """
+    def __call__(self, *args):
+        self.calls.append(args)
 
-    def __init__(self, viewer):
-        self.viewer = viewer
+    @property
+    def count(self):
+        return len(self.calls)
 
-        # Transitional context still stored on owner for now
-        self._image_meta = DummyImageMeta()
-        self._project_path = None
 
-        # Transitional runtime/UI bits manager still consults
-        self._label_mode = "sequential"
-        self._recolor_pending = set()
+def connect_signal_recorders(manager):
+    rec = SimpleNamespace(
+        refresh_video=SignalRecorder(),
+        refresh_status=SignalRecorder(),
+        setup_points=SignalRecorder(),
+        merged_points=SignalRecorder(),
+        removed_points=SignalRecorder(),
+        removed_tracks=SignalRecorder(),
+        move_image_bottom=SignalRecorder(),
+        video_visibility=SignalRecorder(),
+        adopted=SignalRecorder(),
+        inserted=SignalRecorder(),
+        removed=SignalRecorder(),
+        conflicts=SignalRecorder(),
+    )
 
-        # Lifecycle/helper hooks
-        self._validate_header = MagicMock(return_value=True)
-        self._maybe_merge_config_points_layer = MagicMock(return_value=False)
-        self._is_multianimal = MagicMock(return_value=False)
-
-        self._maybe_initialize_layer_point_size_from_config = MagicMock()
-        self._connect_layer_status_events = MagicMock()
-        self._update_image_meta_from_layer = MagicMock()
-        self._sync_points_layers_from_image_meta = MagicMock()
-        self._cache_project_path_from_image_layer = MagicMock()
-        self._schedule_recolor = MagicMock()
-
-        # UI-only hooks
-        self._complete_points_layer_ui_setup = MagicMock()
-        self._on_points_layer_removed_ui = MagicMock()
-        self._refresh_video_panel_context = MagicMock()
-        self._refresh_layer_status_panel = MagicMock()
-        self._move_image_layer_to_bottom = MagicMock()
+    manager.refresh_video_panel_requested.connect(rec.refresh_video)
+    manager.refresh_layer_status_requested.connect(rec.refresh_status)
+    manager.points_layer_setup_requested.connect(rec.setup_points)
+    manager.points_layers_merged_requested.connect(rec.merged_points)
+    manager.points_layer_removed_requested.connect(rec.removed_points)
+    manager.tracks_layer_removed_requested.connect(rec.removed_tracks)
+    manager.move_image_layer_to_bottom_requested.connect(rec.move_image_bottom)
+    manager.video_widget_visibility_requested.connect(rec.video_visibility)
+    manager.adopted_existing_layers.connect(rec.adopted)
+    manager.layer_insert_processed.connect(rec.inserted)
+    manager.layer_remove_processed.connect(rec.removed)
+    manager.session_conflict_rejected.connect(rec.conflicts)
+    return rec
 
 
 # ---------------------------------------------------------------------------
@@ -175,11 +173,8 @@ def make_points(name="pts"):
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
 @pytest.fixture(autouse=True)
 def immediate_qtimer(monkeypatch):
-    """Run QTimer.singleShot callbacks immediately for deterministic tests."""
     from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
 
     monkeypatch.setattr(
@@ -191,52 +186,9 @@ def immediate_qtimer(monkeypatch):
 
 @pytest.fixture
 def fake_store(monkeypatch):
-    """Patch manager-side KeypointStore construction to a lightweight fake."""
     from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
 
     monkeypatch.setattr(manager_module.keypoints, "KeypointStore", FakeStore)
-
-
-@pytest.fixture
-def fake_runtime_attachment(monkeypatch):
-    """Patch away napari patch/keybinding attachment details.
-
-    These tests verify lifecycle orchestration, not compat patch internals.
-    """
-    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
-    from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
-
-    def _fake_attach_points_layer_runtime(self, **kwargs):
-        return PointsRuntimeResources(
-            query_next_frame_event_added=False,
-            query_next_frame_connected=False,
-            add_wrapper_installed=True,
-            paste_patch_installed=True,
-            keybindings_installed=True,
-        )
-
-    # Support either implementation shape:
-    # - class/instance method: self.attach_points_layer_runtime(...)
-    # - module-level function: attach_points_layer_runtime(...)
-    if hasattr(LayerLifecycleManager, "attach_points_layer_runtime"):
-        monkeypatch.setattr(
-            LayerLifecycleManager,
-            "attach_points_layer_runtime",
-            _fake_attach_points_layer_runtime,
-        )
-
-    if hasattr(manager_module, "attach_points_layer_runtime"):
-        monkeypatch.setattr(
-            manager_module,
-            "attach_points_layer_runtime",
-            lambda **kwargs: PointsRuntimeResources(
-                query_next_frame_event_added=False,
-                query_next_frame_connected=False,
-                add_wrapper_installed=True,
-                paste_patch_installed=True,
-                keybindings_installed=True,
-            ),
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -246,8 +198,7 @@ def fake_runtime_attachment(monkeypatch):
 
 def test_manager_attach_and_detach_are_idempotent(qtbot):
     viewer = DummyViewer()
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
 
     manager.attach()
     manager.attach()
@@ -264,8 +215,7 @@ def test_manager_attach_and_detach_are_idempotent(qtbot):
 
 def test_manager_register_and_query_managed_points(qtbot):
     viewer = DummyViewer()
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
 
     pts = make_points()
     store = object()
@@ -308,15 +258,17 @@ def test_manager_register_and_query_managed_points(qtbot):
 def test_manager_on_insert_points_sets_up_points_and_refreshes_ui(
     qtbot,
     fake_store,
-    fake_runtime_attachment,
+    monkeypatch,
 ):
     img = make_image()
     pts_existing = make_points("existing")
     pts_inserted = make_points("inserted")
 
     viewer = DummyViewer([img, pts_existing, pts_inserted])
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
+    rec = connect_signal_recorders(manager)
+
+    monkeypatch.setattr(manager, "validate_header", lambda layer: True)
 
     remap_calls = []
     manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
@@ -327,14 +279,15 @@ def test_manager_on_insert_points_sets_up_points_and_refreshes_ui(
 
     assert manager.is_managed(pts_inserted) is True
 
-    owner._validate_header.assert_any_call(pts_inserted)
-    owner._maybe_merge_config_points_layer.assert_called_once_with(pts_inserted)
-    owner._complete_points_layer_ui_setup.assert_called_once()
-    ui_args, ui_kwargs = owner._complete_points_layer_ui_setup.call_args
-    assert ui_args[0] is pts_inserted
+    assert rec.setup_points.count == 1
+    req = rec.setup_points.calls[0][0]
+    assert req.layer is pts_inserted
+    assert req.store is manager.get_store(pts_inserted)
 
-    owner._refresh_video_panel_context.assert_called()
-    owner._refresh_layer_status_panel.assert_called()
+    assert rec.refresh_video.count >= 1
+    assert rec.refresh_status.count >= 1
+    assert rec.inserted.count == 1
+    assert rec.inserted.calls[0][0] is pts_inserted
 
     assert pts_existing in remap_calls
     assert pts_inserted in remap_calls
@@ -345,8 +298,8 @@ def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
     pts = make_points()
 
     viewer = DummyViewer([img, pts])
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
+    rec = connect_signal_recorders(manager)
 
     remap_calls = []
     manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
@@ -357,13 +310,11 @@ def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
 
     assert manager.active_dlc_image_layer() is img
     assert manager.image_meta.name == "inserted-image"
-    owner._refresh_video_panel_context.assert_called()
-    owner._refresh_layer_status_panel.assert_called()
-    owner._move_image_layer_to_bottom.assert_called_once_with(img)
-    assert pts in remap_calls
 
-    owner._refresh_video_panel_context.assert_called()
-    owner._refresh_layer_status_panel.assert_called()
+    assert rec.refresh_video.count >= 1
+    assert rec.refresh_status.count >= 1
+    assert rec.move_image_bottom.count == 1
+    assert rec.move_image_bottom.calls[0][0] is img
 
     assert pts in remap_calls
 
@@ -371,15 +322,17 @@ def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
 def test_manager_adopt_existing_layers_skips_already_managed_points(
     qtbot,
     fake_store,
-    fake_runtime_attachment,
+    monkeypatch,
 ):
     img = mark_as_dlc_session_image(make_image())
     pts_managed = make_points("managed")
     pts_unmanaged = make_points("unmanaged")
 
     viewer = DummyViewer([img, pts_managed, pts_unmanaged])
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
+    rec = connect_signal_recorders(manager)
+
+    monkeypatch.setattr(manager, "validate_header", lambda layer: True)
 
     remap_calls = []
     manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
@@ -390,10 +343,15 @@ def test_manager_adopt_existing_layers_skips_already_managed_points(
 
     assert manager.active_dlc_image_layer() is img
     assert manager.image_meta.name == img.name
-    owner._move_image_layer_to_bottom.assert_called_once_with(img)
-    owner._complete_points_layer_ui_setup.assert_called_once()
-    ui_args, _ui_kwargs = owner._complete_points_layer_ui_setup.call_args
-    assert ui_args[0] is pts_unmanaged
+
+    assert rec.move_image_bottom.count == 1
+    assert rec.move_image_bottom.calls[0][0] is img
+
+    assert rec.setup_points.count == 1
+    req = rec.setup_points.calls[0][0]
+    assert req.layer is pts_unmanaged
+
+    assert rec.adopted.count == 1
 
     assert pts_managed in remap_calls
     assert pts_unmanaged in remap_calls
@@ -402,28 +360,31 @@ def test_manager_adopt_existing_layers_skips_already_managed_points(
 def test_manager_on_remove_triggers_ui_cleanup_and_refresh(qtbot):
     pts = make_points()
     viewer = DummyViewer([pts])
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
+    rec = connect_signal_recorders(manager)
+
+    manager.register_managed_points_layer(pts, object())
 
     event = SimpleNamespace(value=pts)
 
     manager.on_remove(event)
 
-    owner._on_points_layer_removed_ui.assert_called_once_with(
-        pts,
-        remaining_points_layers=1,
-    )
+    assert rec.removed_points.count == 1
+    removed_layer, remaining = rec.removed_points.calls[0]
+    assert removed_layer is pts
+    assert remaining == 1
 
     manager._flush_post_remove_refresh()
 
-    owner._refresh_video_panel_context.assert_called()
-    owner._refresh_layer_status_panel.assert_called()
+    assert rec.refresh_video.count >= 1
+    assert rec.refresh_status.count >= 1
+    assert rec.removed.count == 1
+    assert rec.removed.calls[0][0] is pts
 
 
 def test_manager_reap_dead_entries_removes_stale_entry(qtbot):
     viewer = DummyViewer()
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
 
     pts = make_points()
     store = object()
@@ -462,8 +423,7 @@ def test_manager_resolve_inserted_layer_prefers_value_then_index_then_source(qtb
     pts = make_points("pts")
 
     viewer = DummyViewer([img, pts])
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
+    manager = LayerLifecycleManager(viewer=viewer)
 
     event = event_factory(viewer, img, pts)
 

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -12,6 +12,21 @@ from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
 from napari_deeplabcut.core.layer_lifecycle.registry import PointsRuntimeResources
 
 
+def mark_as_dlc_session_image(layer, *, role="image"):
+    layer.metadata = dict(layer.metadata or {})
+    layer.metadata["dlc"] = {
+        "session_role": role,
+        "project_context": {
+            "root_anchor": "C:/project/labeled-data/test",
+            "project_root": "C:/project",
+            "config_path": "C:/project/config.yaml",
+            "dataset_folder": "C:/project/labeled-data/test",
+        },
+        "session_key": "C:/project",
+    }
+    return layer
+
+
 # ---------------------------------------------------------------------------
 # Minimal fake viewer/layer event infrastructure
 # ---------------------------------------------------------------------------
@@ -326,7 +341,7 @@ def test_manager_on_insert_points_sets_up_points_and_refreshes_ui(
 
 
 def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
-    img = make_image("inserted-image")
+    img = mark_as_dlc_session_image(make_image("inserted-image"))
     pts = make_points()
 
     viewer = DummyViewer([img, pts])
@@ -340,11 +355,15 @@ def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
 
     manager.on_insert(event)
 
-    owner._update_image_meta_from_layer.assert_called_once_with(img)
-    owner._sync_points_layers_from_image_meta.assert_called_once()
+    assert manager.active_dlc_image_layer() is img
+    assert manager.image_meta.name == "inserted-image"
     owner._refresh_video_panel_context.assert_called()
     owner._refresh_layer_status_panel.assert_called()
-    owner._move_image_layer_to_bottom.assert_called_once_with(0)
+    owner._move_image_layer_to_bottom.assert_called_once_with(img)
+    assert pts in remap_calls
+
+    owner._refresh_video_panel_context.assert_called()
+    owner._refresh_layer_status_panel.assert_called()
 
     assert pts in remap_calls
 
@@ -354,7 +373,7 @@ def test_manager_adopt_existing_layers_skips_already_managed_points(
     fake_store,
     fake_runtime_attachment,
 ):
-    img = make_image()
+    img = mark_as_dlc_session_image(make_image())
     pts_managed = make_points("managed")
     pts_unmanaged = make_points("unmanaged")
 
@@ -369,11 +388,11 @@ def test_manager_adopt_existing_layers_skips_already_managed_points(
 
     manager.adopt_existing_layers()
 
-    owner._update_image_meta_from_layer.assert_called_once_with(img)
-
-    # Only the unmanaged points layer should go through UI completion.
+    assert manager.active_dlc_image_layer() is img
+    assert manager.image_meta.name == img.name
+    owner._move_image_layer_to_bottom.assert_called_once_with(img)
     owner._complete_points_layer_ui_setup.assert_called_once()
-    ui_args, ui_kwargs = owner._complete_points_layer_ui_setup.call_args
+    ui_args, _ui_kwargs = owner._complete_points_layer_ui_setup.call_args
     assert ui_args[0] is pts_unmanaged
 
     assert pts_managed in remap_calls

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -2,14 +2,19 @@ from __future__ import annotations
 
 import gc
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 from napari.layers import Image, Points
 
 from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
+from napari_deeplabcut.core.layer_lifecycle.registry import PointsRuntimeResources
 
 
+# ---------------------------------------------------------------------------
+# Minimal fake viewer/layer event infrastructure
+# ---------------------------------------------------------------------------
 class DummySignal:
     def __init__(self):
         self._callbacks = []
@@ -44,28 +49,100 @@ class DummyViewer:
         self.layers = DummyLayerList(layers)
 
 
+class DummyImageMeta:
+    def __init__(self):
+        self.root = None
+        self.paths = None
+
+    def model_dump(self, **kwargs):
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Transitional owner stub matching the current manager boundary
+# ---------------------------------------------------------------------------
 class DummyOwner:
+    """Owner stub for the refactored lifecycle manager.
+
+    The owner provides:
+    - small validation/context hooks
+    - UI completion hooks
+    - refresh hooks
+    """
+
     def __init__(self, viewer):
         self.viewer = viewer
-        self.calls = []
 
-    def _setup_image_layer(self, layer, index, reorder=True):
-        self.calls.append(("setup_image", layer, index, reorder))
+        # Transitional context still stored on owner for now
+        self._image_meta = DummyImageMeta()
+        self._project_path = None
 
-    def _setup_points_layer(self, layer, allow_merge=True):
-        self.calls.append(("setup_points", layer, allow_merge))
+        # Transitional runtime/UI bits manager still consults
+        self._label_mode = "sequential"
+        self._recolor_pending = set()
 
-    def _remap_frame_indices(self, layer):
-        self.calls.append(("remap", layer))
+        # Lifecycle/helper hooks
+        self._validate_header = MagicMock(return_value=True)
+        self._maybe_merge_config_points_layer = MagicMock(return_value=False)
+        self._is_multianimal = MagicMock(return_value=False)
 
-    def _refresh_video_panel_context(self):
-        self.calls.append(("refresh_video",))
+        self._maybe_initialize_layer_point_size_from_config = MagicMock()
+        self._connect_layer_status_events = MagicMock()
+        self._update_image_meta_from_layer = MagicMock()
+        self._sync_points_layers_from_image_meta = MagicMock()
+        self._cache_project_path_from_image_layer = MagicMock()
+        self._schedule_recolor = MagicMock()
 
-    def _refresh_layer_status_panel(self):
-        self.calls.append(("refresh_status",))
+        # UI-only hooks
+        self._complete_points_layer_ui_setup = MagicMock()
+        self._on_points_layer_removed_ui = MagicMock()
+        self._refresh_video_panel_context = MagicMock()
+        self._refresh_layer_status_panel = MagicMock()
+        self._move_image_layer_to_bottom = MagicMock()
 
-    def _handle_removed_layer(self, layer):
-        self.calls.append(("handle_removed", layer))
+
+# ---------------------------------------------------------------------------
+# Fake store used so manager tests do not depend on real KeypointStore/viewer
+# ---------------------------------------------------------------------------
+
+
+class FakeStore:
+    def __init__(self, viewer, layer):
+        self.viewer = viewer
+        self._layer = layer
+        self._layer_id = id(layer)
+        self._resolver = None
+        self._get_label_mode = None
+
+    @property
+    def layer(self):
+        return self._layer
+
+    @layer.setter
+    def layer(self, layer):
+        self._layer = layer
+        self._layer_id = id(layer)
+
+    @property
+    def layer_id(self):
+        return self._layer_id
+
+    def attach_layer_resolver(self, resolver):
+        self._resolver = resolver
+
+    def set_label_mode_getter(self, getter):
+        self._get_label_mode = getter
+
+    def _advance_step(self, event=None):
+        return None
+
+    def add(self, coord):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Shared factories
+# ---------------------------------------------------------------------------
 
 
 def make_image(name="img"):
@@ -78,6 +155,78 @@ def make_points(name="pts"):
     layer = Points(np.zeros((0, 3)))
     layer.name = name
     return layer
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def immediate_qtimer(monkeypatch):
+    """Run QTimer.singleShot callbacks immediately for deterministic tests."""
+    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
+
+    monkeypatch.setattr(
+        manager_module.QTimer,
+        "singleShot",
+        staticmethod(lambda _ms, fn: fn()),
+    )
+
+
+@pytest.fixture
+def fake_store(monkeypatch):
+    """Patch manager-side KeypointStore construction to a lightweight fake."""
+    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
+
+    monkeypatch.setattr(manager_module.keypoints, "KeypointStore", FakeStore)
+
+
+@pytest.fixture
+def fake_runtime_attachment(monkeypatch):
+    """Patch away napari patch/keybinding attachment details.
+
+    These tests verify lifecycle orchestration, not compat patch internals.
+    """
+    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
+    from napari_deeplabcut.core.layer_lifecycle.manager import LayerLifecycleManager
+
+    def _fake_attach_points_layer_runtime(self, **kwargs):
+        return PointsRuntimeResources(
+            query_next_frame_event_added=False,
+            query_next_frame_connected=False,
+            add_wrapper_installed=True,
+            paste_patch_installed=True,
+            keybindings_installed=True,
+        )
+
+    # Support either implementation shape:
+    # - class/instance method: self.attach_points_layer_runtime(...)
+    # - module-level function: attach_points_layer_runtime(...)
+    if hasattr(LayerLifecycleManager, "attach_points_layer_runtime"):
+        monkeypatch.setattr(
+            LayerLifecycleManager,
+            "attach_points_layer_runtime",
+            _fake_attach_points_layer_runtime,
+        )
+
+    if hasattr(manager_module, "attach_points_layer_runtime"):
+        monkeypatch.setattr(
+            manager_module,
+            "attach_points_layer_runtime",
+            lambda **kwargs: PointsRuntimeResources(
+                query_next_frame_event_added=False,
+                query_next_frame_connected=False,
+                add_wrapper_installed=True,
+                paste_patch_installed=True,
+                keybindings_installed=True,
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 
 
 def test_manager_attach_and_detach_are_idempotent(qtbot):
@@ -141,7 +290,11 @@ def test_manager_register_and_query_managed_points(qtbot):
     assert manager.get_store(pts) is None
 
 
-def test_manager_on_insert_points_delegates_to_owner_and_remaps_non_images(qtbot):
+def test_manager_on_insert_points_sets_up_points_and_refreshes_ui(
+    qtbot,
+    fake_store,
+    fake_runtime_attachment,
+):
     img = make_image()
     pts_existing = make_points("existing")
     pts_inserted = make_points("inserted")
@@ -150,18 +303,29 @@ def test_manager_on_insert_points_delegates_to_owner_and_remaps_non_images(qtbot
     owner = DummyOwner(viewer)
     manager = LayerLifecycleManager(owner=owner)
 
+    remap_calls = []
+    manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
+
     event = SimpleNamespace(value=pts_inserted, index=2, source=viewer.layers)
 
     manager.on_insert(event)
 
-    assert ("setup_points", pts_inserted, True) in owner.calls
-    assert ("remap", pts_existing) in owner.calls
-    assert ("remap", pts_inserted) in owner.calls
-    assert ("refresh_video",) in owner.calls
-    assert ("refresh_status",) in owner.calls
+    assert manager.is_managed(pts_inserted) is True
+
+    owner._validate_header.assert_any_call(pts_inserted)
+    owner._maybe_merge_config_points_layer.assert_called_once_with(pts_inserted)
+    owner._complete_points_layer_ui_setup.assert_called_once()
+    ui_args, ui_kwargs = owner._complete_points_layer_ui_setup.call_args
+    assert ui_args[0] is pts_inserted
+
+    owner._refresh_video_panel_context.assert_called()
+    owner._refresh_layer_status_panel.assert_called()
+
+    assert pts_existing in remap_calls
+    assert pts_inserted in remap_calls
 
 
-def test_manager_on_insert_image_delegates_to_owner(qtbot):
+def test_manager_on_insert_image_updates_context_and_refreshes_ui(qtbot):
     img = make_image("inserted-image")
     pts = make_points()
 
@@ -169,17 +333,27 @@ def test_manager_on_insert_image_delegates_to_owner(qtbot):
     owner = DummyOwner(viewer)
     manager = LayerLifecycleManager(owner=owner)
 
+    remap_calls = []
+    manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
+
     event = SimpleNamespace(value=img, index=0, source=viewer.layers)
 
     manager.on_insert(event)
 
-    assert ("setup_image", img, 0, True) in owner.calls
-    assert ("remap", pts) in owner.calls
-    assert ("refresh_video",) in owner.calls
-    assert ("refresh_status",) in owner.calls
+    owner._update_image_meta_from_layer.assert_called_once_with(img)
+    owner._sync_points_layers_from_image_meta.assert_called_once()
+    owner._refresh_video_panel_context.assert_called()
+    owner._refresh_layer_status_panel.assert_called()
+    owner._move_image_layer_to_bottom.assert_called_once_with(0)
+
+    assert pts in remap_calls
 
 
-def test_manager_adopt_existing_layers_skips_already_managed_points(qtbot):
+def test_manager_adopt_existing_layers_skips_already_managed_points(
+    qtbot,
+    fake_store,
+    fake_runtime_attachment,
+):
     img = make_image()
     pts_managed = make_points("managed")
     pts_unmanaged = make_points("unmanaged")
@@ -188,18 +362,25 @@ def test_manager_adopt_existing_layers_skips_already_managed_points(qtbot):
     owner = DummyOwner(viewer)
     manager = LayerLifecycleManager(owner=owner)
 
+    remap_calls = []
+    manager._remap_frame_indices = lambda layer: remap_calls.append(layer)
+
     manager.register_managed_points_layer(pts_managed, object())
 
     manager.adopt_existing_layers()
 
-    assert ("setup_image", img, 0, True) in owner.calls
-    assert ("setup_points", pts_unmanaged, False) in owner.calls
-    assert ("setup_points", pts_managed, False) not in owner.calls
-    assert ("remap", pts_managed) in owner.calls
-    assert ("remap", pts_unmanaged) in owner.calls
+    owner._update_image_meta_from_layer.assert_called_once_with(img)
+
+    # Only the unmanaged points layer should go through UI completion.
+    owner._complete_points_layer_ui_setup.assert_called_once()
+    ui_args, ui_kwargs = owner._complete_points_layer_ui_setup.call_args
+    assert ui_args[0] is pts_unmanaged
+
+    assert pts_managed in remap_calls
+    assert pts_unmanaged in remap_calls
 
 
-def test_manager_on_remove_delegates_to_owner(qtbot):
+def test_manager_on_remove_triggers_ui_cleanup_and_refresh(qtbot):
     pts = make_points()
     viewer = DummyViewer([pts])
     owner = DummyOwner(viewer)
@@ -209,7 +390,41 @@ def test_manager_on_remove_delegates_to_owner(qtbot):
 
     manager.on_remove(event)
 
-    assert owner.calls == [("handle_removed", pts)]
+    owner._on_points_layer_removed_ui.assert_called_once_with(
+        pts,
+        remaining_points_layers=1,
+    )
+    owner._refresh_video_panel_context.assert_called()
+    owner._refresh_layer_status_panel.assert_called()
+
+
+def test_manager_reap_dead_entries_removes_stale_entry(qtbot):
+    viewer = DummyViewer()
+    owner = DummyOwner(viewer)
+    manager = LayerLifecycleManager(owner=owner)
+
+    pts = make_points()
+    store = object()
+
+    manager.register_managed_points_layer(pts, store)
+
+    layer_id = id(pts)
+    del pts
+    gc.collect()
+
+    report_before = manager.audit_registry()
+    assert report_before.dead_count == 1
+    assert any(issue.code == "dead-entry" and issue.layer_id == layer_id for issue in report_before.issues)
+
+    reaped = manager.clear_dead_entries(log=False)
+
+    assert len(reaped) == 1
+    assert reaped[0].layer_id == layer_id
+    assert reaped[0].runtime.store is store
+
+    report_after = manager.audit_registry()
+    assert report_after.dead_count == 0
+    assert report_after.issues == ()
 
 
 @pytest.mark.parametrize(
@@ -234,49 +449,3 @@ def test_manager_resolve_inserted_layer_prefers_value_then_index_then_source(qtb
 
     assert layer is pts
     assert layer.name == expected_name
-
-
-def test_manager_reap_dead_entries_removes_stale_entry(qtbot):
-    viewer = DummyViewer()
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
-
-    pts = make_points()
-    store = object()
-
-    manager.register_managed_points_layer(pts, store)
-
-    layer_id = id(pts)
-    del pts
-    gc.collect()
-
-    # Before reaping, the entry may still exist by id but not be live.
-    report_before = manager.audit_registry()
-    assert report_before.dead_count == 1
-    assert any(issue.code == "dead-entry" and issue.layer_id == layer_id for issue in report_before.issues)
-
-    reaped = manager.reap_dead_entries(log=False)
-
-    assert len(reaped) == 1
-    assert reaped[0].layer_id == layer_id
-    assert reaped[0].runtime.store is store
-
-    report_after = manager.audit_registry()
-    assert report_after.dead_count == 0
-    assert report_after.issues == ()
-
-
-def test_manager_unregister_by_layer_id_returns_store(qtbot):
-    viewer = DummyViewer()
-    owner = DummyOwner(viewer)
-    manager = LayerLifecycleManager(owner=owner)
-
-    pts = make_points()
-    store = object()
-
-    manager.register_managed_points_layer(pts, store)
-
-    removed = manager.unregister_managed_layer(id(pts))
-
-    assert removed is store
-    assert manager.has_managed_points() is False

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -414,8 +414,7 @@ def test_manager_on_remove_triggers_ui_cleanup_and_refresh(qtbot):
         remaining_points_layers=1,
     )
 
-    # Let the deferred QTimer(0) refresh run
-    qtbot.wait(1)
+    manager._flush_post_remove_refresh()
 
     owner._refresh_video_panel_context.assert_called()
     owner._refresh_layer_status_panel.assert_called()

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
@@ -81,7 +81,7 @@ def test_registry_iter_live_items_layers_runtimes_are_consistent():
     registry.assert_consistent()
 
 
-def test_registry_reap_dead_entries_removes_stale_entry_and_reports_it():
+def test_registry_clear_dead_entries_removes_stale_entry_and_reports_it():
     registry = RuntimeRegistry()
 
     layer = DummyLayer()

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
@@ -14,23 +14,28 @@ class DummyLayer:
     pass
 
 
-def test_registry_register_get_require_unregister_roundtrip():
+def test_registry_register_resolve_require_unregister_roundtrip():
     registry = RuntimeRegistry()
     layer = DummyLayer()
-    runtime = ManagedPointsRuntime(layer=layer, store="store-1")
+    runtime = ManagedPointsRuntime(layer_id=id(layer), store="store-1")
 
     registry.register(layer, runtime)
 
     assert registry.is_managed(layer) is True
-    assert registry.get(layer) is runtime
-    assert registry.require(layer) is runtime
+    assert registry.resolve_live_layer(layer) is layer
+    assert registry.get_live_runtime(layer) is runtime
+    assert registry.require_live_runtime(layer) is runtime
+    assert registry.get_store(layer) == "store-1"
+    assert registry.require_store(layer) == "store-1"
     assert len(registry) == 1
 
     removed = registry.unregister(layer)
 
     assert removed is runtime
     assert registry.is_managed(layer) is False
-    assert registry.get(layer) is None
+    assert registry.resolve_live_layer(layer) is None
+    assert registry.get_live_runtime(layer) is None
+    assert registry.get_store(layer) is None
     assert len(registry) == 0
 
 
@@ -38,49 +43,95 @@ def test_registry_duplicate_registration_raises():
     registry = RuntimeRegistry()
     layer = DummyLayer()
 
-    registry.register(layer, ManagedPointsRuntime(layer=layer, store="a"))
+    registry.register(
+        layer,
+        ManagedPointsRuntime(layer_id=id(layer), store="a"),
+    )
 
     with pytest.raises(ValueError):
-        registry.register(layer, ManagedPointsRuntime(layer=layer, store="b"))
+        registry.register(
+            layer,
+            ManagedPointsRuntime(layer_id=id(layer), store="b"),
+        )
 
 
-def test_registry_items_layers_runtimes_are_consistent():
+def test_registry_iter_live_items_layers_runtimes_are_consistent():
     registry = RuntimeRegistry()
     layer1 = DummyLayer()
     layer2 = DummyLayer()
 
-    runtime1 = ManagedPointsRuntime(layer=layer1, store="s1")
-    runtime2 = ManagedPointsRuntime(layer=layer2, store="s2")
+    runtime1 = ManagedPointsRuntime(layer_id=id(layer1), store="s1")
+    runtime2 = ManagedPointsRuntime(layer_id=id(layer2), store="s2")
 
     registry.register(layer1, runtime1)
     registry.register(layer2, runtime2)
 
-    items = list(registry.items())
-    layers = list(registry.layers())
-    runtimes = list(registry.runtimes())
+    items = list(registry.iter_live_items())
+    layers = list(registry.iter_live_layers())
+    runtimes = list(registry.iter_live_runtimes())
 
     assert items == [(layer1, runtime1), (layer2, runtime2)]
     assert layers == [layer1, layer2]
     assert runtimes == [runtime1, runtime2]
     assert set(registry.layer_ids()) == {id(layer1), id(layer2)}
 
+    assert registry.get_store(layer1) == "s1"
+    assert registry.get_store(layer2) == "s2"
+
     registry.assert_consistent()
 
 
-def test_registry_purges_dead_weakrefs():
+def test_registry_reap_dead_entries_removes_stale_entry_and_reports_it():
     registry = RuntimeRegistry()
 
     layer = DummyLayer()
-    runtime = ManagedPointsRuntime(layer=layer, store="store")
+    runtime = ManagedPointsRuntime(layer_id=id(layer), store="store")
     registry.register(layer, runtime)
 
     assert len(registry) == 1
+    layer_id = id(layer)
+
+    # Remove the only strong reference held by the test.
+    del layer
+    gc.collect()
+
+    # Before reaping, the stale id may still be present in the registry index,
+    # but it should no longer count as live.
+    assert len(registry) == 0
+    assert layer_id in registry.layer_ids()
+
+    reaped = registry.clear_dead_entries(log=False)
+
+    assert len(reaped) == 1
+    assert reaped[0].layer_id == layer_id
+    assert reaped[0].runtime is runtime
+
+    assert layer_id not in registry.layer_ids()
+    assert len(registry) == 0
+    assert list(registry.iter_live_items()) == []
+
+
+def test_registry_audit_reports_dead_entry_before_reap():
+    registry = RuntimeRegistry()
+
+    layer = DummyLayer()
+    runtime = ManagedPointsRuntime(layer_id=id(layer), store="store")
+    registry.register(layer, runtime)
 
     layer_id = id(layer)
     del layer
     gc.collect()
 
-    registry.purge_dead()
+    report = registry.audit()
 
-    assert layer_id not in registry.layer_ids()
-    assert len(registry) == 0
+    assert report.live_count == 0
+    assert report.dead_count == 1
+    assert any(issue.code == "dead-entry" and issue.layer_id == layer_id for issue in report.issues)
+
+    reaped = registry.clear_dead_entries(log=False)
+    assert len(reaped) == 1
+
+    report_after = registry.audit()
+    assert report_after.live_count == 0
+    assert report_after.dead_count == 0
+    assert report_after.issues == ()

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_registry.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import gc
+
+import pytest
+
+from napari_deeplabcut.core.layer_lifecycle.registry import (
+    ManagedPointsRuntime,
+    RuntimeRegistry,
+)
+
+
+class DummyLayer:
+    pass
+
+
+def test_registry_register_get_require_unregister_roundtrip():
+    registry = RuntimeRegistry()
+    layer = DummyLayer()
+    runtime = ManagedPointsRuntime(layer=layer, store="store-1")
+
+    registry.register(layer, runtime)
+
+    assert registry.is_managed(layer) is True
+    assert registry.get(layer) is runtime
+    assert registry.require(layer) is runtime
+    assert len(registry) == 1
+
+    removed = registry.unregister(layer)
+
+    assert removed is runtime
+    assert registry.is_managed(layer) is False
+    assert registry.get(layer) is None
+    assert len(registry) == 0
+
+
+def test_registry_duplicate_registration_raises():
+    registry = RuntimeRegistry()
+    layer = DummyLayer()
+
+    registry.register(layer, ManagedPointsRuntime(layer=layer, store="a"))
+
+    with pytest.raises(ValueError):
+        registry.register(layer, ManagedPointsRuntime(layer=layer, store="b"))
+
+
+def test_registry_items_layers_runtimes_are_consistent():
+    registry = RuntimeRegistry()
+    layer1 = DummyLayer()
+    layer2 = DummyLayer()
+
+    runtime1 = ManagedPointsRuntime(layer=layer1, store="s1")
+    runtime2 = ManagedPointsRuntime(layer=layer2, store="s2")
+
+    registry.register(layer1, runtime1)
+    registry.register(layer2, runtime2)
+
+    items = list(registry.items())
+    layers = list(registry.layers())
+    runtimes = list(registry.runtimes())
+
+    assert items == [(layer1, runtime1), (layer2, runtime2)]
+    assert layers == [layer1, layer2]
+    assert runtimes == [runtime1, runtime2]
+    assert set(registry.layer_ids()) == {id(layer1), id(layer2)}
+
+    registry.assert_consistent()
+
+
+def test_registry_purges_dead_weakrefs():
+    registry = RuntimeRegistry()
+
+    layer = DummyLayer()
+    runtime = ManagedPointsRuntime(layer=layer, store="store")
+    registry.register(layer, runtime)
+
+    assert len(registry) == 1
+
+    layer_id = id(layer)
+    del layer
+    gc.collect()
+
+    registry.purge_dead()
+
+    assert layer_id not in registry.layer_ids()
+    assert len(registry) == 0

--- a/src/napari_deeplabcut/_tests/core/test_conflicts.py
+++ b/src/napari_deeplabcut/_tests/core/test_conflicts.py
@@ -254,7 +254,7 @@ def test_compute_overwrite_report_returns_report_for_existing_gt_file_with_confl
 
     assert result is report
     assert seen["set_df_scorer"] == (raw_new_df, "target_scorer")
-    assert seen["read_hdf_calls"] == [(out, "keypoints")]
+    assert seen["read_hdf_calls"] == [(out, "df_with_missing")]
     assert seen["keypoint_conflicts"] == (old_df, promoted_df)
     assert seen["build_report"] == (
         key_conflict,
@@ -316,7 +316,7 @@ def test_compute_overwrite_report_falls_back_when_keyed_hdf_read_fails(monkeypat
 
     def fake_read_hdf(path, key=None):
         calls.append((Path(path), key))
-        if key == "keypoints":
+        if key == "df_with_missing":
             raise KeyError("missing key")
         return old_df
 
@@ -335,7 +335,7 @@ def test_compute_overwrite_report_falls_back_when_keyed_hdf_read_fails(monkeypat
 
     assert result is report
     assert calls == [
-        (out, "keypoints"),
+        (out, "df_with_missing"),
         (out, None),
     ]
 

--- a/src/napari_deeplabcut/_tests/core/test_dataframes.py
+++ b/src/napari_deeplabcut/_tests/core/test_dataframes.py
@@ -85,6 +85,13 @@ def test_guarantee_multiindex_rows_leaves_numeric_index_unchanged():
     assert not isinstance(df.index, pd.MultiIndex)
 
 
+def test_guarantee_multiindex_rows_empty_df_is_noop():
+    df = pd.DataFrame(columns=["x", "y"])
+    guarantee_multiindex_rows(df)
+    assert len(df.index) == 0
+    assert not isinstance(df.index, pd.MultiIndex)
+
+
 # -----------------------------------------------------------------------------
 # 2) harmonize_keypoint_column_index
 # -----------------------------------------------------------------------------

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -77,7 +77,7 @@ def test_add_unannotated(store):
 
     # IMPORTANT: pass coord with the CURRENT frame index so we truly add to the frame we're on
     # Data layout is (frame, y, x)
-    keypoints.add(store, coord=(ind_to_remove, 1, 1))
+    store.add((ind_to_remove, 1, 1))
 
     # Exactly one new point should be appended
     assert store.layer.data.shape[0] == n_points + 1
@@ -100,7 +100,7 @@ def test_add_quick(store):
 
     # Add (or move) at the CURRENT frame; coord uses (frame, y, x)
     coord = store.current_step, -1, -1
-    keypoints.add(store, coord=coord)
+    store.add(coord)
 
     # After QUICK add/move, the point for the current frame should match the requested coord
     # (If it existed, it was moved; if not, it was added.)

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -50,6 +50,7 @@ def test_store_keypoints(store, fake_keypoints):
     store.next_keypoint()
 
 
+@pytest.mark.usefixtures("qtbot")
 def test_point_resize(qtbot, viewer, points):
     viewer.layers.selection.add(points)
     layer = viewer.layers[0]

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from napari_deeplabcut.core import keypoints
 
@@ -11,8 +12,8 @@ def test_store_advance_step(store):
 
 
 def test_store_labels(store, fake_keypoints):
+    assert store.layer_id == id(store.layer)
     assert store.n_steps == fake_keypoints.shape[0]
-    # Labels are derived from the header (bodyparts level); this asserts the store mirrors header order
     assert store.labels == list(fake_keypoints.columns.get_level_values("bodyparts").unique())
 
 
@@ -76,7 +77,7 @@ def test_add_unannotated(store):
 
     # IMPORTANT: pass coord with the CURRENT frame index so we truly add to the frame we're on
     # Data layout is (frame, y, x)
-    keypoints._add(store, coord=(ind_to_remove, 1, 1))
+    keypoints.add(store, coord=(ind_to_remove, 1, 1))
 
     # Exactly one new point should be appended
     assert store.layer.data.shape[0] == n_points + 1
@@ -99,7 +100,7 @@ def test_add_quick(store):
 
     # Add (or move) at the CURRENT frame; coord uses (frame, y, x)
     coord = store.current_step, -1, -1
-    keypoints._add(store, coord=coord)
+    keypoints.add(store, coord=coord)
 
     # After QUICK add/move, the point for the current frame should match the requested coord
     # (If it existed, it was moved; if not, it was added.)
@@ -107,3 +108,47 @@ def test_add_quick(store):
         store.layer.data[store.current_step],
         coord,
     )
+
+
+def test_store_can_attach_layer_resolver(store):
+    original_layer = store.layer
+    layer_id = id(original_layer)
+
+    # Resolver returns the original live layer by id.
+    store.attach_layer_resolver(lambda requested_id: original_layer if requested_id == layer_id else None)
+
+    assert store.layer_id == layer_id
+    assert store.maybe_layer() is original_layer
+    assert store.layer is original_layer
+
+
+def test_store_layer_raises_when_resolver_returns_none(store):
+    store.attach_layer_resolver(lambda requested_id: None)
+
+    assert store.maybe_layer() is None
+
+    with pytest.raises(keypoints.LayerUnavailableError):
+        _ = store.layer
+
+
+def test_store_resolver_is_authoritative_over_local_fallback(store):
+
+    # Even though the store still has fallback refs, resolver should dominate.
+    store.attach_layer_resolver(lambda requested_id: None)
+
+    assert store.maybe_layer() is None
+
+    with pytest.raises(keypoints.LayerUnavailableError):
+        _ = store.layer
+
+
+def test_store_layer_setter_updates_layer_id_and_keypoints(store, viewer):
+    old_layer = store.layer
+    old_layer_id = store.layer_id
+
+    new_layer = viewer.layers[0].copy() if hasattr(viewer.layers[0], "copy") else old_layer
+    store.layer = new_layer
+
+    assert store.layer is new_layer
+    assert store.layer_id == id(new_layer)
+    assert store.layer_id != old_layer_id or new_layer is old_layer

--- a/src/napari_deeplabcut/_tests/core/test_metadata.py
+++ b/src/napari_deeplabcut/_tests/core/test_metadata.py
@@ -285,7 +285,7 @@ def test_parse_points_metadata_drops_controls_and_coerces_kinds(monkeypatch):
             "kind": "gt",
             "project_root": "/tmp",
             "source_relpath_posix": "CollectedData_A.h5",
-            "dataset_key": "keypoints",
+            "dataset_key": "df_with_missing",
         },
         "save_target": {"kind": "MACHINE"},
     }
@@ -361,7 +361,7 @@ def test_prepare_points_payload_migrates_legacy_source_h5(monkeypatch):
     monkeypatch.setattr(
         metadata_mod,
         "_build_io_from_source_h5",
-        lambda src, dataset_key="keypoints": {"kind": AnnotationKind.GT, "dataset_key": dataset_key},
+        lambda src, dataset_key="df_with_missing": {"kind": AnnotationKind.GT, "dataset_key": dataset_key},
     )
 
     payload = metadata_mod._prepare_points_payload(
@@ -370,7 +370,7 @@ def test_prepare_points_payload_migrates_legacy_source_h5(monkeypatch):
     )
 
     assert payload["io"]["kind"] == AnnotationKind.GT
-    assert payload["io"]["dataset_key"] == "keypoints"
+    assert payload["io"]["dataset_key"] == "df_with_missing"
 
 
 # -----------------------------------------------------------------------------
@@ -394,7 +394,7 @@ def test_attach_source_and_io_to_layer_kwargs_sets_legacy_fields_and_io(monkeypa
     assert inner["source_h5"].endswith("CollectedData_Jane.h5")
     assert inner["io"]["kind"] == AnnotationKind.GT
     assert inner["io"]["source_relpath_posix"] == "CollectedData_Jane.h5"
-    assert inner["io"]["dataset_key"] == "keypoints"
+    assert inner["io"]["dataset_key"] == "df_with_missing"
 
 
 # -----------------------------------------------------------------------------
@@ -532,14 +532,14 @@ def test_build_io_provenance_dict_keeps_enum_kind_object(tmp_path: Path):
         project_root=tmp_path,
         source_relpath_posix="CollectedData_Jane.h5",
         kind=AnnotationKind.GT,
-        dataset_key="keypoints",
+        dataset_key="df_with_missing",
     )
     # mode="python" => should keep enum object at runtime
     assert isinstance(d["kind"], AnnotationKind)
     assert d["kind"] == AnnotationKind.GT
     assert d["project_root"] == str(tmp_path)
     assert d["source_relpath_posix"] == "CollectedData_Jane.h5"
-    assert d["dataset_key"] == "keypoints"
+    assert d["dataset_key"] == "df_with_missing"
     assert d["schema_version"] == 1
 
 
@@ -548,6 +548,6 @@ def test_build_io_provenance_dict_excludes_none_fields(tmp_path: Path):
         project_root=tmp_path,
         source_relpath_posix="CollectedData_Jane.h5",
         kind=None,  # exclude_none=True => kind should be absent
-        dataset_key="keypoints",
+        dataset_key="df_with_missing",
     )
     assert "kind" not in d

--- a/src/napari_deeplabcut/_tests/core/test_project_paths.py
+++ b/src/napari_deeplabcut/_tests/core/test_project_paths.py
@@ -11,6 +11,7 @@ from napari_deeplabcut.core.project_paths import (
     coerce_paths_to_dlc_row_keys,
     dataset_folder_has_files,
     infer_dlc_project_from_config,
+    infer_dlc_project_from_labeled_folder,
     resolve_project_root_from_config,
     target_dataset_folder_for_config,
 )
@@ -618,3 +619,90 @@ def test_infer_dlc_project_from_config_rejects_invalid_path(tmp_path):
 
     with pytest.raises(ValueError):
         infer_dlc_project_from_config(bad_config)
+
+
+# -----------------------------------------------------------------------------
+# infer_dlc_project_from_labeled_folder
+# -----------------------------------------------------------------------------
+def test_infer_dlc_project_from_labeled_folder_without_config_uses_dataset_as_anchor(
+    tmp_path: Path,
+):
+    dataset = tmp_path / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+
+    ctx = infer_dlc_project_from_labeled_folder(dataset)
+
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.root_anchor == dataset.resolve()
+    assert ctx.project_root is None
+    assert ctx.config_path is None
+
+
+def test_infer_dlc_project_from_labeled_folder_with_config_prefers_project_root(
+    tmp_path: Path,
+):
+    project = tmp_path / "project"
+    dataset = project / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    ctx = infer_dlc_project_from_labeled_folder(
+        dataset,
+        prefer_project_root=True,
+    )
+
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+def test_infer_dlc_project_from_labeled_folder_with_config_can_keep_dataset_anchor(
+    tmp_path: Path,
+):
+    project = tmp_path / "project"
+    dataset = project / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    ctx = infer_dlc_project_from_labeled_folder(
+        dataset,
+        prefer_project_root=False,
+    )
+
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == dataset.resolve()
+
+
+def test_infer_dlc_project_from_labeled_folder_respects_max_levels(tmp_path: Path):
+    project = tmp_path / "project"
+    dataset = project / "a" / "b" / "c" / "labeled-data" / "mouse1"
+    dataset.mkdir(parents=True)
+
+    cfg = project / "config.yaml"
+    cfg.touch()
+
+    # Too shallow: should not reach project/config.yaml
+    ctx = infer_dlc_project_from_labeled_folder(dataset, max_levels=2)
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.root_anchor == dataset.resolve()
+    assert ctx.project_root is None
+    assert ctx.config_path is None
+
+    # Deep enough: should find config and elevate to project root by default
+    ctx = infer_dlc_project_from_labeled_folder(dataset, max_levels=5)
+    assert ctx.dataset_folder == dataset.resolve()
+    assert ctx.project_root == project.resolve()
+    assert ctx.config_path == cfg.resolve()
+    assert ctx.root_anchor == project.resolve()
+
+
+def test_infer_dlc_project_from_labeled_folder_rejects_unusable_input():
+    with pytest.raises(ValueError, match="Could not normalize labeled folder"):
+        infer_dlc_project_from_labeled_folder(object())

--- a/src/napari_deeplabcut/_tests/core/test_provenance.py
+++ b/src/napari_deeplabcut/_tests/core/test_provenance.py
@@ -26,7 +26,7 @@ def test_ensure_io_provenance_accepts_model_instance(tmp_path: Path):
         project_root=str(tmp_path),
         source_relpath_posix="CollectedData_Jane.h5",
         kind=AnnotationKind.GT,
-        dataset_key="keypoints",
+        dataset_key="df_with_missing",
     )
     out = ensure_io_provenance(io)
     assert out is io
@@ -38,7 +38,7 @@ def test_ensure_io_provenance_accepts_dict_with_enum_kind(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,  # IMPORTANT: enum instance, not string
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     out = ensure_io_provenance(payload)
     assert isinstance(out, IOProvenance)
@@ -57,7 +57,7 @@ def test_ensure_io_provenance_rejects_dict_with_string_kind(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": "gt",  # invalid at runtime by policy
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     with pytest.raises(MissingProvenanceError):
         ensure_io_provenance(payload)
@@ -69,7 +69,7 @@ def test_ensure_io_provenance_rejects_invalid_kind_value(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": "not-a-kind",
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     with pytest.raises(MissingProvenanceError):
         ensure_io_provenance(payload)
@@ -86,7 +86,7 @@ def test_ensure_io_provenance_rejects_missing_required_relpath(tmp_path: Path):
         "project_root": str(tmp_path),
         # missing source_relpath_posix
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     # ensure_io_provenance validates; resolve_provenance_path is stricter about missing relpath
     out = ensure_io_provenance(payload)
@@ -108,7 +108,7 @@ def test_normalize_provenance_converts_backslashes(tmp_path: Path):
         project_root=str(tmp_path),
         source_relpath_posix=r"labeled-data\test\CollectedData_Jane.h5",
         kind=AnnotationKind.GT,
-        dataset_key="keypoints",
+        dataset_key="df_with_missing",
     )
     out = normalize_provenance(io)
     assert out is not None
@@ -135,7 +135,7 @@ def test_resolve_provenance_path_uses_root_anchor_when_provided(tmp_path: Path):
         "project_root": str(other_root),  # valid dir, but not where file exists
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
 
     resolved = resolve_provenance_path(io, root_anchor=anchor)
@@ -152,7 +152,7 @@ def test_resolve_provenance_path_uses_project_root_when_root_anchor_missing(tmp_
         "project_root": str(root),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
 
     resolved = resolve_provenance_path(io, root_anchor=None)
@@ -165,7 +165,7 @@ def test_resolve_provenance_path_requires_source_relpath_posix(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": None,
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     with pytest.raises(MissingProvenanceError):
         resolve_provenance_path(payload)
@@ -177,7 +177,7 @@ def test_resolve_provenance_path_requires_anchor_or_project_root(tmp_path: Path)
         "project_root": None,
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     with pytest.raises(UnresolvablePathError):
         resolve_provenance_path(payload, root_anchor=None)
@@ -189,7 +189,7 @@ def test_resolve_provenance_path_raises_if_missing_by_default(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     with pytest.raises(UnresolvablePathError):
         resolve_provenance_path(payload, allow_missing=False)
@@ -201,7 +201,7 @@ def test_resolve_provenance_path_allows_missing_when_flag_true(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     resolved = resolve_provenance_path(payload, allow_missing=True)
     assert resolved == tmp_path / "CollectedData_Jane.h5"
@@ -217,7 +217,7 @@ def test_resolve_provenance_path_normalizes_backslashes(tmp_path: Path):
         "project_root": str(tmp_path),
         "source_relpath_posix": r"labeled-data\CollectedData_Jane.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     resolved = resolve_provenance_path(payload)
     assert resolved == tmp_path / "labeled-data" / "CollectedData_Jane.h5"

--- a/src/napari_deeplabcut/_tests/core/test_reader_layerdata_contract.py
+++ b/src/napari_deeplabcut/_tests/core/test_reader_layerdata_contract.py
@@ -19,7 +19,7 @@ def _write_minimal_h5(path: Path, scorer: str, with_likelihood: bool = False, al
         row = [10.0, 20.0] + ([0.9] if with_likelihood else [])
     df = pd.DataFrame([row], index=["img000.png"], columns=cols)
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_hdf(path, key="keypoints", mode="w")
+    df.to_hdf(path, key="df_with_missing", mode="w")
     return df
 
 
@@ -68,7 +68,7 @@ def test_read_hdf_single_filters_data_and_properties_consistently(tmp_path: Path
     h5 = tmp_path / "CollectedData_John.h5"
     cols = pd.MultiIndex.from_product([["John"], ["bp1", "bp2"], ["x", "y"]], names=["scorer", "bodyparts", "coords"])
     df = pd.DataFrame([[10.0, 20.0, np.nan, np.nan]], index=["img000.png"], columns=cols)
-    df.to_hdf(h5, key="keypoints", mode="w")
+    df.to_hdf(h5, key="df_with_missing", mode="w")
 
     layers = read_hdf_single(h5, kind=AnnotationKind.GT)
     data, meta, _ = layers[0]

--- a/src/napari_deeplabcut/_tests/core/test_writer_promotion.py
+++ b/src/napari_deeplabcut/_tests/core/test_writer_promotion.py
@@ -32,7 +32,7 @@ def _make_minimal_points_metadata(
                 "project_root": str(root),
                 "source_relpath_posix": f"{name}.h5",
                 "kind": kind,
-                "dataset_key": "keypoints",
+                "dataset_key": "df_with_missing",
             },
         },
     }
@@ -42,7 +42,7 @@ def _make_minimal_points_metadata(
 
 
 def _read_keypoints_h5(p: Path) -> pd.DataFrame:
-    return pd.read_hdf(p, key="keypoints")
+    return pd.read_hdf(p, key="df_with_missing")
 
 
 def test_writer_aborts_if_machine_source_without_save_target(tmp_path: Path):
@@ -86,7 +86,7 @@ def test_writer_promotion_writes_collecteddata_and_rewrites_scorer(tmp_path: Pat
         "project_root": str(tmp_path),
         "source_relpath_posix": "CollectedData_Alice.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
         "scorer": "Alice",
     }
 
@@ -101,7 +101,7 @@ def test_writer_promotion_writes_collecteddata_and_rewrites_scorer(tmp_path: Pat
     # Create a dummy machine file and snapshot it (writer must not touch it)
     machine_path = tmp_path / "machinelabels-iter0.h5"
     df_machine = pd.DataFrame(np.nan, columns=cols, index=["img000.png"])
-    df_machine.to_hdf(machine_path, key="keypoints", mode="w")
+    df_machine.to_hdf(machine_path, key="df_with_missing", mode="w")
     machine_before = _read_keypoints_h5(machine_path)
 
     points = np.array(

--- a/src/napari_deeplabcut/_tests/e2e/conftest.py
+++ b/src/napari_deeplabcut/_tests/e2e/conftest.py
@@ -98,9 +98,9 @@ def overwrite_confirm(monkeypatch):
 
         return state["result"]
 
-    import napari_deeplabcut.ui.dialogs as dlg
+    import napari_deeplabcut.ui.ui_dialogs.save as save_dlg
 
-    monkeypatch.setattr(dlg, "maybe_confirm_overwrite", _patched_maybe_confirm_overwrite)
+    monkeypatch.setattr(save_dlg, "maybe_confirm_overwrite", _patched_maybe_confirm_overwrite)
 
     class Controller:
         @property

--- a/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_layer_coloring.py
@@ -55,7 +55,7 @@ def test_config_placeholder_points_layer_colors_after_first_keypoint_added(viewe
     assert "header" in md, "Expected header in metadata for config.yaml placeholder layer"
 
     # 3) Begin editing: add bodypart1 then bodypart2
-    store = controls._stores.get(placeholder)
+    store = controls.get_layer_store(placeholder)
     assert store is not None, "Expected KeypointStore to be registered for placeholder Points layer"
 
     # Add first point
@@ -134,7 +134,7 @@ def test_config_placeholder_multianimal_colors_by_id_after_first_keypoint_added(
     assert "animal2" in id_cycles, f"Expected 'animal2' in derived id cycles; got keys={list(id_cycles)[:10]}"
 
     # 3) Begin editing: add a point for animal1, then animal2
-    store = controls._stores.get(placeholder)
+    store = controls.get_layer_store(placeholder)
     assert store is not None, "Expected KeypointStore for placeholder Points layer"
 
     # Add first point: (frame, y, x)
@@ -212,7 +212,7 @@ def test_color_scheme_panel_toggle_shows_active_then_full_config_bodyparts(
     # Make sure the placeholder is the active target layer
     viewer.layers.selection.active = placeholder
 
-    store = controls._stores.get(placeholder)
+    store = controls.get_layer_store(placeholder)
     assert store is not None
 
     # Deterministically add bodypart1
@@ -273,8 +273,8 @@ def test_color_scheme_panel_multianimal_toggle_shows_active_then_full_config_ind
     assert placeholder.data is None or len(placeholder.data) == 0
 
     # Wait until the existing controls instance has wired the layer
-    qtbot.waitUntil(lambda: placeholder in controls._stores, timeout=5_000)
-    store = controls._stores.get(placeholder)
+    qtbot.waitUntil(lambda: controls.get_layer_store(placeholder) is not None, timeout=5_000)
+    store = controls.get_layer_store(placeholder)
     assert store is not None
 
     # This assertion is now valid because we're using the controls instance

--- a/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_config_first_hazard_regression_no_silent_deletion(viewer, keypoint_controls, qtbot, tmp_path, caplog):
+def test_config_regression_no_silent_deletion(viewer, keypoint_controls, qtbot, tmp_path, caplog):
     """
     Regression for the original report:
     Save the WRONG (placeholder) layer and still preserve previous labels due to merge-on-save.
@@ -22,7 +22,7 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, keypoint_cont
 
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    pre = pd.read_hdf(h5_path, key="keypoints")
+    pre = pd.read_hdf(h5_path, key="df_with_missing")
     assert np.isfinite(_get_coord_from_df(pre, "bodypart1", "x"))
     assert np.isnan(_get_coord_from_df(pre, "bodypart2", "x"))
 
@@ -57,7 +57,7 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, keypoint_cont
     viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
     qtbot.wait(200)
 
-    post = pd.read_hdf(h5_path, key="keypoints")
+    post = pd.read_hdf(h5_path, key="df_with_missing")
     b1x_post = _get_coord_from_df(post, "bodypart1", "x")
     b2x_post = _get_coord_from_df(post, "bodypart2", "x")
 
@@ -129,7 +129,7 @@ def test_no_overwrite_warning_when_only_filling_nans(viewer, keypoint_controls, 
     viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
     qtbot.wait(200)
 
-    post = pd.read_hdf(h5_path, key="keypoints")
+    post = pd.read_hdf(h5_path, key="df_with_missing")
     assert np.isfinite(_get_coord_from_df(post, "bodypart1", "x"))
     assert np.isfinite(_get_coord_from_df(post, "bodypart2", "x"))
 
@@ -163,7 +163,7 @@ def test_overwrite_warning_triggers_on_conflict(viewer, keypoint_controls, qtbot
     assert overwrite_confirm.calls[0]["n_pairs"] is not None
     assert overwrite_confirm.calls[0]["n_pairs"] >= 1
 
-    post = pd.read_hdf(h5_path, key="keypoints")
+    post = pd.read_hdf(h5_path, key="df_with_missing")
     assert _get_coord_from_df(post, "bodypart1", "x") == 99.0
 
 
@@ -176,7 +176,7 @@ def test_overwrite_warning_cancel_aborts_write(viewer, keypoint_controls, qtbot,
 
     project, config_path, labeled_folder, h5_path = _make_minimal_dlc_project(tmp_path)
 
-    pre = pd.read_hdf(h5_path, key="keypoints")
+    pre = pd.read_hdf(h5_path, key="df_with_missing")
     b1x_pre = _get_coord_from_df(pre, "bodypart1", "x")
     b1y_pre = _get_coord_from_df(pre, "bodypart1", "y")
 
@@ -203,6 +203,6 @@ def test_overwrite_warning_cancel_aborts_write(viewer, keypoint_controls, qtbot,
 
     assert len(overwrite_confirm.calls) == 1, "Expected overwrite confirmation to be requested once."
 
-    post = pd.read_hdf(h5_path, key="keypoints")
+    post = pd.read_hdf(h5_path, key="df_with_missing")
     assert _get_coord_from_df(post, "bodypart1", "x") == b1x_pre
     assert _get_coord_from_df(post, "bodypart1", "y") == b1y_pre

--- a/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_overwrite_and_merge.py
@@ -46,7 +46,7 @@ def test_config_first_hazard_regression_no_silent_deletion(viewer, keypoint_cont
     # Placeholder should still be present for this regression to apply
     assert placeholder in viewer.layers
 
-    store = keypoint_controls._stores.get(placeholder)
+    store = keypoint_controls.get_layer_store(placeholder)
     assert store is not None
 
     # Add a new bodypart2 point to placeholder using (frame, y, x)
@@ -119,7 +119,7 @@ def test_no_overwrite_warning_when_only_filling_nans(viewer, keypoint_controls, 
     logger.info("any NaNs in points.data = %s", np.isnan(points.data).any())
     logger.info("labels[:10] = %s", points.properties.get("label")[:10])
     logger.info("ids[:10] = %s", points.properties.get("id")[:10] if "id" in points.properties else None)
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     # Fill NaNs for bodypart2
@@ -149,7 +149,7 @@ def test_overwrite_warning_triggers_on_conflict(viewer, keypoint_controls, qtbot
     qtbot.wait(200)
 
     points = _get_points_layer_with_data(viewer)
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     # Create conflict: overwrite bodypart1 from (10,20) -> (99,88)
@@ -187,7 +187,7 @@ def test_overwrite_warning_cancel_aborts_write(viewer, keypoint_controls, qtbot,
     qtbot.wait(200)
 
     points = _get_points_layer_with_data(viewer)
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     _set_or_add_bodypart_xy(points, store, "bodypart1", x=456.0, y=123.0)

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -158,8 +158,8 @@ def test_copy_paste_points_to_new_frame_does_not_crash_and_offsets_frame(
     layer = viewer.add_points(data, **md)
 
     assert isinstance(layer, Points)
-    qtbot.waitUntil(lambda: layer in controls._stores, timeout=5_000)
-    assert layer in controls._stores
+    qtbot.waitUntil(lambda: controls.get_layer_store(layer) is not None, timeout=5_000)
+    assert controls.get_layer_store(layer) is not None
 
     # frame 0: select and copy
     viewer.dims.set_point(0, 0)

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -356,7 +356,7 @@ def test_promotion_first_save_skip_config_then_prompt_scorer_and_create_sidecar(
     labeled_folder = _make_labeled_folder_with_machine_only(tmp_path)
 
     machine_path = labeled_folder / "machinelabels-iter0.h5"
-    machine_pre = pd.read_hdf(machine_path, key="keypoints")
+    machine_pre = pd.read_hdf(machine_path, key="df_with_missing")
 
     # Open folder
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
@@ -406,7 +406,7 @@ def test_promotion_first_save_skip_config_then_prompt_scorer_and_create_sidecar(
     assert gt_path.exists()
 
     # Machine file unchanged
-    machine_post = pd.read_hdf(machine_path, key="keypoints")
+    machine_post = pd.read_hdf(machine_path, key="df_with_missing")
     pd.testing.assert_frame_equal(machine_pre, machine_post)
 
 
@@ -429,7 +429,7 @@ def test_promotion_second_save_skip_config_then_use_sidecar_without_scorer_promp
     sidecar.write_text('{"schema_version": 1, "default_scorer": "Alice"}', encoding="utf-8")
 
     machine_path = labeled_folder / "machinelabels-iter0.h5"
-    machine_pre = pd.read_hdf(machine_path, key="keypoints")
+    machine_pre = pd.read_hdf(machine_path, key="df_with_missing")
 
     controls = keypoint_controls
     viewer.window.add_dock_widget(controls, name="Keypoint controls", area="right")
@@ -457,7 +457,7 @@ def test_promotion_second_save_skip_config_then_use_sidecar_without_scorer_promp
     gt_path = labeled_folder / "CollectedData_Alice.h5"
     assert gt_path.exists()
 
-    machine_post = pd.read_hdf(machine_path, key="keypoints")
+    machine_post = pd.read_hdf(machine_path, key="df_with_missing")
     pd.testing.assert_frame_equal(machine_pre, machine_post)
 
     controls._save_layers_dialog(selected=True)
@@ -601,7 +601,7 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     assert points.metadata["paths"] == expected_paths
 
     # H5 row index contains canonical DLC row keys for the safe cases
-    df = pd.read_hdf(expected_h5, key="keypoints")
+    df = pd.read_hdf(expected_h5, key="df_with_missing")
     if isinstance(df.index, pd.MultiIndex):
         observed_rows = ["/".join(map(str, idx)) for idx in df.index]
     else:
@@ -724,7 +724,7 @@ def test_promotion_nearby_config_wins_no_dialog_no_prompt(
     sidecar = labeled_folder / ".napari-deeplabcut.json"
     sidecar.write_text('{"schema_version": 1, "default_scorer": "Alice"}', encoding="utf-8")
 
-    machine_pre = pd.read_hdf(machine_path, key="keypoints")
+    machine_pre = pd.read_hdf(machine_path, key="df_with_missing")
 
     dialog_calls = {"count": 0}
 
@@ -769,7 +769,7 @@ def test_promotion_nearby_config_wins_no_dialog_no_prompt(
     assert expected_gt.exists(), f"Expected GT with config scorer to be created: {expected_gt}"
     assert not unexpected_gt.exists(), f"Sidecar scorer must be ignored when config.yaml is nearby: {unexpected_gt}"
 
-    machine_post = pd.read_hdf(machine_path, key="keypoints")
+    machine_post = pd.read_hdf(machine_path, key="df_with_missing")
     pd.testing.assert_frame_equal(machine_pre, machine_post)
 
 
@@ -792,7 +792,7 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
     """
     labeled_folder = _make_labeled_folder_with_machine_only(tmp_path)
     machine_path = labeled_folder / "machinelabels-iter0.h5"
-    machine_pre = pd.read_hdf(machine_path, key="keypoints")
+    machine_pre = pd.read_hdf(machine_path, key="df_with_missing")
 
     # External DLC project whose config scorer should be used.
     external_project, external_config_path, _external_dataset = _make_project_config_and_frames_no_gt(
@@ -856,7 +856,7 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
         f"Sidecar scorer must be ignored when a valid external config is selected: {unexpected_gt}"
     )
 
-    machine_post = pd.read_hdf(machine_path, key="keypoints")
+    machine_post = pd.read_hdf(machine_path, key="df_with_missing")
     pd.testing.assert_frame_equal(machine_pre, machine_post)
 
 

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 
 import numpy as np
@@ -5,7 +6,9 @@ import pandas as pd
 import pytest
 from napari.layers import Points
 
-from napari_deeplabcut.core.io import AnnotationKind, MissingProvenanceError
+import napari_deeplabcut._widgets as widgets_mod
+from napari_deeplabcut.config.models import AnnotationKind
+from napari_deeplabcut.core.errors import MissingProvenanceError
 
 from .utils import (
     _assert_only_these_files_changed,
@@ -21,23 +24,35 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def forbid_project_config_dialog(monkeypatch):
+def save_workflow_mod():
+    """
+    Module object where PointsLayerSaveWorkflow is defined and whose imported
+    names must be monkeypatched for save-flow tests.
+    """
+    return importlib.import_module(widgets_mod.PointsLayerSaveWorkflow.__module__)
+
+
+@pytest.fixture
+def forbid_project_config_dialog(monkeypatch, save_workflow_mod):
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
+        save_workflow_mod,
+        "prompt_for_project_config_for_save",
         lambda *args, **kwargs: pytest.fail("Unexpected project-config dialog."),
     )
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.maybe_confirm_dataset_path_rewrite",
+        save_workflow_mod,
+        "maybe_confirm_dataset_path_rewrite",
         lambda *args, **kwargs: pytest.fail("Unexpected dataset path rewrite confirmation."),
     )
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.warn_existing_dataset_folder_conflict",
+        save_workflow_mod,
+        "warn_existing_dataset_folder_conflict",
         lambda *args, **kwargs: pytest.fail("Unexpected dataset-folder conflict warning."),
     )
 
 
 @pytest.fixture
-def skip_project_config_dialog(monkeypatch):
+def skip_project_config_dialog(monkeypatch, save_workflow_mod):
     """
     Simulate the new promotion policy when no config.yaml exists.
 
@@ -56,10 +71,7 @@ def skip_project_config_dialog(monkeypatch):
             action=ui_dialogs.ProjectConfigPromptAction.SKIP,
         )
 
-    monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
-        _skip,
-    )
+    monkeypatch.setattr(save_workflow_mod, "prompt_for_project_config_for_save", _skip)
     return calls
 
 
@@ -464,6 +476,7 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     tmp_path,
     monkeypatch,
     overwrite_confirm,
+    save_workflow_mod,
 ):
     """
     Contract: a project-less labeled folder can be associated with a chosen DLC
@@ -523,21 +536,8 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     store.current_keypoint = keypoints.Keypoint("bodypart1", "")
     points.add(np.array([0.0, 11.0, 22.0], dtype=float))
 
-    from napari_deeplabcut.ui import dialogs as ui_dialogs
-
-    monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
-        lambda *args, **kwargs: ui_dialogs.ProjectConfigPromptResult(
-            action=ui_dialogs.ProjectConfigPromptAction.ASSOCIATE,
-            config_path=str(config_path),
-        ),
-    )
-    monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.maybe_confirm_dataset_path_rewrite",
-        lambda *args, **kwargs: True,
-    )
-
     import napari_deeplabcut.core.conflicts as conflicts
+    from napari_deeplabcut.ui import dialogs as ui_dialogs
 
     real_compute = conflicts.compute_overwrite_report_for_points_save
     captured = {}
@@ -547,7 +547,21 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
         return real_compute(data, attributes)
 
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.compute_overwrite_report_for_points_save",
+        save_workflow_mod,
+        "prompt_for_project_config_for_save",
+        lambda *args, **kwargs: ui_dialogs.ProjectConfigPromptResult(
+            action=ui_dialogs.ProjectConfigPromptAction.ASSOCIATE,
+            config_path=str(config_path),
+        ),
+    )
+    monkeypatch.setattr(
+        save_workflow_mod,
+        "maybe_confirm_dataset_path_rewrite",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        save_workflow_mod,
+        "compute_overwrite_report_for_points_save",
         _wrapped_compute,
     )
 
@@ -607,6 +621,7 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
     tmp_path,
     monkeypatch,
     overwrite_confirm,
+    save_workflow_mod,
 ):
     """
     Contract: project-association save must refuse if the target dataset folder
@@ -652,18 +667,21 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
     from napari_deeplabcut.ui import dialogs as ui_dialogs
 
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
+        save_workflow_mod,
+        "prompt_for_project_config_for_save",
         lambda *args, **kwargs: ui_dialogs.ProjectConfigPromptResult(
             action=ui_dialogs.ProjectConfigPromptAction.ASSOCIATE,
             config_path=str(config_path),
         ),
     )
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.warn_existing_dataset_folder_conflict",
+        save_workflow_mod,
+        "warn_existing_dataset_folder_conflict",
         lambda *args, **kwargs: warned.setdefault("called", True),
     )
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.maybe_confirm_dataset_path_rewrite",
+        save_workflow_mod,
+        "maybe_confirm_dataset_path_rewrite",
         lambda *args, **kwargs: True,
     )
 
@@ -687,6 +705,7 @@ def test_promotion_nearby_config_wins_no_dialog_no_prompt(
     tmp_path,
     monkeypatch,
     inputdialog,
+    save_workflow_mod,
 ):
     """
     If a valid DLC config.yaml is discoverable near a machine-labeled layer,
@@ -714,7 +733,8 @@ def test_promotion_nearby_config_wins_no_dialog_no_prompt(
         pytest.fail("Config-selection dialog must not appear when nearby config.yaml is auto-discovered.")
 
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
+        save_workflow_mod,
+        "prompt_for_project_config_for_save",
         _unexpected_config_dialog,
     )
 
@@ -761,6 +781,7 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
     tmp_path,
     monkeypatch,
     inputdialog,
+    save_workflow_mod,
 ):
     """
     If no nearby config.yaml is found, but the user points the save flow to a
@@ -797,7 +818,8 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
         )
 
     monkeypatch.setattr(
-        "napari_deeplabcut._widgets.ui_dialogs.prompt_for_project_config_for_save",
+        save_workflow_mod,
+        "prompt_for_project_config_for_save",
         _choose_external_config,
     )
 
@@ -836,3 +858,100 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
 
     machine_post = pd.read_hdf(machine_path, key="keypoints")
     pd.testing.assert_frame_equal(machine_pre, machine_post)
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_direct_video_labeling_save_is_blocked_without_paths(
+    viewer,
+    keypoint_controls,
+    qtbot,
+    tmp_path,
+    monkeypatch,
+    overwrite_confirm,
+):
+    """
+    Unsupported workflow guard:
+    - user has a video layer open
+    - user adds config.yaml / placeholder points layer
+    - points layer has no extracted-frame paths
+    - save must abort with a warning before overwrite preflight / writer save
+    """
+    overwrite_confirm.forbid()
+
+    project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
+
+    # 1) Open config first -> placeholder Points layer with valid DLC header
+    viewer.open(str(config_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
+    qtbot.wait(200)
+
+    points = next(ly for ly in viewer.layers if isinstance(ly, Points))
+    store = keypoint_controls.get_layer_store(points)
+    assert store is not None
+
+    # Ensure the placeholder truly has no extracted-frame paths
+    points.metadata = dict(points.metadata or {})
+    points.metadata["paths"] = []
+    # Keep a root/project hint if your normal workflow would have one
+    points.metadata.setdefault("project", str(project))
+    points.metadata.setdefault("root", str(labeled_folder))
+
+    # Add one point so the layer looks "dirty" / save-worthy
+    _set_or_add_bodypart_xy(points, store, "bodypart1", x=11.0, y=22.0)
+
+    # 2) Add a synthetic video image layer to create the unsupported context
+    viewer.add_image(
+        np.zeros((3, 8, 8, 3), dtype=np.uint8),
+        name="clip.mp4",
+        metadata={"dlc": {"session_role": "video"}},
+    )
+    qtbot.wait(100)
+
+    # Select the points layer for save
+    viewer.layers.selection.active = points
+    keypoint_controls.viewer.layers.selection.active = points
+    keypoint_controls.viewer.layers.selection.select_only(points)
+
+    warned = {"called": False}
+
+    # Patch the save workflow module where the imported symbols are actually used
+    save_mod = importlib.import_module(keypoint_controls._save_workflow.__class__.__module__)
+
+    # If you added a dedicated warning helper, patch that directly (cleanest)
+    if hasattr(keypoint_controls._save_workflow, "_warn_unsupported_direct_video_label_save"):
+        monkeypatch.setattr(
+            keypoint_controls._save_workflow,
+            "_warn_unsupported_direct_video_label_save",
+            lambda layer, metadata: warned.__setitem__("called", True),
+        )
+    else:
+        # Fallback if you still use QMessageBox.warning directly in the workflow module
+        monkeypatch.setattr(
+            save_mod.QMessageBox,
+            "warning",
+            lambda *args, **kwargs: warned.__setitem__("called", True),
+        )
+
+    # Guard must abort BEFORE overwrite preflight
+    monkeypatch.setattr(
+        save_mod,
+        "compute_overwrite_report_for_points_save",
+        lambda *args, **kwargs: pytest.fail("Overwrite preflight must not run for unsupported direct-video save."),
+    )
+
+    # Optional extra safety: writer save must not be reached either
+
+    def _unexpected_save(*args, **kwargs):
+        pytest.fail("viewer.layers.save must not be called for unsupported direct-video save.")
+
+    monkeypatch.setattr(viewer.layers, "save", _unexpected_save)
+
+    # Call the workflow directly so we can assert on the outcome
+    outcome = keypoint_controls._save_workflow.save_layers(selected=True)
+    qtbot.wait(100)
+
+    assert outcome.saved is False
+    assert warned["called"] is True
+
+    # No GT file should have been created in the dataset folder
+    assert not (labeled_folder / "CollectedData_John.h5").exists()

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -89,7 +89,7 @@ def test_save_routes_to_correct_gt_when_multiple_gt_exist(
     points_b = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == gt_b.stem), None)
     assert points_b is not None, f"Expected a Points layer named {gt_b.stem}"
 
-    store_b = keypoint_controls._stores.get(points_b)
+    store_b = keypoint_controls.get_layer_store(points_b)
     assert store_b is not None
 
     # Fill NaNs for bodypart2 in B only (no overwrite dialog)
@@ -136,7 +136,7 @@ def test_machine_layer_does_not_modify_gt_on_save(viewer, keypoint_controls, qtb
     machine_layer = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == machine_path.stem), None)
     assert machine_layer is not None
 
-    store = keypoint_controls._stores.get(machine_layer)
+    store = keypoint_controls.get_layer_store(machine_layer)
     assert store is not None
 
     # Fill NaNs in machine file (no overwrite prompt)
@@ -177,7 +177,7 @@ def test_layer_rename_does_not_change_save_target(viewer, keypoint_controls, qtb
 
     layer = next((ly for ly in viewer.layers if isinstance(ly, Points) and ly.name == gt_a.stem), None)
     assert layer is not None
-    store = keypoint_controls._stores.get(layer)
+    store = keypoint_controls.get_layer_store(layer)
     assert store is not None
 
     # Rename in UI
@@ -230,7 +230,7 @@ def test_ambiguous_placeholder_save_aborts_when_multiple_gt_exist(
     viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
     qtbot.wait(200)
 
-    store = keypoint_controls._stores.get(placeholder)
+    store = keypoint_controls.get_layer_store(placeholder)
     assert store is not None
 
     # Add a point to placeholder
@@ -311,7 +311,7 @@ def test_config_first_save_writes_gt_into_dataset_folder(viewer, keypoint_contro
     assert pts_layers, "Expected a Points layer from config.yaml"
 
     points = pts_layers[0]
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     # Add a point and save
@@ -357,7 +357,7 @@ def test_promotion_first_save_skip_config_then_prompt_scorer_and_create_sidecar(
     machine_layer = next(p for p in pts_layers if p.name == "machinelabels-iter0")
 
     # Edit: add bodypart2 (use helper that works across versions)
-    store = keypoint_controls._stores.get(machine_layer)
+    store = keypoint_controls.get_layer_store(machine_layer)
     assert store is not None
     _set_or_add_bodypart_xy(machine_layer, store, "bodypart2", x=44.0, y=33.0)
 
@@ -429,7 +429,7 @@ def test_promotion_second_save_skip_config_then_use_sidecar_without_scorer_promp
     pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
     machine_layer = next(p for p in pts_layers if p.name == "machinelabels-iter0")
 
-    store = controls._stores.get(machine_layer)
+    store = controls.get_layer_store(machine_layer)
     assert store is not None
     _set_or_add_bodypart_xy(machine_layer, store, "bodypart1", x=99.0, y=88.0)
 
@@ -506,7 +506,7 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
 
     points = next(ly for ly in viewer.layers if isinstance(ly, Points))
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     # Simulate project-less folder metadata:
@@ -636,7 +636,7 @@ def test_projectless_folder_save_refuses_when_target_dataset_folder_already_cont
     qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
 
     points = next(ly for ly in viewer.layers if isinstance(ly, Points))
-    store = keypoint_controls._stores.get(points)
+    store = keypoint_controls.get_layer_store(points)
     assert store is not None
 
     points.metadata = dict(points.metadata or {})
@@ -728,7 +728,7 @@ def test_promotion_nearby_config_wins_no_dialog_no_prompt(
     pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
     machine_layer = next(p for p in pts_layers if p.name == machine_path.stem)
 
-    store = keypoint_controls._stores.get(machine_layer)
+    store = keypoint_controls.get_layer_store(machine_layer)
     assert store is not None
     _set_or_add_bodypart_xy(machine_layer, store, "bodypart2", x=54.0, y=43.0)
 
@@ -811,7 +811,7 @@ def test_promotion_selected_external_config_wins_no_scorer_prompt(
     pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
     machine_layer = next(p for p in pts_layers if p.name == "machinelabels-iter0")
 
-    store = keypoint_controls._stores.get(machine_layer)
+    store = keypoint_controls.get_layer_store(machine_layer)
     assert store is not None
     _set_or_add_bodypart_xy(machine_layer, store, "bodypart1", x=91.0, y=82.0)
 

--- a/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
@@ -1,0 +1,256 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+from napari.layers import Points
+
+from napari_deeplabcut.config.models import DLCHeaderModel
+from napari_deeplabcut.core.io import _read_hdf_any_key
+
+from .utils import (
+    _make_project_config_and_frames_no_gt,
+    _set_or_add_bodypart_xy,
+)
+
+
+def _assert_single_animal_on_disk(path: Path, *, expected_bodyparts: tuple[str, ...] | None = None) -> pd.DataFrame:
+    """
+    Assert canonical SA on-disk format:
+      columns = 3-level MultiIndex [scorer, bodyparts, coords]
+    """
+    df = _read_hdf_any_key(path)
+    assert isinstance(df.columns, pd.MultiIndex), f"Expected MultiIndex columns in {path}"
+    assert df.columns.nlevels == 3, (
+        f"Expected SA 3-level columns in {path}, got {df.columns.nlevels}: {df.columns.names}"
+    )
+    assert list(df.columns.names) == ["scorer", "bodyparts", "coords"], (
+        f"Expected SA names ['scorer','bodyparts','coords'], got {df.columns.names}"
+    )
+
+    if expected_bodyparts is not None:
+        observed = tuple(dict.fromkeys(df.columns.get_level_values("bodyparts")))
+        assert observed == expected_bodyparts, f"Expected bodyparts {expected_bodyparts}, got {observed}"
+
+    return df
+
+
+def _seed_single_animal_gt(
+    labeled_folder: Path,
+    *,
+    scorer: str = "John",
+    bodyparts: tuple[str, ...] = ("bodypart1",),
+) -> Path:
+    """
+    Create a canonical SA GT file in labeled_folder:
+      - 3-level columns
+      - 1 labeled image row
+      - first bodypart gets finite coords, the rest NaN
+    """
+    image_files = sorted(labeled_folder.glob("*.png"))
+    assert image_files, f"No extracted frames found in {labeled_folder}"
+
+    img_name = image_files[0].name
+    dataset_name = labeled_folder.name
+
+    cols = pd.MultiIndex.from_product(
+        [[scorer], list(bodyparts), ["x", "y"]],
+        names=["scorer", "bodyparts", "coords"],
+    )
+    idx = pd.MultiIndex.from_tuples(
+        [("labeled-data", dataset_name, img_name)],
+    )
+
+    arr = np.full((1, len(cols)), np.nan, dtype=float)
+
+    # Give the first bodypart one finite label so the file is non-empty
+    arr[0, 0] = 10.0  # bodypart1 x
+    arr[0, 1] = 20.0  # bodypart1 y
+
+    df = pd.DataFrame(arr, index=idx, columns=cols)
+
+    gt_path = labeled_folder / f"CollectedData_{scorer}.h5"
+    df.to_hdf(gt_path, key="df_with_missing", mode="w")
+    df.to_csv(gt_path.with_suffix(".csv"))
+
+    return gt_path
+
+
+def _append_bodypart_to_config(config_path: Path, bodypart: str) -> None:
+    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    bodyparts = list(cfg.get("bodyparts", []))
+    if bodypart not in bodyparts:
+        bodyparts.append(bodypart)
+        cfg["bodyparts"] = bodyparts
+        config_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+
+def _header_model_for_layer(layer: Points) -> DLCHeaderModel:
+    hdr = (layer.metadata or {}).get("header")
+    if isinstance(hdr, DLCHeaderModel):
+        return hdr
+    return DLCHeaderModel.model_validate(hdr)
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_single_animal_direct_h5_roundtrip_preserves_sa_format(
+    viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm
+):
+    """
+    Open a canonical SA GT .h5 directly, edit, save.
+
+    This isolates the plain reader/writer path:
+    - NO config layer
+    - NO config merge
+    - NO placeholder workflow
+
+    If this test fails, then config merge is NOT required to reproduce the bug.
+    """
+    overwrite_confirm.capture()
+
+    project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
+    gt_path = _seed_single_animal_gt(labeled_folder, bodyparts=("bodypart1",))
+
+    # Sanity: seed file really is canonical SA on disk
+    _assert_single_animal_on_disk(gt_path, expected_bodyparts=("bodypart1",))
+
+    viewer.open(str(gt_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(lambda: len([ly for ly in viewer.layers if isinstance(ly, Points)]) == 1, timeout=10_000)
+    qtbot.wait(100)
+
+    layer = next(ly for ly in viewer.layers if isinstance(ly, Points))
+    store = keypoint_controls.get_layer_store(layer)
+    assert store is not None
+
+    # Internal diagnostic: direct H5 read already normalizes SA -> canonical_4 with individuals=[""]
+    hdr = _header_model_for_layer(layer)
+    assert hdr.as_multiindex().nlevels == 4
+    assert hdr.individuals == [""]
+
+    # Edit existing bodypart and save
+    _set_or_add_bodypart_xy(layer, store, "bodypart1", x=101.0, y=202.0)
+
+    viewer.layers.selection.active = layer
+    keypoint_controls.viewer.layers.selection.select_only(layer)
+    keypoint_controls._save_layers_dialog(selected=True)
+    qtbot.wait(100)
+
+    # This is the real regression assertion.
+    _assert_single_animal_on_disk(gt_path, expected_bodyparts=("bodypart1",))
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_single_animal_gt_then_config_merge_preserves_sa_format(
+    viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm
+):
+    """
+      1) existing SA GT on disk
+      2) config.yaml edited to add bodypart2
+      3) open GT first
+      4) open config.yaml
+      5) save
+
+    This isolates the 'config merge into existing GT layer' path.
+    """
+    overwrite_confirm.capture()
+
+    project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
+    gt_path = _seed_single_animal_gt(labeled_folder, bodyparts=("bodypart1",))
+    _append_bodypart_to_config(config_path, "bodypart2")
+
+    # Open GT first
+    viewer.open(str(gt_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(
+        lambda: len([ly for ly in viewer.layers if isinstance(ly, Points)]) == 1,
+        timeout=10_000,
+    )
+    qtbot.wait(100)
+
+    gt_layer = next(ly for ly in viewer.layers if isinstance(ly, Points))
+    gt_store = keypoint_controls.get_layer_store(gt_layer)
+    assert gt_store is not None
+
+    # Then open config -> should merge and settle back to one Points layer
+    viewer.open(str(config_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(
+        lambda: len([ly for ly in viewer.layers if isinstance(ly, Points)]) == 1,
+        timeout=10_000,
+    )
+    qtbot.wait(100)
+
+    pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
+    assert len(pts_layers) == 1, f"Expected merged single Points layer, got {[p.name for p in pts_layers]}"
+
+    layer = pts_layers[0]
+    store = keypoint_controls.get_layer_store(layer)
+    assert store is not None
+
+    hdr = _header_model_for_layer(layer)
+    assert "bodypart2" in hdr.bodyparts, f"Expected merged header to contain bodypart2, got {hdr.bodyparts}"
+    assert "bodypart2" in [kp.label for kp in store._keypoints], (
+        f"Store keypoints are stale after config merge: {store._keypoints}"
+    )
+
+    _set_or_add_bodypart_xy(layer, store, "bodypart2", x=77.0, y=88.0)
+
+    viewer.layers.selection.active = layer
+    keypoint_controls.viewer.layers.selection.select_only(layer)
+    keypoint_controls._save_layers_dialog(selected=True)
+    qtbot.wait(100)
+
+    _assert_single_animal_on_disk(gt_path, expected_bodyparts=("bodypart1", "bodypart2"))
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_single_animal_config_first_then_folder_new_bodypart_preserves_sa_format(
+    viewer, keypoint_controls, qtbot, tmp_path, overwrite_confirm
+):
+    """
+      1) existing SA GT on disk
+      2) config.yaml edited to add bodypart2
+      3) open config.yaml first
+      4) open labeled-data folder
+      5) add labels
+      6) save
+
+    This exercises the config-first / placeholder path.
+    """
+    overwrite_confirm.capture()
+
+    _project, config_path, labeled_folder = _make_project_config_and_frames_no_gt(tmp_path)
+    gt_path = _seed_single_animal_gt(labeled_folder, bodyparts=("bodypart1",))
+
+    # Simulate user editing config.yaml outside the plugin
+    _append_bodypart_to_config(config_path, "bodypart2")
+
+    # Open config first -> placeholder points layer
+    viewer.open(str(config_path), plugin="napari-deeplabcut")
+    qtbot.waitUntil(lambda: any(isinstance(ly, Points) for ly in viewer.layers), timeout=5_000)
+    qtbot.wait(100)
+
+    # Then open the labeled-data folder
+    viewer.open(str(labeled_folder), plugin="napari-deeplabcut")
+    qtbot.waitUntil(lambda: len(viewer.layers) >= 2, timeout=10_000)
+    # qtbot.wait(500)
+
+    pts_layers = [ly for ly in viewer.layers if isinstance(ly, Points)]
+    assert pts_layers, "Expected at least one Points layer after config-first + folder open"
+
+    # In this workflow the surviving layer is typically the placeholder / merged layer
+    layer = pts_layers[0]
+    store = keypoint_controls.get_layer_store(layer)
+    assert store is not None
+
+    hdr = _header_model_for_layer(layer)
+    assert "bodypart2" in hdr.bodyparts, f"Expected config-first layer header to contain bodypart2, got {hdr.bodyparts}"
+
+    _set_or_add_bodypart_xy(layer, store, "bodypart2", x=55.0, y=66.0)
+
+    viewer.layers.selection.active = layer
+    keypoint_controls.viewer.layers.selection.select_only(layer)
+    keypoint_controls._save_layers_dialog(selected=True)
+    qtbot.wait(100)
+
+    # Expected good behavior: still canonical SA on disk
+    _assert_single_animal_on_disk(gt_path, expected_bodyparts=("bodypart1", "bodypart2"))

--- a/src/napari_deeplabcut/_tests/e2e/utils.py
+++ b/src/napari_deeplabcut/_tests/e2e/utils.py
@@ -74,7 +74,7 @@ def _make_minimal_dlc_project(tmp_path: Path):
     df0 = pd.DataFrame([[10.0, 20.0, np.nan, np.nan]], index=idx, columns=cols)
 
     h5_path = labeled / "CollectedData_John.h5"
-    df0.to_hdf(h5_path, key="keypoints", mode="w")
+    df0.to_hdf(h5_path, key="df_with_missing", mode="w")
     df0.to_csv(str(h5_path).replace(".h5", ".csv"))
 
     return project, config_path, labeled, h5_path
@@ -97,7 +97,7 @@ def _make_labeled_folder_with_machine_only(tmp_path: Path) -> Path:
     )
     df0 = pd.DataFrame([[np.nan, np.nan, np.nan, np.nan]], index=["img000.png"], columns=cols)
     (folder / "machinelabels-iter0.h5").unlink(missing_ok=True)
-    df0.to_hdf(folder / "machinelabels-iter0.h5", key="keypoints", mode="w")
+    df0.to_hdf(folder / "machinelabels-iter0.h5", key="df_with_missing", mode="w")
     df0.to_csv(str(folder / "machinelabels-iter0.csv"))
 
     return folder
@@ -126,7 +126,7 @@ def _write_keypoints_h5(
     df = pd.DataFrame([values], index=idx, columns=cols)
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    df.to_hdf(path, key="keypoints", mode="w")
+    df.to_hdf(path, key="df_with_missing", mode="w")
     df.to_csv(str(path).replace(".h5", ".csv"))
     return path
 
@@ -211,7 +211,7 @@ def _make_project_config_and_frames_no_gt(tmp_path: Path):
 
 
 def _read_h5_keypoints(path: Path) -> pd.DataFrame:
-    return pd.read_hdf(path, key="keypoints")
+    return pd.read_hdf(path, key="df_with_missing")
 
 
 def _index_mask_for_img(df: pd.DataFrame, basename: str) -> np.ndarray:

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -85,7 +85,7 @@ def test_read_hdf_old_index(tmp_path_factory, fake_keypoints):
     path = str(tmp_path_factory.mktemp("folder") / "data.h5")
     old_index = [f"labeled-data/video/img{i}.png" for i in range(fake_keypoints.shape[0])]
     fake_keypoints.index = old_index
-    fake_keypoints.to_hdf(path, key="keypoints")
+    fake_keypoints.to_hdf(path, key="df_with_missing")
     layers = read_hdf(path)
     assert len(layers) == 1
     image_paths = layers[0][1]["metadata"]["paths"]
@@ -104,7 +104,7 @@ def test_read_hdf_new_index(tmp_path_factory, fake_keypoints):
         ]
     )
     fake_keypoints.index = new_index
-    fake_keypoints.to_hdf(path, key="keypoints")
+    fake_keypoints.to_hdf(path, key="df_with_missing")
     layers = read_hdf(path)
     assert len(layers) == 1
     image_paths = layers[0][1]["metadata"]["paths"]

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -53,7 +53,8 @@ def test_save_layers(viewer, keypoint_controls, points):
 
 @pytest.mark.usefixtures("qtbot")
 def test_show_trails(viewer, keypoint_controls, store):
-    keypoint_controls._stores[store.layer] = store
+    # keypoint_controls._stores[store.layer] = store
+    keypoint_controls.layer_manager.register_managed_layer(store.layer, store)
     viewer.layers.selection.active = store.layer
     keypoint_controls._is_saved = True
 

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -553,7 +553,6 @@ def test_read_config_injects_tables_metadata(tmp_path):
     }
 
 
-@pytest.mark.usefixtures("qtbot")
 def test_points_layer_with_tables_shows_superkeypoints_button(keypoint_controls, qtbot, points):
     controls = keypoint_controls
     qtbot.add_widget(controls)
@@ -562,26 +561,26 @@ def test_points_layer_with_tables_shows_superkeypoints_button(keypoint_controls,
 
     points.metadata["tables"] = {"superanimal_quadruped": {"bp1": "nose", "bp2": "upper_jaw"}}
 
-    # Simulate the same setup path that real inserted/adopted layers use
-    controls._setup_points_layer(points, allow_merge=False)
+    controls.layer_manager._setup_points_layer(points, allow_merge=False)
 
     assert not controls._keypoint_mapping_button.isHidden()
-    assert controls._keypoint_mapping_button.text() == "Load superkeypoints diagram"
 
 
 @pytest.mark.usefixtures("qtbot")
-def test_points_layer_with_tables_button_not_lost_on_merge_path(keypoint_controls, qtbot, points, monkeypatch):
+def test_points_layer_with_tables_button_not_lost_on_merge_path(keypoint_controls, qtbot, points):
     controls = keypoint_controls
     qtbot.add_widget(controls)
 
     points.metadata["tables"] = {"superanimal_quadruped": {"bp1": "nose"}}
 
-    # Force the merge branch to happen
-    monkeypatch.setattr(controls, "_maybe_merge_config_points_layer", lambda layer: True)
+    # First do a normal setup so the button becomes visible.
+    controls.layer_manager._setup_points_layer(points, allow_merge=False)
+    assert not controls._keypoint_mapping_button.isHidden()
 
-    controls._setup_points_layer(points, allow_merge=True)
+    # Simulate manager-driven merge refresh on the already-managed layer.
+    controls._on_points_layers_merged_requested((points,))
 
-    assert controls._keypoint_mapping_button.isHidden()
+    assert not controls._keypoint_mapping_button.isHidden()
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -485,7 +485,7 @@ def test_widget_map_keypoints_writes_to_config(keypoint_controls, qtbot, points,
 
     # neighbors indices correspond to ordering of list(dummy_superkpts)
     # Here: ["nose", "upper_jaw"] -> indices [0, 1]
-    monkeypatch.setattr(keypoints, "_find_nearest_neighbors", lambda xy, xy_ref: np.array([0, 1]))
+    monkeypatch.setattr(keypoints, "find_nearest_neighbors", lambda xy, xy_ref: np.array([0, 1]))
 
     # If your io.load_config / io.write_config do more than YAML I/O,
     # you can keep them. Otherwise stubbing them makes the test isolated.

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -231,9 +231,6 @@ def test_write_hdf_promotion_merges_into_existing_gt(tmp_path, fake_keypoints, m
     root = tmp_path / "proj"
     root.mkdir()
 
-    # Always allow overwrite confirmation in unit test
-    # monkeypatch.setattr(dialogs, "maybe_confirm_overwrite", lambda *args, **kwargs: True)
-
     header = DLCHeaderModel(columns=fake_keypoints.columns)
 
     n_rows = len(fake_keypoints)
@@ -349,8 +346,6 @@ def test_write_hdf_promotion_creates_gt_when_missing(tmp_path, fake_keypoints, m
     """
     root = tmp_path / "proj"
     root.mkdir()
-
-    # monkeypatch.setattr(dialogs, "maybe_confirm_overwrite", lambda *args, **kwargs: True)
 
     header = DLCHeaderModel(columns=fake_keypoints.columns)
     n_rows = len(fake_keypoints)

--- a/src/napari_deeplabcut/_tests/test_writer.py
+++ b/src/napari_deeplabcut/_tests/test_writer.py
@@ -89,7 +89,7 @@ def _add_source_io(metadata: dict, *, root: Path, kind: AnnotationKind, source_n
         "project_root": str(root),
         "source_relpath_posix": source_name.replace("\\", "/"),
         "kind": kind,  # AnnotationKind.GT or AnnotationKind.MACHINE
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
     }
     # legacy migration compatibility (optional but good)
     md["source_h5"] = str((root / source_name).resolve())
@@ -105,7 +105,7 @@ def _add_save_target(metadata: dict, *, root: Path, scorer: str) -> None:
         "project_root": str(root),
         "source_relpath_posix": f"CollectedData_{scorer}.h5",
         "kind": AnnotationKind.GT,
-        "dataset_key": "keypoints",
+        "dataset_key": "df_with_missing",
         "scorer": scorer,
     }
 
@@ -271,13 +271,13 @@ def test_write_hdf_promotion_merges_into_existing_gt(tmp_path, fake_keypoints, m
     # Convert to MultiIndex of path components (matches refactored indexing model)
     guarantee_multiindex_rows(gt)
 
-    gt.to_hdf(gt_path, key="keypoints", mode="w")
+    gt.to_hdf(gt_path, key="df_with_missing", mode="w")
 
     # Create a machine file too; it must remain untouched
     machine_path = root / "machinelabels-iter0.h5"
     df_machine = pd.DataFrame(np.nan, index=[0], columns=fake_keypoints.columns)
-    df_machine.to_hdf(machine_path, key="keypoints", mode="w")
-    machine_before = pd.read_hdf(machine_path, key="keypoints")
+    df_machine.to_hdf(machine_path, key="df_with_missing", mode="w")
+    machine_before = pd.read_hdf(machine_path, key="df_with_missing")
 
     points = np.column_stack([np.arange(n_rows), rng.random(n_rows), rng.random(n_rows)])
 
@@ -285,14 +285,14 @@ def test_write_hdf_promotion_merges_into_existing_gt(tmp_path, fake_keypoints, m
     assert Path(fnames[0]).name == "CollectedData_me.h5"
 
     # GT should exist and be readable
-    df = pd.read_hdf(fnames[0], key="keypoints")
+    df = pd.read_hdf(fnames[0], key="df_with_missing")
     assert isinstance(df, pd.DataFrame)
 
     # Must still be scored as "me" after promotion
     assert df.columns.get_level_values("scorer")[0] == "me"
 
     # Machine file must be unchanged
-    machine_after = pd.read_hdf(machine_path, key="keypoints")
+    machine_after = pd.read_hdf(machine_path, key="df_with_missing")
     pd.testing.assert_frame_equal(machine_before, machine_after)
 
 
@@ -382,7 +382,7 @@ def test_write_hdf_promotion_creates_gt_when_missing(tmp_path, fake_keypoints, m
     out_h5 = Path(fnames[0])
     assert out_h5.exists()
 
-    df = pd.read_hdf(out_h5, key="keypoints")
+    df = pd.read_hdf(out_h5, key="df_with_missing")
     assert df.columns.get_level_values("scorer")[0] == "alice"
 
     # Ensure we still did NOT write back to a machine source file

--- a/src/napari_deeplabcut/_tests/ui/test_debug_window.py
+++ b/src/napari_deeplabcut/_tests/ui/test_debug_window.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
+
+from napari_deeplabcut.ui.debug_window import (
+    DebugTextWindow,
+    make_issue_report_provider,
+    make_log_text_provider,
+)
+
+
+class FakeRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def render_text(self, *, limit: int = 0) -> str:
+        self.calls.append(limit)
+        return f"rendered:{limit}"
+
+
+def test_make_log_text_provider_uses_recorder_limit():
+    recorder = FakeRecorder()
+    provider = make_log_text_provider(recorder=recorder, limit=123)
+
+    text = provider()
+
+    assert text == "rendered:123"
+    assert recorder.calls == [123]
+
+
+def test_make_log_text_provider_handles_missing_recorder():
+    provider = make_log_text_provider(recorder=None, limit=5)
+    assert provider() == "<debug recorder unavailable>"
+
+
+def test_make_issue_report_provider_calls_build_debug_report(monkeypatch):
+    calls = []
+
+    def fake_build_debug_report(*, viewer, recorder, log_limit):
+        calls.append((viewer, recorder, log_limit))
+        return "full-report"
+
+    monkeypatch.setattr(
+        "napari_deeplabcut.ui.debug_window.build_debug_report",
+        fake_build_debug_report,
+    )
+
+    viewer = object()
+    recorder = object()
+    provider = make_issue_report_provider(viewer=viewer, recorder=recorder, log_limit=77)
+
+    text = provider()
+
+    assert text == "full-report"
+    assert calls == [(viewer, recorder, 77)]
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_shows_initial_text(qtbot):
+    provider_calls = []
+
+    def provider():
+        provider_calls.append("called")
+        return "hello debug world"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+        initial_hint="hint",
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    assert provider_calls == ["called"]
+    assert window.windowTitle() == "Debug"
+    assert "hello debug world" in window._text_edit.toPlainText()
+    assert window._text_edit.isReadOnly()
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_refresh_reloads_text(qtbot):
+    state = {"n": 0}
+
+    def provider():
+        state["n"] += 1
+        return f"value:{state['n']}"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    assert window._text_edit.toPlainText() == "value:1"
+
+    qtbot.mouseClick(window._refresh_btn, Qt.LeftButton)
+    assert window._text_edit.toPlainText() == "value:2"
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_copy_to_clipboard(qtbot):
+    def provider():
+        return "copy me"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    qtbot.mouseClick(window._copy_btn, Qt.LeftButton)
+
+    assert QApplication.clipboard().text() == "copy me"
+    assert "Copied to clipboard" in window._status_label.text()
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_handles_provider_failure(qtbot):
+    def provider():
+        raise RuntimeError("provider failed")
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+
+    text = window._text_edit.toPlainText()
+    assert "[debug-window] failed to build debug text" in text
+    assert "RuntimeError" in text
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_debug_window_copy_shortcut_works(qtbot):
+    QApplication.clipboard().clear()
+
+    def provider():
+        return "shortcut copy"
+
+    window = DebugTextWindow(
+        title="Debug",
+        text_provider=provider,
+    )
+    qtbot.addWidget(window)
+    window.show()
+    window.raise_()
+    window.activateWindow()
+    window.setFocus()
+    qtbot.wait(50)
+
+    qtbot.keyClick(window, Qt.Key_C, modifier=Qt.ControlModifier)
+
+    assert QApplication.clipboard().text() == "shortcut copy"

--- a/src/napari_deeplabcut/_tests/ui/test_save.py
+++ b/src/napari_deeplabcut/_tests/ui/test_save.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from napari.layers import Image, Points
+
+import napari_deeplabcut.ui.ui_dialogs.save as save_mod
+
+# ---------------------------------------------------------------------
+# Lightweight test doubles
+# ---------------------------------------------------------------------
+
+
+class DummySelection(list):
+    def __init__(self, items=(), *, active=None):
+        super().__init__(items)
+        self.active = active
+
+    def select_only(self, layer):
+        self[:] = [layer]
+        self.active = layer
+
+
+class DummyLayers(list):
+    def __init__(self, items=()):
+        super().__init__(items)
+        self.selection = DummySelection()
+        self.save_calls = []
+
+    def save(self, *args, **kwargs):
+        self.save_calls.append((args, kwargs))
+
+
+class DummyViewer:
+    def __init__(self, layers=()):
+        self.layers = DummyLayers(layers)
+
+
+class DummyLayerManager:
+    def __init__(self):
+        self.image_root = None
+        self.image_paths = None
+        self._active_image = None
+        self._managed_points = ()
+
+    def active_dlc_image_layer(self):
+        return self._active_image
+
+    def managed_points_layers(self):
+        return tuple(self._managed_points)
+
+
+class DummyTrailsController:
+    def __init__(self):
+        self.persist_calls = []
+
+    def persist_folder_ui_state_for_points_layer(self, layer, *, checkbox_checked: bool):
+        self.persist_calls.append((layer, checkbox_checked))
+
+
+# ---------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------
+
+
+@pytest.fixture
+def points_layer():
+    return Points(
+        np.empty((0, 3), dtype=float),
+        name="points",
+        metadata={},
+        properties={},
+    )
+
+
+@pytest.fixture
+def points_layer_2():
+    return Points(
+        np.empty((0, 3), dtype=float),
+        name="points-2",
+        metadata={},
+        properties={},
+    )
+
+
+@pytest.fixture
+def image_layer():
+    return Image(
+        np.zeros((5, 8, 8), dtype=np.uint8),
+        name="img-stack",
+        metadata={},
+    )
+
+
+@pytest.fixture
+def workflow_factory():
+    def _make(*, viewer=None, layer_manager=None, trails_controller=None, trail_checked=False, resolve_config=None):
+        viewer = viewer or DummyViewer()
+        layer_manager = layer_manager or DummyLayerManager()
+        trails_controller = trails_controller or DummyTrailsController()
+
+        wf = save_mod.PointsLayerSaveWorkflow(
+            parent=None,
+            viewer=viewer,
+            layer_manager=layer_manager,
+            trails_controller=trails_controller,
+            trail_checkbox_getter=lambda: trail_checked,
+            resolve_config_path_for_layer=resolve_config or (lambda _layer: None),
+            current_project_path_getter=lambda: None,
+            current_image_meta_getter=lambda: None,
+            logger=logging.getLogger("test.save_workflow"),
+        )
+        return wf, viewer, layer_manager, trails_controller
+
+    return _make
+
+
+# ---------------------------------------------------------------------
+# _save_multiple_layers
+# ---------------------------------------------------------------------
+
+
+def test_save_multiple_layers_returns_false_when_dialog_cancelled(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+):
+    class FakeDialog:
+        def __init__(self):
+            self.history = None
+
+        def setHistory(self, hist):
+            self.history = hist
+
+        def getSaveFileName(self, **kwargs):
+            return "", ""
+
+    monkeypatch.setattr(save_mod, "QFileDialog", FakeDialog)
+    monkeypatch.setattr(save_mod, "get_save_history", lambda: [r"C:\tmp"])
+
+    viewer = DummyViewer([points_layer])
+    wf, viewer, _lm, trails = workflow_factory(viewer=viewer)
+
+    outcome = wf._save_multiple_layers(selected=True, selected_layers=[points_layer])
+
+    assert outcome.saved is False
+    assert viewer.layers.save_calls == []
+    assert trails.persist_calls == []
+
+
+def test_save_multiple_layers_selected_persists_only_selected_points_layers(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    image_layer,
+):
+    captured = {}
+
+    class FakeDialog:
+        def __init__(self):
+            self.history = None
+
+        def setHistory(self, hist):
+            self.history = hist
+            captured["history"] = hist
+
+        def getSaveFileName(self, **kwargs):
+            captured["dialog_kwargs"] = kwargs
+            return r"C:\tmp\out.tif", "ignored"
+
+    monkeypatch.setattr(save_mod, "QFileDialog", FakeDialog)
+    monkeypatch.setattr(save_mod, "get_save_history", lambda: [r"C:\start"])
+
+    viewer = DummyViewer([points_layer, image_layer])
+    wf, viewer, _lm, trails = workflow_factory(viewer=viewer, trail_checked=True)
+
+    selected_layers = [points_layer, image_layer]
+    outcome = wf._save_multiple_layers(selected=True, selected_layers=selected_layers)
+
+    assert outcome.saved is True
+    assert outcome.status_message == "Data successfully saved"
+
+    assert viewer.layers.save_calls == [((r"C:\tmp\out.tif",), {"selected": True})]
+
+    # Only Points layers from the selected set should be persisted
+    assert trails.persist_calls == [(points_layer, True)]
+
+    assert captured["history"] == [r"C:\start"]
+    assert captured["dialog_kwargs"]["caption"] == "Save selected layers"
+    assert captured["dialog_kwargs"]["dir"] == r"C:\start"
+
+
+def test_save_multiple_layers_all_uses_managed_points_layers(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    points_layer_2,
+):
+    class FakeDialog:
+        def setHistory(self, hist):
+            pass
+
+        def getSaveFileName(self, **kwargs):
+            return r"C:\tmp\all_layers.npy", "ignored"
+
+    monkeypatch.setattr(save_mod, "QFileDialog", FakeDialog)
+    monkeypatch.setattr(save_mod, "get_save_history", lambda: [r"C:\start"])
+
+    viewer = DummyViewer([points_layer, points_layer_2])
+    lm = DummyLayerManager()
+    lm._managed_points = (points_layer, points_layer_2)
+
+    wf, viewer, _lm, trails = workflow_factory(
+        viewer=viewer,
+        layer_manager=lm,
+        trail_checked=False,
+    )
+
+    outcome = wf._save_multiple_layers(selected=False, selected_layers=[])
+
+    assert outcome.saved is True
+    assert viewer.layers.save_calls == [((r"C:\tmp\all_layers.npy",), {"selected": False})]
+    assert trails.persist_calls == [
+        (points_layer, False),
+        (points_layer_2, False),
+    ]
+
+
+def test_save_layers_dispatches_to_save_multiple_for_non_single_points_selection(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    image_layer,
+):
+    viewer = DummyViewer([points_layer, image_layer])
+    viewer.layers.selection[:] = [points_layer, image_layer]
+    viewer.layers.selection.active = points_layer
+
+    wf, _viewer, _lm, _trails = workflow_factory(viewer=viewer)
+
+    called = {}
+
+    def _fake_save_multiple(*, selected, selected_layers):
+        called["selected"] = selected
+        called["selected_layers"] = list(selected_layers)
+        return save_mod.SaveOutcome(saved=True, status_message="ok")
+
+    monkeypatch.setattr(wf, "_save_multiple_layers", _fake_save_multiple)
+
+    outcome = wf.save_layers(selected=True)
+
+    assert outcome.saved is True
+    assert called["selected"] is True
+    assert called["selected_layers"] == [points_layer, image_layer]
+
+
+# ---------------------------------------------------------------------
+# _best_image_context_layer
+# ---------------------------------------------------------------------
+
+
+def test_best_image_context_layer_prefers_lifecycle_owned_active_image(
+    workflow_factory,
+    image_layer,
+):
+    selected_image = Image(np.zeros((2, 2), dtype=np.uint8), name="selected")
+    first_image = Image(np.zeros((2, 2), dtype=np.uint8), name="first")
+
+    viewer = DummyViewer([first_image])
+    viewer.layers.selection.active = selected_image
+
+    lm = DummyLayerManager()
+    lm._active_image = image_layer
+
+    wf, *_ = workflow_factory(viewer=viewer, layer_manager=lm)
+
+    assert wf._best_image_context_layer() is image_layer
+
+
+def test_best_image_context_layer_falls_back_to_selected_image(workflow_factory):
+    selected_image = Image(np.zeros((2, 2), dtype=np.uint8), name="selected")
+    viewer = DummyViewer([selected_image])
+    viewer.layers.selection.active = selected_image
+
+    wf, *_ = workflow_factory(viewer=viewer)
+
+    assert wf._best_image_context_layer() is selected_image
+
+
+def test_best_image_context_layer_falls_back_to_first_image_in_viewer(workflow_factory):
+    img1 = Image(np.zeros((2, 2), dtype=np.uint8), name="img1")
+    img2 = Image(np.zeros((2, 2), dtype=np.uint8), name="img2")
+
+    viewer = DummyViewer([img1, img2])
+    viewer.layers.selection.active = None
+
+    wf, *_ = workflow_factory(viewer=viewer)
+
+    assert wf._best_image_context_layer() is img1
+
+
+# ---------------------------------------------------------------------
+# _enrich_points_metadata_for_save
+# ---------------------------------------------------------------------
+
+
+def test_enrich_metadata_returns_unchanged_if_root_already_present(
+    workflow_factory,
+    points_layer,
+):
+    wf, _viewer, lm, _trails = workflow_factory()
+    lm.image_root = r"C:\project\labeled-data\ctx"
+    lm.image_paths = ["img001.png", "img002.png"]
+
+    md = {"root": r"C:\already\set", "paths": []}
+
+    out = wf._enrich_points_metadata_for_save(points_layer, md)
+
+    # Current behavior: early return if root exists
+    assert out == md
+
+
+def test_enrich_metadata_fills_from_layer_manager_image_context(
+    workflow_factory,
+    points_layer,
+):
+    wf, _viewer, lm, _trails = workflow_factory()
+    lm.image_root = r"C:\project\labeled-data\session1"
+    lm.image_paths = ["img001.png", "img002.png"]
+
+    out = wf._enrich_points_metadata_for_save(points_layer, {})
+
+    assert out["root"] == r"C:\project\labeled-data\session1"
+    assert out["paths"] == ["img001.png", "img002.png"]
+
+
+def test_enrich_metadata_returns_unchanged_when_no_context_and_no_config(
+    workflow_factory,
+    points_layer,
+):
+    wf, *_ = workflow_factory(resolve_config=lambda _layer: None)
+
+    md = {}
+    out = wf._enrich_points_metadata_for_save(points_layer, md)
+
+    assert out == {}
+
+
+def test_enrich_metadata_adds_project_when_config_resolves_but_no_image_layer(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    tmp_path,
+):
+    project_root = tmp_path / "project"
+    config_path = project_root / "config.yaml"
+    project_root.mkdir()
+    config_path.write_text("dummy", encoding="utf-8")
+
+    monkeypatch.setattr(save_mod, "resolve_project_root_from_config", lambda p: project_root)
+
+    wf, *_ = workflow_factory(resolve_config=lambda _layer: config_path)
+
+    out = wf._enrich_points_metadata_for_save(points_layer, {})
+
+    assert out["project"] == str(project_root)
+    assert "root" not in out
+
+
+def test_enrich_metadata_uses_source_anchor_when_it_looks_like_labeled_folder(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    tmp_path,
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    config_path = project_root / "config.yaml"
+    config_path.write_text("dummy", encoding="utf-8")
+
+    inferred_root = project_root / "labeled-data" / "sessionA"
+
+    monkeypatch.setattr(save_mod, "resolve_project_root_from_config", lambda p: project_root)
+    monkeypatch.setattr(save_mod, "normalize_anchor_candidate", lambda src: inferred_root)
+    monkeypatch.setattr(save_mod, "looks_like_dlc_labeled_folder", lambda p: True)
+
+    lm = DummyLayerManager()
+    lm._active_image = SimpleNamespace(
+        source=SimpleNamespace(path=r"C:\whatever\img001.png"),
+        name="ignored",
+        metadata={},
+    )
+
+    wf, _viewer, _lm, _trails = workflow_factory(
+        layer_manager=lm,
+        resolve_config=lambda _layer: config_path,
+    )
+
+    out = wf._enrich_points_metadata_for_save(points_layer, {})
+
+    assert out["project"] == str(project_root)
+    assert out["root"] == str(inferred_root)
+
+
+def test_enrich_metadata_falls_back_to_project_labeled_data_image_name_folder(
+    monkeypatch,
+    workflow_factory,
+    points_layer,
+    tmp_path,
+):
+    project_root = tmp_path / "project"
+    dataset_dir = project_root / "labeled-data" / "session42"
+    dataset_dir.mkdir(parents=True)
+    config_path = project_root / "config.yaml"
+    config_path.write_text("dummy", encoding="utf-8")
+
+    monkeypatch.setattr(save_mod, "resolve_project_root_from_config", lambda p: project_root)
+    monkeypatch.setattr(save_mod, "normalize_anchor_candidate", lambda src: None)
+
+    lm = DummyLayerManager()
+    lm._active_image = SimpleNamespace(
+        source=SimpleNamespace(path=None),
+        name="session42",
+        metadata={},
+    )
+
+    wf, _viewer, _lm, _trails = workflow_factory(
+        layer_manager=lm,
+        resolve_config=lambda _layer: config_path,
+    )
+
+    out = wf._enrich_points_metadata_for_save(points_layer, {})
+
+    assert out["project"] == str(project_root)
+    assert out["root"] == str(dataset_dir)

--- a/src/napari_deeplabcut/_tests/ui/test_singleton_widget.py
+++ b/src/napari_deeplabcut/_tests/ui/test_singleton_widget.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import pytest
+from qtpy.QtWidgets import QWidget
+
+from napari_deeplabcut.ui.base_widget import ViewerSingletonWidget
+
+
+class DummyWindow:
+    def __init__(self):
+        self.dock_widgets = {}
+
+
+class DummyViewer:
+    def __init__(self):
+        self.window = DummyWindow()
+
+
+class Wrapper:
+    def __init__(self, wrapped=None, *, use_obj=False):
+        if use_obj:
+            self._obj = wrapped
+        else:
+            self.__wrapped__ = wrapped
+
+
+class DockWrapper:
+    def __init__(self, widget):
+        self._widget = widget
+
+    def widget(self):
+        return self._widget
+
+
+class TestSingleton(ViewerSingletonWidget):
+    def __init__(self, napari_viewer):
+        if not self._singleton_prepare_init(napari_viewer=napari_viewer):
+            return
+
+        super().__init__()
+        self._singleton_finalize_init()
+
+        self.viewer = self.canonical_viewer(napari_viewer)
+        self.init_count = getattr(self, "init_count", 0) + 1
+
+
+class OtherSingleton(ViewerSingletonWidget):
+    def __init__(self, napari_viewer):
+        if not self._singleton_prepare_init(napari_viewer=napari_viewer):
+            return
+
+        super().__init__()
+        self._singleton_finalize_init()
+
+        self.viewer = self.canonical_viewer(napari_viewer)
+        self.init_count = getattr(self, "init_count", 0) + 1
+
+
+@pytest.fixture(autouse=True)
+def clear_singleton_registry():
+    """
+    Keep tests isolated because the registry is class-level global state.
+    """
+    ViewerSingletonWidget._instances_by_cls.clear()
+    yield
+    ViewerSingletonWidget._instances_by_cls.clear()
+
+
+def test_extract_viewer_from_call_positional():
+    viewer = DummyViewer()
+    assert ViewerSingletonWidget._extract_viewer_from_call((viewer,), {}) is viewer
+
+
+def test_extract_viewer_from_call_napari_viewer_kwarg():
+    viewer = DummyViewer()
+    assert ViewerSingletonWidget._extract_viewer_from_call((), {"napari_viewer": viewer}) is viewer
+
+
+def test_extract_viewer_from_call_viewer_kwarg():
+    viewer = DummyViewer()
+    assert ViewerSingletonWidget._extract_viewer_from_call((), {"viewer": viewer}) is viewer
+
+
+def test_extract_viewer_from_call_none_when_missing():
+    assert ViewerSingletonWidget._extract_viewer_from_call((), {}) is None
+
+
+def test_canonical_viewer_unwraps_wrapped_chain():
+    viewer = DummyViewer()
+    wrapped = Wrapper(Wrapper(viewer))
+    assert ViewerSingletonWidget.canonical_viewer(wrapped) is viewer
+
+
+def test_canonical_viewer_unwraps_obj_chain():
+    viewer = DummyViewer()
+    wrapped = Wrapper(Wrapper(viewer, use_obj=True), use_obj=True)
+    assert ViewerSingletonWidget.canonical_viewer(wrapped) is viewer
+
+
+def test_canonical_viewer_stops_on_self_wrapped():
+    wrapped = Wrapper(None)
+    wrapped.__wrapped__ = wrapped
+    assert ViewerSingletonWidget.canonical_viewer(wrapped) is wrapped
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_same_viewer_same_subclass_returns_same_instance(qtbot):
+    viewer = DummyViewer()
+
+    w1 = TestSingleton(viewer)
+    qtbot.addWidget(w1)
+
+    w2 = TestSingleton(viewer)
+
+    assert w1 is w2
+    assert w1.init_count == 1
+    assert w2.init_count == 1
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_get_or_create_returns_existing_instance(qtbot):
+    viewer = DummyViewer()
+
+    w1 = TestSingleton(viewer)
+    qtbot.addWidget(w1)
+
+    w2 = TestSingleton.get_or_create(viewer)
+
+    assert w1 is w2
+    assert w1.init_count == 1
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_get_existing_accepts_wrapped_viewer(qtbot):
+    viewer = DummyViewer()
+    proxy = Wrapper(viewer)
+
+    w = TestSingleton(viewer)
+    qtbot.addWidget(w)
+
+    assert TestSingleton.get_existing(proxy) is w
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_different_subclasses_have_independent_singletons(qtbot):
+    viewer = DummyViewer()
+
+    w1 = TestSingleton(viewer)
+    qtbot.addWidget(w1)
+
+    w2 = OtherSingleton(viewer)
+    qtbot.addWidget(w2)
+
+    assert w1 is not w2
+    assert isinstance(w1, TestSingleton)
+    assert isinstance(w2, OtherSingleton)
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_is_docked_true_when_widget_directly_registered(qtbot):
+    viewer = DummyViewer()
+    widget = TestSingleton(viewer)
+    qtbot.addWidget(widget)
+
+    viewer.window.dock_widgets["a"] = widget
+
+    assert TestSingleton.is_docked(viewer, widget) is True
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_is_docked_true_when_wrapper_returns_widget(qtbot):
+    viewer = DummyViewer()
+    widget = TestSingleton(viewer)
+    qtbot.addWidget(widget)
+
+    viewer.window.dock_widgets["a"] = DockWrapper(widget)
+
+    assert TestSingleton.is_docked(viewer, widget) is True
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_is_docked_false_when_widget_not_present(qtbot):
+    viewer = DummyViewer()
+    widget = TestSingleton(viewer)
+    qtbot.addWidget(widget)
+
+    other = QWidget()
+    qtbot.addWidget(other)
+
+    assert TestSingleton.is_docked(viewer, widget) is False
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_get_existing_returns_none_after_widget_deleted(qtbot):
+    viewer = DummyViewer()
+
+    widget = TestSingleton(viewer)
+    qtbot.addWidget(widget)
+
+    assert TestSingleton.get_existing(viewer) is widget
+
+    widget.deleteLater()
+    qtbot.waitUntil(lambda: TestSingleton.get_existing(viewer) is None, timeout=1000)
+
+    assert TestSingleton.get_existing(viewer) is None

--- a/src/napari_deeplabcut/_tests/utils/test_debug.py
+++ b/src/napari_deeplabcut/_tests/utils/test_debug.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from napari_deeplabcut.utils.debug import (
+    InMemoryDebugRecorder,
+    _safe_tail,
+    collect_environment_summary,
+    format_debug_report,
+    get_debug_recorder,
+    install_debug_recorder,
+    summarize_layer,
+    summarize_viewer,
+)
+
+
+class _BrokenStr:
+    def __str__(self):
+        raise RuntimeError("boom")
+
+
+def _cleanup_logger(logger_name: str) -> None:
+    logger = logging.getLogger(logger_name)
+    recorder = get_debug_recorder(logger_name=logger_name)
+    if recorder is not None:
+        try:
+            logger.removeHandler(recorder)
+        except Exception:
+            pass
+        try:
+            delattr(logger, "_napari_dlc_debug_recorder")
+        except Exception:
+            pass
+
+
+def test_install_debug_recorder_is_idempotent():
+    logger_name = "napari-deeplabcut.test.idempotent"
+    _cleanup_logger(logger_name)
+
+    rec1 = install_debug_recorder(logger_name=logger_name, capacity=50)
+    rec2 = install_debug_recorder(logger_name=logger_name, capacity=999)
+
+    try:
+        assert rec1 is rec2
+        assert get_debug_recorder(logger_name=logger_name) is rec1
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_captures_debug_message():
+    logger_name = "napari-deeplabcut.test.capture"
+    _cleanup_logger(logger_name)
+
+    recorder = install_debug_recorder(logger_name=logger_name, capacity=50)
+    logger = logging.getLogger(logger_name)
+
+    try:
+        logger.debug("hello %s", "world")
+
+        records = recorder.snapshot()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.level == "DEBUG"
+        assert rec.logger_name == logger_name
+        assert rec.message == "hello world"
+        assert rec.exc_text is None
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_captures_exception_text():
+    logger_name = "napari-deeplabcut.test.exc"
+    _cleanup_logger(logger_name)
+
+    recorder = install_debug_recorder(logger_name=logger_name, capacity=50)
+    logger = logging.getLogger(logger_name)
+
+    try:
+        try:
+            raise ValueError("bad things")
+        except ValueError:
+            logger.exception("something failed")
+
+        records = recorder.snapshot()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.message == "something failed"
+        assert rec.exc_text is not None
+        assert "ValueError: bad things" in rec.exc_text
+    finally:
+        _cleanup_logger(logger_name)
+
+
+def test_recorder_is_bounded():
+    recorder = InMemoryDebugRecorder(capacity=3)
+    logger = logging.getLogger("napari-deeplabcut.test.bounded")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        for i in range(10):
+            logger.debug("msg-%d", i)
+
+        records = recorder.snapshot()
+        assert len(records) == 3
+        assert [r.message for r in records] == ["msg-7", "msg-8", "msg-9"]
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_clear_resets_records_and_dropped_count():
+    recorder = InMemoryDebugRecorder(capacity=3)
+    logger = logging.getLogger("napari-deeplabcut.test.clear")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        logger.debug("before clear")
+        assert len(recorder.snapshot()) == 1
+
+        recorder.clear()
+
+        assert recorder.snapshot() == []
+        assert recorder.dropped_count == 0
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_render_text_includes_message_and_level():
+    recorder = InMemoryDebugRecorder(capacity=10)
+    logger = logging.getLogger("napari-deeplabcut.test.render")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        logger.info("hello render")
+        text = recorder.render_text(limit=10)
+
+        assert "INFO" in text
+        assert "hello render" in text
+        assert "napari-deeplabcut.test.render" in text
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_render_text_respects_limit():
+    recorder = InMemoryDebugRecorder(capacity=10)
+    logger = logging.getLogger("napari-deeplabcut.test.limit")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(recorder)
+
+    try:
+        for i in range(5):
+            logger.debug("line-%d", i)
+
+        text = recorder.render_text(limit=2)
+        assert "line-3" in text
+        assert "line-4" in text
+        assert "line-0" not in text
+        assert "line-1" not in text
+        assert "line-2" not in text
+    finally:
+        logger.removeHandler(recorder)
+
+
+def test_emit_handles_unrenderable_message_without_raising():
+    recorder = InMemoryDebugRecorder(capacity=10)
+
+    record = logging.LogRecord(
+        name="napari-deeplabcut.test.unrenderable",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=_BrokenStr(),
+        args=(),
+        exc_info=None,
+    )
+
+    # Should never raise
+    recorder.emit(record)
+
+    records = recorder.snapshot()
+    assert len(records) == 1
+    assert records[0].message == "<unrenderable log message>"
+
+
+class FakeLayer:
+    def __init__(
+        self,
+        *,
+        name="layer",
+        metadata=None,
+        properties=None,
+        data=None,
+        visible=True,
+    ):
+        self.name = name
+        self.metadata = metadata if metadata is not None else {}
+        self.properties = properties if properties is not None else {}
+        self.data = data
+        self.visible = visible
+
+
+class FakeSelection:
+    def __init__(self, active=None):
+        self.active = active
+
+
+class FakeViewerLayers(list):
+    def __init__(self, layers, active=None):
+        super().__init__(layers)
+        self.selection = FakeSelection(active=active)
+
+
+class FakeViewer:
+    def __init__(self, layers, active=None):
+        self.layers = FakeViewerLayers(layers, active=active)
+
+
+def test_safe_tail_redacts_to_last_two_parts():
+    assert _safe_tail("/a/b/c/d.txt").endswith("c/d.txt")
+    assert _safe_tail("single") == "single"
+
+
+def test_collect_environment_summary_contains_expected_keys():
+    env = collect_environment_summary()
+
+    expected = {
+        "python",
+        "platform",
+        "napari-deeplabcut",
+        "napari",
+        "qtpy",
+        "PySide6",
+        "PyQt6",
+        "shiboken6",
+        "numpy",
+        "pydantic",
+        "plugin_module_path",
+    }
+    assert expected.issubset(env.keys())
+
+
+def test_summarize_layer_basic_fields():
+    layer = FakeLayer(
+        name="points",
+        metadata={
+            "project": "/tmp/myproj",
+            "root": "/tmp/data/images",
+            "paths": ["a.png", "b.png"],
+            "header": {"dummy": True},
+            "tables": {"x": "y"},
+            "save_target": {"kind": "gt"},
+        },
+        properties={"label": ["nose"], "id": ["mouse1"]},
+        data=SimpleNamespace(shape=(12, 3)),
+        visible=False,
+    )
+
+    summary = summarize_layer(layer)
+
+    assert summary["name"] == "points"
+    assert summary["type"] == "FakeLayer"
+    assert summary["visible"] is False
+    assert summary["paths_count"] == 2
+    assert summary["has_header"] is True
+    assert summary["has_tables"] is True
+    assert summary["has_save_target"] is True
+    assert "project" in summary
+    assert "root" in summary
+    assert summary["property_keys"] == ["id", "label"]
+    assert summary["data_shape"] == (12, 3)
+
+
+def test_summarize_layer_handles_missing_or_weird_values():
+    layer = FakeLayer(
+        name="empty",
+        metadata=None,
+        properties=None,
+        data=None,
+        visible=True,
+    )
+
+    summary = summarize_layer(layer)
+
+    assert summary["name"] == "empty"
+    assert summary["metadata_keys"] == []
+    assert summary["property_keys"] == []
+    assert summary["data_shape"] is None
+    assert summary["has_header"] is False
+    assert summary["has_tables"] is False
+    assert summary["has_save_target"] is False
+
+
+def test_summarize_viewer_basic():
+    layer1 = FakeLayer(name="img")
+    layer2 = FakeLayer(name="pts")
+    viewer = FakeViewer([layer1, layer2], active=layer2)
+
+    summary = summarize_viewer(viewer)
+
+    assert summary["n_layers"] == 2
+    assert summary["active_layer"] == "pts"
+    assert len(summary["layers"]) == 2
+    assert summary["layers"][0]["name"] == "img"
+    assert summary["layers"][1]["name"] == "pts"
+
+
+def test_format_debug_report_contains_sections():
+    text = format_debug_report(
+        env={"python": "3.x", "platform": "test-os"},
+        viewer_summary={
+            "n_layers": 2,
+            "active_layer": "pts",
+            "layers": [
+                {
+                    "name": "pts",
+                    "type": "Points",
+                    "visible": True,
+                    "data_shape": (10, 3),
+                    "metadata_keys": ["header", "paths"],
+                    "property_keys": ["label"],
+                    "project": "proj/config",
+                    "root": "data/images",
+                    "paths_count": 2,
+                    "has_header": True,
+                    "has_tables": False,
+                    "has_save_target": False,
+                }
+            ],
+        },
+        logs_text="12:00:00 | DEBUG | napari-deeplabcut | hello",
+    )
+
+    assert "## Environment" in text
+    assert "## Viewer" in text
+    assert "## Layers" in text
+    assert "## Recent plugin logs" in text
+    assert "hello" in text
+    assert "pts" in text

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -873,7 +873,8 @@ class KeypointControls(ViewerSingletonWidget):
             active_image if active_image is not None else active_layer,
             fallback_root=self.layer_manager.image_root,
         )
-        self._layer_status_panel.set_folder_name(folder_name)
+        project_path = self.layer_manager.project_path
+        self._layer_status_panel.set_folder_name(folder_name, full_path=project_path)
 
         # No active layer or not a Points layer at all
         if active_layer is None or not isinstance(active_layer, Points):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -42,7 +42,7 @@ from napari.layers import Image, Points
 from napari.utils.events import Event
 from napari.utils.history import get_save_history
 from pydantic import ValidationError
-from qtpy.QtCore import QSettings, Qt, QTimer
+from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -57,7 +57,6 @@ from qtpy.QtWidgets import (
     QPushButton,
     QRadioButton,
     QVBoxLayout,
-    QWidget,
 )
 
 from . import misc
@@ -65,7 +64,7 @@ from .config import settings
 from .config.keybinds import (
     install_global_points_keybindings,
 )
-from .config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
+from .config.models import ImageMetadata, PointsMetadata
 from .core import io, keypoints
 from .core.config_sync import (
     load_point_size_from_config,
@@ -73,7 +72,13 @@ from .core.config_sync import (
     save_point_size_to_config,
 )
 from .core.conflicts import compute_overwrite_report_for_points_save
-from .core.layer_lifecycle import LayerLifecycleManager
+from .core.layer_lifecycle import (
+    MergeDecisionRequest,
+    MergeDecisionResult,
+    MergeDisposition,
+    PointsLayerSetupRequest,
+    get_or_create_layer_manager,
+)
 from .core.layer_versioning import mark_layer_presentation_changed
 from .core.layers import (
     PointsInteractionEvent,
@@ -117,6 +122,7 @@ from .napari_compat import (
     register_points_action,
 )
 from .ui import dialogs as ui_dialogs
+from .ui.base_widget import ViewerSingletonWidget
 from .ui.color_scheme_display import ColorSchemePanel
 from .ui.cropping import (
     build_video_action_menu,
@@ -134,7 +140,6 @@ from .ui.labels_and_dropdown import (
 from .ui.layer_stats import LayerStatusPanel
 from .ui.plots.trajectory import TrajectoryMatplotlibCanvas
 from .utils.debug import get_debug_recorder, install_debug_recorder, log_timing
-from .utils.deprecations import deprecated
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -169,39 +174,37 @@ def _temporary_layer_metadata(layer: Points, metadata: dict):
         layer.metadata = old_metadata
 
 
-class KeypointControls(QWidget):
+class KeypointControls(ViewerSingletonWidget):
     def __init__(self, napari_viewer):
+        if not self._singleton_prepare_init(napari_viewer=napari_viewer):
+            return
+
         super().__init__()
+        self._singleton_finalize_init()
+        self.viewer = self.canonical_viewer(napari_viewer)
+
         # Monkey-patch napari continuous variable type guess
         patch_color_manager_guess_continuous()
-
         self._is_saved = False
 
-        self.viewer = napari_viewer
-
         # Layer lifecycle manager
-        self.layer_manager = LayerLifecycleManager(owner=self)
-        self.layer_manager.attach()
+        self.layer_manager = get_or_create_layer_manager(self.viewer)
+        self.layer_manager.set_merge_decision_provider(self)
         ## Hook up signals for layer lifecycle events as needed, e.g.:
-        self.layer_manager.session_conflict_rejected.connect(
-            self._on_session_conflict_detected,
-        )
-        # self.viewer.layers.events.inserted.connect(self.on_insert)
-        # self.viewer.layers.events.removed.connect(self.on_remove)
+        self.layer_manager.session_conflict_rejected.connect(self._on_session_conflict_detected)
+        self.layer_manager.refresh_video_panel_requested.connect(self._refresh_video_panel_context)
+        self.layer_manager.refresh_layer_status_requested.connect(self._refresh_layer_status_panel)
+        self.layer_manager.video_widget_visibility_requested.connect(self._on_video_widget_visibility_requested)
+        self.layer_manager.move_image_layer_to_bottom_requested.connect(self._move_image_layer_to_bottom)
+
+        self.layer_manager.points_layer_setup_requested.connect(self._on_points_layer_setup_requested)
+        self.layer_manager.points_layers_merged_requested.connect(self._on_points_layers_merged_requested)
+        self.layer_manager.points_layer_removed_requested.connect(self._on_points_layer_removed_requested)
+        self.layer_manager.tracks_layer_removed_requested.connect(self._on_tracks_layer_removed_requested)
 
         ## Debug ##
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
-        ###########
-
-        ## Debug ##
-        self._debug_recorder = install_debug_recorder()
-        self._debug_window = None
-
-        show_debug_action = QAction("&Generate napari-dlc log", self)
-        show_debug_action.setToolTip("Show a debug report with recent plugin logs")
-        show_debug_action.triggered.connect(self._show_debug_window)
-        self.viewer.window.help_menu.addAction(show_debug_action)
         ###########
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
@@ -329,7 +332,7 @@ class KeypointControls(QWidget):
         self._color_scheme_panel = ColorSchemePanel(
             viewer=self.viewer,
             get_color_mode=lambda: self.color_mode,
-            get_header_model=self._get_header_model_from_metadata,
+            get_header_model=self.layer_manager.get_header_model_from_metadata,
             parent=self,
         )
         self._color_scheme_display = self.viewer.window.add_dock_widget(
@@ -401,6 +404,24 @@ class KeypointControls(QWidget):
 
         # Refresh layers stats widget
         QTimer.singleShot(0, self._refresh_layer_status_panel)
+
+        self.destroyed.connect(self._on_destroyed)
+
+    def _on_destroyed(self, *args) -> None:
+        canonical = getattr(self, "_viewer_identity", None)
+        if canonical is None:
+            return
+
+        ref = self.__class__._instances.get(canonical)
+        if ref is not None and ref() is self:
+            self.__class__._instances.pop(canonical, None)
+
+        # Optional: clear manager merge provider if this widget registered itself
+        try:
+            if getattr(self, "layer_manager", None) is not None:
+                self.layer_manager.set_merge_decision_provider(None)
+        except Exception:
+            pass
 
     @cached_property
     def settings(self):
@@ -480,25 +501,10 @@ class KeypointControls(QWidget):
         self._update_color_scheme()
         self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
 
-    def _is_multianimal(self, layer) -> bool:
-        if layer is None or not isinstance(layer, Points):
-            return False
-
-        md = layer.metadata or {}
-        hdr = self._get_header_model_from_metadata(md)
-        if hdr is None:
-            return False
-
-        try:
-            inds = hdr.individuals
-            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
-        except Exception:
-            return False
-
     def _active_layer_is_multianimal(self) -> bool:
         """Returns: whether the active layer is a multi-animal points layer"""
         for layer in self.viewer.layers.selection:
-            if self._is_multianimal(layer):
+            if self.layer_manager.is_multianimal(layer):
                 return True
 
         return False
@@ -538,198 +544,52 @@ class KeypointControls(QWidget):
     # ######################## #
     # Layer setup core methods #
     # ######################## #
+    def resolve_merge(self, request: MergeDecisionRequest) -> MergeDecisionResult:
+        if not request.added_keypoints:
+            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
 
-    @deprecated(
-        details="Lifecycle-owned image setup has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._setup_image_layer(...)",
-    )
-    def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
-        self.layer_manager._setup_image_layer(layer, index=index, reorder=reorder)
-
-    def _is_config_placeholder_points_layer(self, layer: Points) -> bool:
-        """Return True if this looks like the temporary config placeholder layer.
-
-        Conservative rule:
-        - must be a Points layer
-        - must carry a project hint
-        - must not already be tied to image/root/paths context
-        - must not contain actual point data
-        """
-        if layer is None or not isinstance(layer, Points):
-            return False
-
-        md = layer.metadata or {}
-        if not md.get("project"):
-            return False
-
-        # Real labeled/prediction layers usually carry image/root/paths context.
-        if md.get("root") or md.get("paths"):
-            return False
-
-        try:
-            data = np.asarray(layer.data) if layer.data is not None else np.empty((0, 3))
-        except Exception:
-            data = np.empty((0, 3))
-
-        return data.size == 0
-
-    def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
-        """Merge a temporary config placeholder layer into existing managed layers.
-
-        Semantics
-        ---------
-        - Only consumes true config placeholder layers.
-        - The placeholder layer is temporary and is removed after merge.
-        - Existing managed points layers remain authoritative.
-        - If new keypoints are introduced, the user may optionally hide the
-          currently visible managed layer to focus on the new keypoints.
-        """
-        if not self._is_config_placeholder_points_layer(layer):
-            return False
-
-        managed = list(self.layer_manager.iter_managed_points())
-        if not managed:
-            return False
-
-        md = layer.metadata or {}
-        logger.debug(
-            "Maybe merge config placeholder layer=%r project=%r managed_layers=%d",
-            getattr(layer, "name", layer),
-            md.get("project"),
-            len(managed),
+        shared = "Do you want to keep the existing keypoints visible and add the new ones as a separate layer?"
+        text = f"{request.message}\n\n{shared}" if request.message else shared
+        answer = QMessageBox.question(
+            self,
+            "",
+            text,
+            QMessageBox.Yes | QMessageBox.No,
         )
 
-        new_metadata = md.copy()
-        new_header = self._get_header_model_from_metadata(new_metadata)
-        if new_header is None:
-            logger.debug(
-                "Skipping config placeholder merge for layer=%r: missing/invalid header",
-                getattr(layer, "name", layer),
-            )
-            return False
+        if answer == QMessageBox.Yes:
+            return MergeDecisionResult(disposition=MergeDisposition.HIDE_EXISTING)
 
-        # Use an actual managed layer as the reference source of truth,
-        # not the first dropdown menu.
-        reference_layer, _reference_store = managed[0]
-        reference_header = self._get_header_model_from_metadata(reference_layer.metadata or {})
-        if reference_header is None:
-            logger.debug(
-                "Skipping config placeholder merge for layer=%r: reference managed layer has no valid header",
-                getattr(layer, "name", layer),
-            )
-            return False
+        return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
 
-        current_keypoint_set = set(reference_header.bodyparts)
-        new_keypoint_set = set(new_header.bodyparts)
-        diff = new_keypoint_set.difference(current_keypoint_set)
-
-        placeholder_layer = layer
-
-        # Identify the currently visible existing managed layer that we may hide.
-        visible_existing_layer = None
-        for managed_layer, _store in managed:
-            if managed_layer is placeholder_layer:
-                continue
-            try:
-                if getattr(managed_layer, "visible", True):
-                    visible_existing_layer = managed_layer
-                    break
-            except Exception:
-                visible_existing_layer = managed_layer
-                break
-
-        if diff:
-            answer = QMessageBox.question(
-                self,
-                "",
-                "Do you want to display the new keypoints only?",
-            )
-            if answer == QMessageBox.Yes and visible_existing_layer is not None:
-                self.layer_manager._set_layer_visible(visible_existing_layer, False)
-                logger.debug(
-                    "Config placeholder merge layer=%r new_keypoints=%s hid_existing_layer=%r",
-                    getattr(layer, "name", layer),
-                    sorted(diff),
-                    getattr(visible_existing_layer, "name", visible_existing_layer),
-                )
-
-            self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(sorted(diff))} found."
-
-        # Merge header into all managed layers.
-        for managed_layer, store in managed:
-            pts = read_points_meta(
-                managed_layer,
-                migrate_legacy=True,
-                drop_controls=True,
-                drop_header=False,
-            )
-            if not hasattr(pts, "errors"):
-                updated = pts.model_copy(update={"header": new_header})
-                write_points_meta(
-                    managed_layer,
-                    updated,
-                    merge_policy=MergePolicy.MERGE,
-                    fields={"header"},
-                )
-            store.layer = managed_layer
-
-        # Refresh dropdown menus after header/bodypart changes.
-        for menu in self._menus:
-            try:
-                menu._map_individuals_to_bodyparts()
-                menu._update_items()
-            except Exception:
-                logger.debug("Failed to refresh dropdown menu after config merge", exc_info=True)
-
-        # Apply updated presentation metadata to existing managed layers.
-        for managed_layer, store in managed:
-            managed_layer.metadata["config_colormap"] = new_metadata.get(
-                "config_colormap",
-                managed_layer.metadata.get("config_colormap"),
-            )
-            if "face_color_cycles" in new_metadata:
-                managed_layer.metadata["face_color_cycles"] = new_metadata["face_color_cycles"]
-            managed_layer.metadata["colormap_name"] = new_metadata.get(
-                "colormap_name",
-                managed_layer.metadata.get("colormap_name"),
-            )
-
-            mark_layer_presentation_changed(managed_layer)
-            self._apply_points_coloring_from_metadata(managed_layer)
-            store.layer = managed_layer
-
-        # Remove the temporary placeholder layer explicitly by identity.
-        QTimer.singleShot(
-            0,
-            lambda ly=placeholder_layer: self.layer_manager._remove_layer_if_present(ly),
-        )
-
-        self._update_color_scheme()
-        return True
-
-    def _get_header_model_from_metadata(self, md: dict) -> DLCHeaderModel | None:
-        """Return DLCHeaderModel regardless of whether md['header'] is a model, dict payload, or MultiIndex."""
-        if not isinstance(md, dict):
-            return None
-        hdr = md.get("header", None)
-        if hdr is None:
-            return None
-
-        if isinstance(hdr, DLCHeaderModel):
-            logger.debug("Header is already a DLCHeaderModel instance.")
-            return hdr
-
-        if isinstance(hdr, dict):
-            try:
-                return DLCHeaderModel.model_validate(hdr)
-            except Exception:
-                return None
-
-        # fallback: allow MultiIndex / list-of-tuples / Index inputs
+    def _on_points_layers_merged_requested(self, layers: tuple[Points, ...]) -> None:
+        """Refresh widget-owned UI after manager merged placeholder config into managed layers."""
         try:
-            return DLCHeaderModel(columns=hdr)
+            # Refresh dropdown menus after header/bodypart changes.
+            for menu in self._menus:
+                try:
+                    menu._map_individuals_to_bodyparts()
+                    menu._update_items()
+                except Exception:
+                    logger.debug("Failed to refresh dropdown menu after config merge", exc_info=True)
+
+            # Re-apply presentation metadata to affected layers.
+            for layer in layers:
+                try:
+                    self._apply_points_coloring_from_metadata(layer)
+                except Exception:
+                    logger.debug(
+                        "Failed to re-apply points coloring after merge for layer=%r",
+                        getattr(layer, "name", layer),
+                        exc_info=True,
+                    )
+
+            self._update_color_scheme()
+            self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
+            self._refresh_layer_status_panel()
+
         except Exception:
-            return None
+            logger.debug("Failed to refresh widget state after merged points update", exc_info=True)
 
     @staticmethod
     def get_layer_controls(layer: Points) -> KeypointControls | None:
@@ -738,13 +598,6 @@ class KeypointControls(QWidget):
     @staticmethod
     def get_layer_store(layer: Points) -> keypoints.KeypointStore | None:
         return getattr(layer, "_dlc_store", None)
-
-    @deprecated(
-        details="Lifecycle-owned points wiring has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._wire_points_layer(...)",
-    )
-    def _wire_points_layer(self, layer: Points) -> keypoints.KeypointStore | None:
-        return self.layer_manager._wire_points_layer(layer)
 
     # ------------------------------------------------------------------ #
     # UI-only hooks used by LayerLifecycleManager                        #
@@ -771,7 +624,8 @@ class KeypointControls(QWidget):
         self._apply_points_coloring_from_metadata(layer)
         self._trails_controller.on_points_layer_added_or_rewired(checkbox_checked=self._trail_cb.isChecked())
 
-        self._form_dropdown_menus(store)
+        if layer not in self._layer_to_menu:
+            self._form_dropdown_menus(store)
 
         # proj = layer.metadata.get("project") # MOVED to LayerLifecycleManager
         # if proj:
@@ -784,6 +638,62 @@ class KeypointControls(QWidget):
             getattr(layer, "name", layer),
             sorted((layer.metadata or {}).keys()),
         )
+
+    def _on_points_layer_setup_requested(self, req: PointsLayerSetupRequest) -> None:
+        layer = req.layer
+        store = req.store
+
+        try:
+            resources = self.layer_manager.attach_points_layer_runtime(
+                layer=layer,
+                store=store,
+                controls=self,
+                resolve_layer_by_id=self.layer_manager.resolve_live_layer,
+                get_label_mode=lambda: self._label_mode,
+                schedule_recolor=self._schedule_recolor,
+                existing_resources=req.existing_resources,
+            )
+            req.runtime_resources = resources
+
+            layer._dlc_controls = self
+
+            if self.layer_manager.managed_points_count() == 1 and self.layer_manager.is_multianimal(layer):
+                self._color_mode = keypoints.ColorMode.INDIVIDUAL
+                for btn in self._color_mode_selector.buttons():
+                    if btn.text().lower() == str(self._color_mode).lower():
+                        btn.setChecked(True)
+                        break
+
+            self._maybe_initialize_layer_point_size_from_config(layer)
+            self._connect_layer_status_events(layer)
+            self._complete_points_layer_ui_setup(layer, store)
+
+        except Exception:
+            logger.debug(
+                "Failed to complete points layer setup for layer=%r",
+                getattr(layer, "name", layer),
+                exc_info=True,
+            )
+
+    def _on_video_widget_visibility_requested(self, visible: bool) -> None:
+        try:
+            self.video_widget.setVisible(bool(visible))
+        except Exception:
+            logger.debug("Failed to update video widget visibility", exc_info=True)
+
+    def _on_points_layer_removed_requested(self, layer: Points, remaining_points_layers: int) -> None:
+        self._on_points_layer_removed_ui(layer, remaining_points_layers=remaining_points_layers)
+
+    def _on_tracks_layer_removed_requested(self, layer) -> None:
+        try:
+            was_trails = self._trails_controller.on_tracks_layer_removed(layer)
+        except Exception:
+            logger.debug("Failed to process tracks layer removal", exc_info=True)
+            return
+
+        if was_trails:
+            with QSignalBlocker(self._trail_cb):
+                self._trail_cb.setChecked(False)
 
     def _on_points_layer_removed_ui(self, layer: Points, *, remaining_points_layers: int) -> None:
         """UI-only cleanup after lifecycle manager removed a managed Points layer."""
@@ -823,36 +733,6 @@ class KeypointControls(QWidget):
                 self._layer_to_menu = {}
                 self._set_points_controls_enabled(False)
                 self.last_saved_label.hide()
-
-    @deprecated(
-        details="Lifecycle-owned points setup has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._setup_points_layer(...)",
-    )
-    def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
-        self.layer_manager._setup_points_layer(layer, allow_merge=allow_merge)
-
-    @deprecated(
-        details="Layer adoption is now handled by LayerLifecycleManager.",
-        replacement="self.layer_manager.schedule_initial_adoption()",
-    )
-    def _adopt_existing_layers(self) -> None:
-        self.layer_manager.adopt_existing_layers()
-
-    @deprecated(
-        details="Layer adoption is now handled by LayerLifecycleManager.",
-        replacement="LayerLifecycleManager._adopt_layer(...)",
-    )
-    def _adopt_layer(self, layer, index: int) -> None:
-        self.layer_manager._adopt_layer(layer, index)
-
-    def _validate_header(self, layer) -> bool:
-        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-        if isinstance(res, ValidationError) or res.header is None:
-            self.viewer.status = (
-                "This Points layer does not look like a DLC keypoints layer. Missing a valid DLC header."
-            )
-            return False
-        return True
 
     def _schedule_recolor(self, layer: Points) -> None:
         if not hasattr(self, "_recolor_pending"):
@@ -1007,7 +887,7 @@ class KeypointControls(QWidget):
         config_path = str(Path(project_path) / "config.yaml")
         cfg = io.load_config(config_path)
         conversion_tables = cfg.get("SuperAnimalConversionTables", {})
-        hdr = self._get_header_model_from_metadata(points_layer.metadata or {})
+        hdr = self.layer_manager.get_header_model_from_metadata(points_layer.metadata or {})
         if hdr is None:
             return
         bdprts_map = map(str, hdr.bodyparts)
@@ -1044,33 +924,6 @@ class KeypointControls(QWidget):
     # ------------------------------------------------------------------
     # Metadata helpers (authoritative models + napari-friendly dict sync)
     # ------------------------------------------------------------------
-    @deprecated(
-        details="Lifecycle-owned image metadata management has moved to LayerLifecycleManager.",
-        replacement="LayerLifecycleManager._layer_source_path(...)",
-    )
-    @staticmethod
-    def _layer_source_path(layer) -> str | None:
-        """Best-effort access to napari layer source path (may not exist)."""
-        return LayerLifecycleManager._layer_source_path(layer)
-
-    @deprecated(
-        details="Lifecycle-owned image metadata management has moved to LayerLifecycleManager.",
-        replacement="LayerLifecycleManager._update_image_meta_from_layer(...)",
-    )
-    def _update_image_meta_from_layer(self, layer: Image) -> None:
-        """
-        Update authoritative self._images_meta using an Image layer.
-        Also keep a dict-like subset synced for other layers (non-breaking).
-        """
-        self.layer_manager._update_image_meta_from_layer(layer)
-
-    @deprecated(
-        details="Lifecycle-owned image→points metadata sync has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._sync_points_layers_from_image_meta()",
-    )
-    def _sync_points_layers_from_image_meta(self) -> None:
-        self.layer_manager._sync_points_layers_from_image_meta()
-
     def _resolve_config_path_for_layer(self, layer: Points | None) -> Path | None:
         if layer is None:
             return None
@@ -1101,7 +954,8 @@ class KeypointControls(QWidget):
             - (None, True): user cancelled or operation was refused; abort save
         """
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-        if isinstance(res, ValidationError):
+        # if isinstance(res, ValidationError):
+        if hasattr(res, "errors"):
             return None, False
 
         pts_meta: PointsMetadata = res
@@ -1397,18 +1251,11 @@ class KeypointControls(QWidget):
     def _refresh_video_panel_context(self) -> None:
         update_video_panel_context(self.viewer, self._video_group)
 
-    @deprecated(
-        details="Lifecycle-owned project-path caching has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._cache_project_path_from_image_layer(...)",
-    )
-    def _cache_project_path_from_image_layer(self, layer: Image) -> None:
-        self.layer_manager._cache_project_path_from_image_layer(layer)
-
     def _extract_single_frame(self, *args):
         ok, msg = run_extract_current_frame(
             self.viewer,
             self._video_group,
-            validate_points_layer=self._validate_header,
+            validate_points_layer=self.layer_manager.validate_header,
         )
         self.viewer.status = msg
         self._refresh_video_panel_context()
@@ -1479,27 +1326,6 @@ class KeypointControls(QWidget):
                 layer.face_color_mode = "direct"
             except Exception:
                 pass
-
-    @deprecated(
-        details="Lifecycle-owned remap orchestration has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._remap_frame_indices(...)",
-    )
-    def _remap_frame_indices(self, layer) -> None:
-        self.layer_manager._remap_frame_indices(layer)
-
-    @deprecated(
-        replacement="self.layer_manager.on_insert(...)",
-        details="Direct layer management is now handled by LayerLifecycleManager",
-    )
-    def on_insert(self, event):
-        self.layer_manager.on_insert(event)
-
-    @deprecated(
-        details="Lifecycle-owned remove handling has moved to LayerLifecycleManager.",
-        replacement="self.layer_manager._handle_removed_layer(...)",
-    )
-    def _handle_removed_layer(self, layer) -> None:
-        self.layer_manager._handle_removed_layer(layer)
 
     def _on_show_trails_toggled(self, state):
         self._trails_controller.toggle(Qt.CheckState(state) == Qt.CheckState.Checked)
@@ -1787,6 +1613,9 @@ class KeypointControls(QWidget):
         if report.issues:
             logger.warning("Layer manager audit on close reported issues:\n%s", report.issues)
 
+        if self.layer_manager is not None:
+            self.layer_manager.set_merge_decision_provider(None)
+
     def on_active_layer_change(self, event) -> None:
         """Updates the GUI when the active layer changes
         * Hides all KeypointsDropdownMenu that aren't for the selected layer
@@ -1796,7 +1625,7 @@ class KeypointControls(QWidget):
         with log_timing(
             logger, f"on_active_layer_change value={getattr(event.value, 'name', None)!r}", threshold_ms=0.0
         ):
-            self._color_grp.setVisible(self._is_multianimal(event.value))
+            self._color_grp.setVisible(self.layer_manager.is_multianimal(event.value))
             # self._update_color_scheme() # if needed
             menu_idx = -1
             if event.value is not None and isinstance(event.value, Points):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -778,9 +778,11 @@ class KeypointControls(QWidget):
         if remaining_points_layers == 0:
             while self._menus:
                 menu = self._menus.pop()
-                self._layout.removeWidget(menu)
+                try:
+                    self._layout.removeWidget(menu)
+                except Exception:
+                    pass
                 menu.deleteLater()
-                menu.destroy()
 
             self._layer_to_menu = {}
             self._set_points_controls_enabled(False)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -26,7 +26,6 @@ TODO: And general dev notes:
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
 from functools import cached_property
@@ -36,17 +35,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 from napari.layers import Image, Points
 from napari.utils.events import Event
-from napari.utils.history import get_save_history
 from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
     QButtonGroup,
     QCheckBox,
-    QFileDialog,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QMessageBox,
     QPushButton,
@@ -59,14 +55,13 @@ from .config import settings
 from .config.keybinds import (
     install_global_points_keybindings,
 )
-from .config.models import ImageMetadata, PointsMetadata
+from .config.models import ImageMetadata
 from .core import io, keypoints
 from .core.config_sync import (
     load_point_size_from_config,
     resolve_config_path_from_layer,
     save_point_size_to_config,
 )
-from .core.conflicts import compute_overwrite_report_for_points_save
 from .core.layer_lifecycle import (
     MergeDecisionRequest,
     MergeDecisionResult,
@@ -83,40 +78,17 @@ from .core.layers import (
     get_points_layer_with_tables,
     get_uniform_point_size,
     infer_folder_display_name,
-    is_machine_layer,
     set_uniform_point_size,
 )
 from .core.metadata import (
-    MergePolicy,
-    apply_project_paths_override_to_points_meta,
-    migrate_points_layer_metadata,
     read_points_meta,
-    write_points_meta,
 )
-from .core.project_paths import (
-    coerce_paths_to_dlc_row_keys,
-    dataset_folder_has_files,
-    find_nearest_config,
-    resolve_project_root_from_config,
-    target_dataset_folder_for_config,
-)
-from .core.provenance import (
-    apply_gt_save_target,
-    is_projectless_folder_association_candidate,
-    requires_gt_promotion,
-    suggest_human_placeholder,
-)
-from .core.sidecar import (
-    get_default_scorer,
-    set_default_scorer,
-)
-from .core.trails import TrailsController, safe_folder_anchor_from_points_layer
+from .core.trails import TrailsController
 from .napari_compat import (
     apply_points_layer_ui_tweaks,
     patch_color_manager_guess_continuous,
     register_points_action,
 )
-from .ui import dialogs as ui_dialogs
 from .ui.base_widget import ViewerSingletonWidget
 from .ui.color_scheme_display import ColorSchemePanel
 from .ui.cropping import (
@@ -134,39 +106,11 @@ from .ui.labels_and_dropdown import (
 )
 from .ui.layer_stats import LayerStatusPanel
 from .ui.plots.trajectory import TrajectoryMatplotlibCanvas
+from .ui.ui_dialogs.save import PointsLayerSaveWorkflow
 from .utils.debug import get_debug_recorder, install_debug_recorder, log_timing
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
-
-
-def _prompt_for_scorer(parent_widget, *, anchor: str, suggested: str) -> str | None:
-    """Prompt user for a scorer name. Returns non-empty string or None if cancelled."""
-    text, ok = QInputDialog.getText(
-        parent_widget,
-        "Choose scorer",
-        "No DLC config.yaml scorer found.\n"
-        "Please enter a scorer name for the CollectedData file.\n\n"
-        "Tip: Use your name or a stable lab identifier.\n"
-        "(We strongly discourage keeping the generic 'human_xxxxxx'.)",
-        text=suggested,
-    )
-    if not ok:
-        return None
-    scorer = (text or "").strip()
-    if not scorer:
-        return None
-    return scorer
-
-
-@contextmanager
-def _temporary_layer_metadata(layer: Points, metadata: dict):
-    old_metadata = dict(layer.metadata or {})
-    layer.metadata = metadata
-    try:
-        yield
-    finally:
-        layer.metadata = old_metadata
 
 
 class KeypointControls(ViewerSingletonWidget):
@@ -337,6 +281,18 @@ class KeypointControls(ViewerSingletonWidget):
             watch_content=False,
         )
         self._points_interactions.install()
+
+        self._save_workflow = PointsLayerSaveWorkflow(
+            parent=self,
+            viewer=self.viewer,
+            layer_manager=self.layer_manager,
+            trails_controller=self._trails_controller,
+            trail_checkbox_getter=lambda: self._trail_cb.isChecked(),
+            resolve_config_path_for_layer=self._resolve_config_path_for_layer,
+            current_project_path_getter=lambda: self._project_path,
+            current_image_meta_getter=lambda: self._image_meta,
+            logger=logger,
+        )
         ### UI setup ends here
 
         # Modes init
@@ -885,108 +841,6 @@ class KeypointControls(ViewerSingletonWidget):
             max_levels=5,
         )
 
-    def _maybe_prepare_project_path_override_metadata(self, layer: Points) -> tuple[dict | None, bool]:
-        """
-        Optionally prepare save-time metadata by associating a project-less labeled
-        folder with an explicit DLC project chosen via config.yaml.
-
-        Returns
-        -------
-        tuple[dict | None, bool]
-            (overridden_metadata, abort_save)
-
-            - (None, False): feature not applicable; continue normal save
-            - (metadata, False): apply metadata override and continue
-            - (None, True): user cancelled or operation was refused; abort save
-        """
-        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-        # if isinstance(res, ValidationError):
-        if hasattr(res, "errors"):
-            return None, False
-
-        pts_meta: PointsMetadata = res
-        paths = pts_meta.paths or []
-        if not paths:
-            return None, False
-
-        if not is_projectless_folder_association_candidate(pts_meta):
-            return None, False
-
-        source_root = pts_meta.root
-        if not source_root:
-            return None, False
-
-        try:
-            source_root_path = Path(source_root).expanduser().resolve(strict=False)
-        except Exception:
-            source_root_path = Path(source_root)
-
-        # NOTE: @C-Achard 2026-03-27 Currently does not let user choose
-        # a different dataset name than the source folder,
-        # to keep a lightweight workflow.
-        # This could be allowed in the future if there is demand.
-        dataset_name = source_root_path.name
-        if not dataset_name:
-            return None, False
-
-        initial_dir = self._project_path or pts_meta.project or str(source_root_path)
-        dialog_result = ui_dialogs.prompt_for_project_config_for_save(self, initial_dir=initial_dir)
-
-        if dialog_result.action is ui_dialogs.ProjectConfigPromptAction.CANCEL:
-            logger.debug("User cancelled project association prompt.")
-            return None, True  # abort save
-
-        if dialog_result.action is ui_dialogs.ProjectConfigPromptAction.SKIP:
-            logger.debug("User chose to continue without project association.")
-            return None, False  # continue normal save path
-
-        if dialog_result.action is not ui_dialogs.ProjectConfigPromptAction.ASSOCIATE:
-            logger.warning("Unexpected project association dialog result: %r", dialog_result)
-            return None, True  # fail safe: abort save
-
-        config_path = dialog_result.config_path
-        if not config_path:
-            logger.warning("Project association result was ASSOCIATE but config_path was empty.")
-            return None, True  # fail safe: abort save
-
-        project_root = resolve_project_root_from_config(config_path)
-        if project_root is None:
-            QMessageBox.warning(
-                self,
-                "Invalid project configuration",
-                "The selected file is not a valid DeepLabCut config.yaml or project root. "
-                "The save operation has been cancelled.",
-            )
-            return None, True
-
-        target_folder = target_dataset_folder_for_config(config_path, dataset_name=dataset_name)
-        if dataset_folder_has_files(target_folder):
-            ui_dialogs.warn_existing_dataset_folder_conflict(self, target_folder=target_folder)
-            return None, True  # refuse the save
-
-        rewritten_paths, unresolved = coerce_paths_to_dlc_row_keys(
-            paths,
-            source_root=source_root_path,
-            dataset_name=dataset_name,
-        )
-
-        if not ui_dialogs.maybe_confirm_dataset_path_rewrite(
-            self,
-            project_root=project_root,
-            dataset_name=dataset_name,
-            n_paths=len(paths),
-            n_unresolved=len(unresolved),
-        ):
-            return None, True  # user declined
-
-        overridden = apply_project_paths_override_to_points_meta(
-            pts_meta,
-            project_root=project_root,
-            rewritten_paths=rewritten_paths,
-        )
-
-        return overridden.model_dump(mode="python", exclude_none=True), False
-
     def _show_color_scheme(self):
         show = self._view_scheme_cb.isChecked()
         self._color_scheme_display.setVisible(show)
@@ -1277,150 +1131,6 @@ class KeypointControls(ViewerSingletonWidget):
     def _on_show_trails_toggled(self, state):
         self._trails_controller.toggle(Qt.CheckState(state) == Qt.CheckState.Checked)
 
-    def _ensure_promotion_save_target(self, layer: Points) -> bool:
-        """Ensure a prediction/machine source layer has a GT save_target set.
-
-        Returns True if save_target is set (or already existed), False if user cancels.
-        """
-        if not is_machine_layer(layer):
-            return True
-
-        mig = migrate_points_layer_metadata(layer)
-        if hasattr(mig, "errors"):
-            logger.warning(
-                "Failed to migrate points layer metadata for layer=%r: %s",
-                getattr(layer, "name", layer),
-                mig,
-            )
-
-        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-        # if isinstance(res, ValidationError):
-        if hasattr(res, "errors"):
-            logger.warning(
-                "Points metadata validation failed for layer=%r during save target check: %s",
-                getattr(layer, "name", layer),
-                res,
-            )
-            QMessageBox.warning(self, "Cannot save", "Layer metadata is invalid; see logs for details.")
-            return False
-
-        pts: PointsMetadata = res
-
-        if not requires_gt_promotion(pts):
-            return True
-
-        anchor = safe_folder_anchor_from_points_layer(layer)
-        if not anchor:
-            QMessageBox.warning(self, "Cannot save", "Could not determine a folder anchor for saving.")
-            return False
-
-        scorer = None
-
-        # 1) Auto-discovered config.yaml always wins
-        cfg_path = None
-        try:
-            cfg_path = find_nearest_config(anchor)
-        except Exception:
-            logger.debug("Automatic config discovery failed for anchor=%r", anchor, exc_info=True)
-
-        if cfg_path:
-            try:
-                scorer = ui_dialogs.load_scorer_from_config(cfg_path)
-            except Exception:
-                logger.exception("Failed to load auto-discovered config.yaml: %s", cfg_path)
-                ui_dialogs.warn_invalid_config_for_scorer(
-                    self,
-                    config_path=cfg_path,
-                    reason="unreadable",
-                    auto_found=True,
-                )
-                return False
-
-            if not scorer:
-                ui_dialogs.warn_invalid_config_for_scorer(
-                    self,
-                    config_path=cfg_path,
-                    reason="missing_scorer",
-                    auto_found=True,
-                )
-                return False
-
-        else:
-            # 2) No config found automatically -> let the user choose one
-            dialog_result = ui_dialogs.prompt_for_project_config_for_save(
-                self,
-                initial_dir=self._project_path or anchor,
-                window_title="Locate DLC config for scorer resolution",
-                message=(
-                    "No DeepLabCut config.yaml could be found automatically for this machine-labeled layer.\n\n"
-                    "If this layer belongs to a DLC project, choose its config.yaml so the save uses the "
-                    "project scorer and standard naming.\n\n"
-                    "If no config.yaml exists, you can continue without one."
-                ),
-                choose_button_text="Choose config.yaml",
-                skip_button_text="Continue without config",
-                resolve_scorer=True,
-            )
-
-            if dialog_result.action is ui_dialogs.ProjectConfigPromptAction.CANCEL:
-                return False
-
-            if dialog_result.action is ui_dialogs.ProjectConfigPromptAction.ASSOCIATE:
-                scorer = dialog_result.scorer
-
-            else:
-                # 3) Only if no config is available at all may sidecar be consulted
-                scorer = get_default_scorer(anchor)
-
-                # 4) Final fallback: prompt manually
-                if not scorer:
-                    suggested = suggest_human_placeholder(anchor)
-                    while True:
-                        s = _prompt_for_scorer(self, anchor=anchor, suggested=suggested)
-                        if s is None:
-                            return False
-                        if s.startswith("human_"):
-                            choice = QMessageBox.question(
-                                self,
-                                "Generic scorer name",
-                                "You entered a generic scorer name starting with 'human_'.\n\n"
-                                "We strongly recommend using a real name or stable identifier.\n"
-                                "Do you want to keep this generic scorer anyway?",
-                                QMessageBox.Yes | QMessageBox.No,
-                            )
-                            if choice == QMessageBox.No:
-                                suggested = s
-                                continue
-                        scorer = s
-                        break
-                    try:
-                        set_default_scorer(anchor, scorer)
-                    except Exception:
-                        logger.debug("Failed to persist default scorer to sidecar", exc_info=True)
-
-        updated = apply_gt_save_target(
-            pts,
-            anchor=anchor,
-            scorer=scorer,
-            dataset_key="keypoints",
-        )
-
-        out = write_points_meta(
-            layer,
-            updated,
-            merge_policy=MergePolicy.MERGE,
-            fields={"save_target"},
-            migrate_legacy=True,
-            validate=True,
-        )
-
-        if hasattr(out, "errors"):
-            logger.warning("Failed to write save_target for layer=%r: %s", getattr(layer, "name", layer), out)
-            QMessageBox.warning(self, "Cannot save", "Failed to write save target metadata; see logs for details.")
-            return False
-
-        return True
-
     def _toggle_overwrite_confirmation(self, state) -> None:
         enabled = Qt.CheckState(state) == Qt.CheckState.Checked
         settings.set_overwrite_confirmation_enabled(enabled)
@@ -1428,115 +1138,14 @@ class KeypointControls(ViewerSingletonWidget):
 
     # Hack to save a KeyPoints layer without showing the Save dialog
     def _save_layers_dialog(self, selected=False):
-        """Save layers (all or selected) to disk, using ``LayerList.save()``.
-        Parameters
-        ----------
-        selected : bool
-            If True, only layers that are selected in the viewer will be saved.
-            By default, all layers are saved.
-        """
-
-        selected_layers = list(self.viewer.layers.selection)
-        msg = ""
-        if not len(self.viewer.layers):
-            msg = "There are no layers in the viewer to save."
-        elif selected and not len(selected_layers):
-            msg = "Please select a Points layer to save."
-        if msg:
-            QMessageBox.warning(self, "Nothing to save", msg, QMessageBox.Ok)
+        """Save layers (all or selected) using the dedicated save workflow."""
+        outcome = self._save_workflow.save_layers(selected=selected)
+        if not outcome.saved:
             return
-        if len(selected_layers) == 1 and isinstance(selected_layers[0], Points):
-            layer = selected_layers[0]
 
-            # Promotion-to-GT policy: never write back to machine/prediction sources.
-            ok = self._ensure_promotion_save_target(layer)
-            if not ok:
-                return
-
-            logger.debug(
-                "About to save. io.kind=%r save_target=%r",
-                layer.metadata.get("io", {}).get("kind"),
-                layer.metadata.get("save_target"),
-            )
-            try:
-                overridden_metadata, abort_save = self._maybe_prepare_project_path_override_metadata(layer)
-                if abort_save:
-                    logger.debug("Save aborted during project-association path handling.")
-                    return
-
-                attributes = {
-                    "name": layer.name,
-                    "metadata": overridden_metadata if overridden_metadata is not None else dict(layer.metadata or {}),
-                    "properties": dict(layer.properties or {}),
-                }
-                report = compute_overwrite_report_for_points_save(layer.data, attributes)
-            except Exception as e:
-                logger.exception("Failed to compute overwrite preflight for layer %r", getattr(layer, "name", layer))
-                QMessageBox.warning(
-                    self,
-                    "Cannot save",
-                    f"Failed to prepare save preflight:\n{e}",
-                    QMessageBox.Ok,
-                )
-                return
-
-            if report is not None:
-                if not ui_dialogs.maybe_confirm_overwrite(
-                    parent=self,
-                    report=report,
-                ):
-                    logger.debug("Save cancelled.")
-                    return
-
-            if overridden_metadata is not None:
-                with _temporary_layer_metadata(layer, overridden_metadata):
-                    self.viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
-                # Persist the successful override into live metadata after save
-                layer.metadata = dict(overridden_metadata)
-            else:
-                self.viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
-            # hook to persist UI state on successful save
-            try:
-                self._trails_controller.persist_folder_ui_state_for_points_layer(
-                    layer,
-                    checkbox_checked=self._trail_cb.isChecked(),
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to persist folder UI state after save for layer=%r",
-                    getattr(layer, "name", layer),
-                    exc_info=True,
-                )
-            self.viewer.status = "Data successfully saved"
-        else:
-            dlg = QFileDialog()
-            hist = get_save_history()
-            dlg.setHistory(hist)
-            filename, _ = dlg.getSaveFileName(
-                caption=f"Save {'selected' if selected else 'all'} layers",
-                dir=hist[0],  # home dir by default
-            )
-            if filename:
-                self.viewer.layers.save(filename, selected=selected)
-                #  hook to persist UI state on successful save
-                try:
-                    if selected:
-                        candidate_layers = [ly for ly in selected_layers if isinstance(ly, Points)]
-                    else:
-                        candidate_layers = list(self.layer_manager.managed_points_layers())
-
-                    for ly in candidate_layers:
-                        if ly in self.viewer.layers:
-                            self._trails_controller.persist_folder_ui_state_for_points_layer(
-                                ly,
-                                checkbox_checked=self._trail_cb.isChecked(),
-                            )
-                except Exception:
-                    logger.debug("Failed to persist sidecar UI state after multi-layer save", exc_info=True)
-
-            else:
-                return
         self._is_saved = True
+        if outcome.status_message:
+            self.viewer.status = outcome.status_message
         self.last_saved_label.setText(f"Last saved at {str(datetime.now().time()).split('.')[0]}")
         self.last_saved_label.show()
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -146,6 +146,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
 from napari_deeplabcut.ui.layer_stats import LayerStatusPanel
 from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
 from napari_deeplabcut.utils.debug import get_debug_recorder, install_debug_recorder
+from napari_deeplabcut.utils.deprecations import deprecated
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -758,6 +759,10 @@ class KeypointControls(QWidget):
             sorted((layer.metadata or {}).keys()),
         )
 
+    @deprecated(
+        "This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
+        replacement="self.layer_manager.schedule_initial_adoption()",
+    )
     def _adopt_existing_layers(self) -> None:
         """
         When the widget is opened after layers already exist, we need to
@@ -784,6 +789,10 @@ class KeypointControls(QWidget):
         # (e.g. drag-and-drop DLC data triggering the reader automatically).
         self._refresh_trajectory_plot_from_layers()
 
+    @deprecated(
+        "This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
+        replacement="LayerLifecycleManager.on_insert()",
+    )
     def _adopt_layer(self, layer, index: int) -> None:
         """
         Run the relevant portion of on_insert() for an already-existing layer.
@@ -1614,6 +1623,9 @@ class KeypointControls(QWidget):
             logger.exception("Failed to remap frame indices for layer %s", getattr(layer, "name", str(layer)))
             return
 
+    @deprecated(
+        replacement="self.layer_manager", reason="Direct layer management is now handled by LayerLifecycleManager"
+    )
     def on_insert(self, event):
         logger.debug("on_insert event received: event=%r", event)
         layer = event.source[-1]

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -133,7 +133,7 @@ from .ui.labels_and_dropdown import (
 )
 from .ui.layer_stats import LayerStatusPanel
 from .ui.plots.trajectory import TrajectoryMatplotlibCanvas
-from .utils.debug import get_debug_recorder, install_debug_recorder
+from .utils.debug import get_debug_recorder, install_debug_recorder, log_timing
 from .utils.deprecations import deprecated
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
@@ -772,21 +772,42 @@ class KeypointControls(QWidget):
 
     def _on_points_layer_removed_ui(self, layer: Points, *, remaining_points_layers: int) -> None:
         """UI-only cleanup after lifecycle manager removed a managed Points layer."""
-        self._update_color_scheme()
-        self._trails_controller.on_points_layer_removed(layer)
+        with log_timing(
+            logger,
+            f"_on_points_layer_removed_ui total layer={getattr(layer, 'name', layer)!r}",
+            threshold_ms=0.01,
+        ):
+            with log_timing(
+                logger,
+                "color scheme update after points removal",
+                threshold_ms=0.01,
+            ):
+                self._update_color_scheme()
 
-        if remaining_points_layers == 0:
-            while self._menus:
-                menu = self._menus.pop()
-                try:
-                    self._layout.removeWidget(menu)
-                except Exception:
-                    pass
-                menu.deleteLater()
+            with log_timing(
+                logger,
+                f"trails_controller.on_points_layer_removed layer={getattr(layer, 'name', layer)!r}",
+                threshold_ms=0.01,
+            ):
+                self._trails_controller.on_points_layer_removed(layer)
 
-            self._layer_to_menu = {}
-            self._set_points_controls_enabled(False)
-            self.last_saved_label.hide()
+            if remaining_points_layers == 0:
+                with log_timing(
+                    logger,
+                    "points menu teardown",
+                    threshold_ms=0.01,
+                ):
+                    while self._menus:
+                        menu = self._menus.pop()
+                        try:
+                            self._layout.removeWidget(menu)
+                        except Exception:
+                            pass
+                        menu.deleteLater()
+
+                self._layer_to_menu = {}
+                self._set_points_controls_enabled(False)
+                self.last_saved_label.hide()
 
     @deprecated(
         details="Lifecycle-owned points setup has moved to LayerLifecycleManager.",
@@ -1757,20 +1778,23 @@ class KeypointControls(QWidget):
         * Sets the visibility of the "Color mode" box to True if the selected layer
             is a multi-animal one, or False otherwise
         """
-        self._color_grp.setVisible(self._is_multianimal(event.value))
-        # self._update_color_scheme() # if needed
-        menu_idx = -1
-        if event.value is not None and isinstance(event.value, Points):
-            menu_idx = self._layer_to_menu.get(event.value, -1)
+        with log_timing(
+            logger, f"on_active_layer_change value={getattr(event.value, 'name', None)!r}", threshold_ms=0.0
+        ):
+            self._color_grp.setVisible(self._is_multianimal(event.value))
+            # self._update_color_scheme() # if needed
+            menu_idx = -1
+            if event.value is not None and isinstance(event.value, Points):
+                menu_idx = self._layer_to_menu.get(event.value, -1)
 
-        for idx, menu in enumerate(self._menus):
-            if idx == menu_idx:
-                menu.setHidden(False)
-            else:
-                menu.setHidden(True)
+            for idx, menu in enumerate(self._menus):
+                if idx == menu_idx:
+                    menu.setHidden(False)
+                else:
+                    menu.setHidden(True)
 
-        self._refresh_video_panel_context()
-        self._refresh_layer_status_panel()
+            self._refresh_video_panel_context()
+            self._refresh_layer_status_panel()
 
     def _update_colormap(self, colormap_name: str):
         for layer in self.viewer.layers.selection:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -195,11 +195,6 @@ class KeypointControls(QWidget):
         ## Debug ##
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
-
-        show_debug_action = QAction("&Generate napari-dlc log", self)
-        show_debug_action.setToolTip("Show a debug report with recent plugin logs")
-        show_debug_action.triggered.connect(self._show_debug_window)
-        self.viewer.window.help_menu.addAction(show_debug_action)
         ###########
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
@@ -367,17 +362,7 @@ class KeypointControls(QWidget):
             elif "save all layers" in action_name:
                 self.viewer.window.file_menu.removeAction(action)
 
-        # Add action to show the walkthrough again
-        launch_tutorial = QAction("&Launch napari-dlc tutorial", self)
-        launch_tutorial.triggered.connect(self.start_tutorial)
-        self.viewer.window.view_menu.addAction(launch_tutorial)
-
-        # Add action to view keyboard shortcuts
-        display_shortcuts_action = QAction("&Show napari-dlc shortcuts", self)
-        display_shortcuts_action.triggered.connect(self.display_shortcuts)
-        self.viewer.window.help_menu.addAction(display_shortcuts_action)
-        # Install global keybinds
-        install_global_points_keybindings()
+        self._add_plugin_actions()
 
         # Hide some unused viewer buttons
         # NOTE (future) do we truly want to disable these ? Tracking util may need to create new points layers
@@ -1328,6 +1313,80 @@ class KeypointControls(QWidget):
         except Exception:
             pass
 
+    # ------------------------------------------------------------------
+    # UI setup
+    # ------------------------------------------------------------------
+    def _add_plugin_actions(self):
+        # Help menu
+        self.viewer.window.help_menu.addSeparator()
+        # Add action to show the walkthrough again
+        launch_tutorial = QAction("&Launch napari-dlc tutorial", self)
+        launch_tutorial.triggered.connect(self.start_tutorial)
+        self.viewer.window.help_menu.addAction(launch_tutorial)
+
+        # Add action to view keyboard shortcuts
+        display_shortcuts_action = QAction("&Show napari-dlc shortcuts", self)
+        display_shortcuts_action.triggered.connect(self.display_shortcuts)
+        self.viewer.window.help_menu.addAction(display_shortcuts_action)
+        # Install global keybinds hook
+        install_global_points_keybindings()
+
+        # Add debug action to generate a log report for troubleshooting
+        show_debug_action = QAction("&Generate napari-dlc log", self)
+        show_debug_action.setToolTip("Show a debug report with recent plugin logs")
+        show_debug_action.triggered.connect(self._show_debug_window)
+        self.viewer.window.help_menu.addAction(show_debug_action)
+
+    def _form_dropdown_menus(self, store):
+        menu = KeypointsDropdownMenu(store)
+        self.viewer.dims.events.current_step.connect(
+            menu.smart_reset,
+            position="last",
+        )
+        menu.smart_reset(event=None)
+        self._menus.append(menu)
+        self._layer_to_menu[store.layer] = len(self._menus) - 1
+        layout = QVBoxLayout()
+        layout.addWidget(menu)
+        self._layout.addLayout(layout)
+
+    def _form_mode_radio_buttons(self):
+        group_box = QGroupBox("Labeling mode")
+        layout = QHBoxLayout()
+        group = QButtonGroup(self)
+        for i, mode in enumerate(keypoints.LabelMode.__members__, start=1):
+            btn = QRadioButton(mode.capitalize())
+            btn.setToolTip(keypoints.TOOLTIPS[mode])
+            group.addButton(btn, i)
+            layout.addWidget(btn)
+        group.button(1).setChecked(True)
+        group_box.setLayout(layout)
+        self._layout.addWidget(group_box)
+
+        def _func():
+            self.label_mode = group.checkedButton().text().lower()
+
+        group.buttonClicked.connect(_func)
+        return group_box, group
+
+    def _form_color_mode_selector(self):
+        group_box = QGroupBox("Keypoint coloring mode")
+        layout = QHBoxLayout()
+        group = QButtonGroup(self)
+        for i, mode in enumerate(keypoints.ColorMode.__members__, start=1):
+            btn = QRadioButton(mode.capitalize())
+            group.addButton(btn, i)
+            layout.addWidget(btn)
+        group.button(1).setChecked(True)
+        group_box.setLayout(layout)
+        self._layout.addWidget(group_box)
+
+        def _func():
+            self.color_mode = group.checkedButton().text().lower()
+
+        group.buttonClicked.connect(_func)
+        return group_box, group
+
     def _form_help_buttons(self):
         layout = QVBoxLayout()
         help_buttons_layout = QHBoxLayout()
@@ -1392,56 +1451,6 @@ class KeypointControls(QWidget):
             self._project_path = project_path
         self.viewer.status = msg
         self._refresh_video_panel_context()
-
-    def _form_dropdown_menus(self, store):
-        menu = KeypointsDropdownMenu(store)
-        self.viewer.dims.events.current_step.connect(
-            menu.smart_reset,
-            position="last",
-        )
-        menu.smart_reset(event=None)
-        self._menus.append(menu)
-        self._layer_to_menu[store.layer] = len(self._menus) - 1
-        layout = QVBoxLayout()
-        layout.addWidget(menu)
-        self._layout.addLayout(layout)
-
-    def _form_mode_radio_buttons(self):
-        group_box = QGroupBox("Labeling mode")
-        layout = QHBoxLayout()
-        group = QButtonGroup(self)
-        for i, mode in enumerate(keypoints.LabelMode.__members__, start=1):
-            btn = QRadioButton(mode.capitalize())
-            btn.setToolTip(keypoints.TOOLTIPS[mode])
-            group.addButton(btn, i)
-            layout.addWidget(btn)
-        group.button(1).setChecked(True)
-        group_box.setLayout(layout)
-        self._layout.addWidget(group_box)
-
-        def _func():
-            self.label_mode = group.checkedButton().text().lower()
-
-        group.buttonClicked.connect(_func)
-        return group_box, group
-
-    def _form_color_mode_selector(self):
-        group_box = QGroupBox("Keypoint coloring mode")
-        layout = QHBoxLayout()
-        group = QButtonGroup(self)
-        for i, mode in enumerate(keypoints.ColorMode.__members__, start=1):
-            btn = QRadioButton(mode.capitalize())
-            group.addButton(btn, i)
-            layout.addWidget(btn)
-        group.button(1).setChecked(True)
-        group_box.setLayout(layout)
-        self._layout.addWidget(group_box)
-
-        def _func():
-            self.color_mode = group.checkedButton().text().lower()
-
-        group.buttonClicked.connect(_func)
-        return group_box, group
 
     def _update_color_scheme(self):
         if hasattr(self, "_color_scheme_panel"):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -523,29 +523,86 @@ class KeypointControls(QWidget):
     def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
         self.layer_manager._setup_image_layer(layer, index=index, reorder=reorder)
 
+    def _is_config_placeholder_points_layer(self, layer: Points) -> bool:
+        """Return True if this looks like the temporary config placeholder layer.
+
+        Conservative rule:
+        - must be a Points layer
+        - must carry a project hint
+        - must not already be tied to image/root/paths context
+        - must not contain actual point data
+        """
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        md = layer.metadata or {}
+        if not md.get("project"):
+            return False
+
+        # Real labeled/prediction layers usually carry image/root/paths context.
+        if md.get("root") or md.get("paths"):
+            return False
+
+        try:
+            data = np.asarray(layer.data) if layer.data is not None else np.empty((0, 3))
+        except Exception:
+            data = np.empty((0, 3))
+
+        return data.size == 0
+
     def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
+        """Merge a temporary config placeholder layer into existing managed layers.
+
+        Semantics
+        ---------
+        - Only consumes true config placeholder layers.
+        - The placeholder layer is temporary and is removed after merge.
+        - Existing managed points layers remain authoritative.
+        - If new keypoints are introduced, the user may optionally hide the
+          currently visible managed layer to focus on the new keypoints.
+        """
+        if not self._is_config_placeholder_points_layer(layer):
+            return False
+
+        managed = list(self.layer_manager.iter_managed_points())
+        if not managed:
+            return False
+
         md = layer.metadata or {}
         logger.debug(
-            "Maybe merge config points layer=%r project=%r stores=%d",
+            "Maybe merge config placeholder layer=%r project=%r managed_layers=%d",
             getattr(layer, "name", layer),
             md.get("project"),
-            self.layer_manager.managed_points_count(),
+            len(managed),
         )
-        managed = list(self.layer_manager.iter_managed_points())
-        if not md.get("project", "") or not managed:
-            return False
 
         new_metadata = md.copy()
-
-        keypoints_menu = self._menus[0].menus["label"]
-        current_keypoint_set = {keypoints_menu.itemText(i) for i in range(keypoints_menu.count())}
-        hdr = self._get_header_model_from_metadata(new_metadata)
-        if hdr is None:
+        new_header = self._get_header_model_from_metadata(new_metadata)
+        if new_header is None:
+            logger.debug(
+                "Skipping config placeholder merge for layer=%r: missing/invalid header",
+                getattr(layer, "name", layer),
+            )
             return False
-        new_keypoint_set = set(hdr.bodyparts)
+
+        # Use an actual managed layer as the reference source of truth,
+        # not the first dropdown menu.
+        reference_layer, _reference_store = managed[0]
+        reference_header = self._get_header_model_from_metadata(reference_layer.metadata or {})
+        if reference_header is None:
+            logger.debug(
+                "Skipping config placeholder merge for layer=%r: reference managed layer has no valid header",
+                getattr(layer, "name", layer),
+            )
+            return False
+
+        current_keypoint_set = set(reference_header.bodyparts)
+        new_keypoint_set = set(new_header.bodyparts)
         diff = new_keypoint_set.difference(current_keypoint_set)
 
-        placeholder_layer = layer  # newly inserted temporary config layer
+        placeholder_layer = layer
+
+        # Identify the currently visible existing managed layer that we may hide.
         visible_existing_layer = None
         for managed_layer, _store in managed:
             if managed_layer is placeholder_layer:
@@ -559,40 +616,70 @@ class KeypointControls(QWidget):
                 break
 
         if diff:
-            answer = QMessageBox.question(self, "", "Do you want to display the new keypoints only?")
+            answer = QMessageBox.question(
+                self,
+                "",
+                "Do you want to display the new keypoints only?",
+            )
             if answer == QMessageBox.Yes and visible_existing_layer is not None:
                 self.layer_manager._set_layer_visible(visible_existing_layer, False)
                 logger.debug(
-                    "Merging config points layer=%r new_keypoints=%s hid_existing_layer=%r",
+                    "Config placeholder merge layer=%r new_keypoints=%s hid_existing_layer=%r",
                     getattr(layer, "name", layer),
                     sorted(diff),
                     getattr(visible_existing_layer, "name", visible_existing_layer),
                 )
 
-            self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
-            for _layer, store in managed:
-                pts = read_points_meta(_layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-                if not hasattr(pts, "errors"):
-                    updated = pts.model_copy(update={"header": hdr})
-                    write_points_meta(_layer, updated, merge_policy=MergePolicy.MERGE, fields={"header"})
-                store.layer = _layer
+            self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(sorted(diff))} found."
 
-            for menu in self._menus:
+        # Merge header into all managed layers.
+        for managed_layer, store in managed:
+            pts = read_points_meta(
+                managed_layer,
+                migrate_legacy=True,
+                drop_controls=True,
+                drop_header=False,
+            )
+            if not hasattr(pts, "errors"):
+                updated = pts.model_copy(update={"header": new_header})
+                write_points_meta(
+                    managed_layer,
+                    updated,
+                    merge_policy=MergePolicy.MERGE,
+                    fields={"header"},
+                )
+            store.layer = managed_layer
+
+        # Refresh dropdown menus after header/bodypart changes.
+        for menu in self._menus:
+            try:
                 menu._map_individuals_to_bodyparts()
                 menu._update_items()
+            except Exception:
+                logger.debug("Failed to refresh dropdown menu after config merge", exc_info=True)
 
-        QTimer.singleShot(0, lambda: self.layer_manager._remove_layer_if_present(placeholder_layer))
-
-        # apply the new color cycles + recolor safely
-        for _layer, store in managed:
-            _layer.metadata["config_colormap"] = new_metadata.get(
-                "config_colormap", _layer.metadata.get("config_colormap")
+        # Apply updated presentation metadata to existing managed layers.
+        for managed_layer, store in managed:
+            managed_layer.metadata["config_colormap"] = new_metadata.get(
+                "config_colormap",
+                managed_layer.metadata.get("config_colormap"),
             )
-            _layer.metadata["face_color_cycles"] = new_metadata["face_color_cycles"]
-            _layer.metadata["colormap_name"] = new_metadata.get("colormap_name", _layer.metadata.get("colormap_name"))
-            mark_layer_presentation_changed(_layer)
-            self._apply_points_coloring_from_metadata(_layer)
-            store.layer = _layer
+            if "face_color_cycles" in new_metadata:
+                managed_layer.metadata["face_color_cycles"] = new_metadata["face_color_cycles"]
+            managed_layer.metadata["colormap_name"] = new_metadata.get(
+                "colormap_name",
+                managed_layer.metadata.get("colormap_name"),
+            )
+
+            mark_layer_presentation_changed(managed_layer)
+            self._apply_points_coloring_from_metadata(managed_layer)
+            store.layer = managed_layer
+
+        # Remove the temporary placeholder layer explicitly by identity.
+        QTimer.singleShot(
+            0,
+            lambda ly=placeholder_layer: self.layer_manager._remove_layer_if_present(ly),
+        )
 
         self._update_color_scheme()
         return True

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -90,10 +90,8 @@ from .core.layers import (
 from .core.metadata import (
     MergePolicy,
     apply_project_paths_override_to_points_meta,
-    infer_image_root,
     migrate_points_layer_metadata,
     read_points_meta,
-    sync_points_from_image,
     write_points_meta,
 )
 from .core.project_paths import (
@@ -124,7 +122,6 @@ from .ui.color_scheme_display import ColorSchemePanel
 from .ui.cropping import (
     build_video_action_menu,
     handle_apply_crop_toggled,
-    resolve_project_path_from_image_layer,
     run_extract_current_frame,
     run_store_crop_coordinates,
     update_video_panel_context,
@@ -198,7 +195,7 @@ class KeypointControls(QWidget):
         #     self.viewer.window.qt_viewer,
         # )
         # Project data
-        self._project_path: str | None = None
+        # self._project_path: str | None = None # DEPRECATED, owned by LayerLifecycleManager
 
         status_bar = self.viewer.window._qt_window.statusBar()
         self.last_saved_label = QLabel("")
@@ -231,7 +228,7 @@ class KeypointControls(QWidget):
         # Storage for extra image metadata that are relevant to other layers.
         # These are updated anytime images are added to the Viewer
         # and passed on to the other layers upon creation.
-        self._image_meta = ImageMetadata()
+        # self._image_meta = ImageMetadata() # DEPRECATED, owned by LayerLifecycleManager
         # Storage for layers requiring recoloring
         self._recolor_pending = set()
 
@@ -394,6 +391,24 @@ class KeypointControls(QWidget):
     @cached_property
     def settings(self):
         return QSettings()
+
+    @property
+    def _image_meta(self) -> ImageMetadata:
+        """Compatibility shim: lifecycle-owned image context now lives in manager."""
+        return self.layer_manager.image_meta
+
+    @_image_meta.setter
+    def _image_meta(self, value: ImageMetadata) -> None:
+        self.layer_manager._image_meta = value
+
+    @property
+    def _project_path(self) -> str | None:
+        """Compatibility shim: lifecycle-owned project path now lives in manager."""
+        return self.layer_manager.project_path
+
+    @_project_path.setter
+    def _project_path(self, value: str | None) -> None:
+        self.layer_manager.project_path = value
 
     @register_points_action("Change labeling mode")
     def cycle_through_label_modes(self, *args):
@@ -635,9 +650,9 @@ class KeypointControls(QWidget):
 
         self._form_dropdown_menus(store)
 
-        proj = layer.metadata.get("project")
-        if proj:
-            self._project_path = proj
+        # proj = layer.metadata.get("project") # MOVED to LayerLifecycleManager
+        # if proj:
+        #     self._project_path = proj
 
         self._set_points_controls_enabled(True)
         self._update_color_scheme()
@@ -870,101 +885,32 @@ class KeypointControls(QWidget):
     # ------------------------------------------------------------------
     # Metadata helpers (authoritative models + napari-friendly dict sync)
     # ------------------------------------------------------------------
+    @deprecated(
+        details="Lifecycle-owned image metadata management has moved to LayerLifecycleManager.",
+        replacement="LayerLifecycleManager._layer_source_path(...)",
+    )
     @staticmethod
     def _layer_source_path(layer) -> str | None:
         """Best-effort access to napari layer source path (may not exist)."""
-        try:
-            src = getattr(layer, "source", None)
-            p = getattr(src, "path", None) if src is not None else None
-            return str(p) if p else None
-        except Exception:
-            return None
+        return LayerLifecycleManager._layer_source_path(layer)
 
+    @deprecated(
+        details="Lifecycle-owned image metadata management has moved to LayerLifecycleManager.",
+        replacement="LayerLifecycleManager._update_image_meta_from_layer(...)",
+    )
     def _update_image_meta_from_layer(self, layer: Image) -> None:
         """
         Update authoritative self._images_meta using an Image layer.
         Also keep a dict-like subset synced for other layers (non-breaking).
         """
-        md = layer.metadata or {}
+        self.layer_manager._update_image_meta_from_layer(layer)
 
-        paths = md.get("paths")
-        shape = None
-        try:
-            shape = layer.level_shapes[0]
-        except Exception:
-            shape = None
-
-        root = infer_image_root(
-            explicit_root=md.get("root"),
-            paths=paths,
-            source_path=self._layer_source_path(layer),
-        )
-
-        incoming = ImageMetadata(
-            paths=list(paths) if paths else None,
-            root=str(root) if root else None,
-            shape=tuple(shape) if shape is not None else None,
-            name=getattr(layer, "name", None),
-        )
-
-        # Merge without clobbering already-known values
-        # (same behavior as old "only set if non-empty")
-        base = self._image_meta
-        merged = base.model_copy(deep=True)
-        for field, value in incoming.model_dump().items():
-            if getattr(merged, field) in (None, "", []) and value not in (None, "", []):
-                setattr(merged, field, value)
-
-        self._image_meta = merged
-
+    @deprecated(
+        details="Lifecycle-owned image→points metadata sync has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._sync_points_layers_from_image_meta()",
+    )
     def _sync_points_layers_from_image_meta(self) -> None:
-        """
-        Ensure all Points layers have core fields required for saving.
-
-        Adapter-based flow:
-        - read validated points meta (visible failures)
-        - apply sync logic against authoritative self._image_meta
-        - write back validated dict via gateway
-        """
-        if self._image_meta is None:
-            return
-
-        for ly in list(self.viewer.layers):
-            if not isinstance(ly, Points):
-                continue
-
-            if ly.metadata is None:
-                ly.metadata = {}
-
-            # 1) Read + migrate legacy (io from source_h5, header coercion, etc.)
-            res = read_points_meta(ly, migrate_legacy=True, drop_controls=False, drop_header=False)
-            if hasattr(res, "errors"):  # ValidationError duck-typing
-                logger.warning(
-                    "Points metadata validation failed during sync for layer=%r: %s",
-                    getattr(ly, "name", ly),
-                    res,
-                )
-                continue
-
-            pts_model: PointsMetadata = res
-
-            # 2) Sync missing fields from image meta (pure model transform)
-            synced = sync_points_from_image(self._image_meta, pts_model)
-
-            # 3) Write back through gateway (fill missing only; never clobber)
-            out = write_points_meta(
-                ly,
-                synced,
-                merge_policy=MergePolicy.MERGE_MISSING,
-                migrate_legacy=True,
-                validate=True,
-            )
-            if hasattr(out, "errors"):
-                logger.warning(
-                    "Failed to write synced points metadata for layer=%r: %s",
-                    getattr(ly, "name", ly),
-                    out,
-                )
+        self.layer_manager._sync_points_layers_from_image_meta()
 
     def _resolve_config_path_for_layer(self, layer: Points | None) -> Path | None:
         if layer is None:
@@ -974,8 +920,8 @@ class KeypointControls(QWidget):
 
         return resolve_config_path_from_layer(
             layer,
-            fallback_project=self._project_path,
-            fallback_root=self._image_meta.root,
+            fallback_project=self.layer_manager.project_path,
+            fallback_root=self.layer_manager.image_root,
             image_layer=image_layer,
             prefer_project_root=True,
             max_levels=5,
@@ -1111,7 +1057,7 @@ class KeypointControls(QWidget):
 
         folder_name = infer_folder_display_name(
             active_image if active_image is not None else active_layer,
-            fallback_root=self._image_meta.root,
+            fallback_root=self.layer_manager.image_root,
         )
         self._layer_status_panel.set_folder_name(folder_name)
 
@@ -1128,7 +1074,7 @@ class KeypointControls(QWidget):
         self._layer_status_panel.set_point_size_enabled(True)
         self._layer_status_panel.set_point_size(get_uniform_point_size(active_dlc_points))
 
-        progress = compute_label_progress(active_dlc_points, fallback_paths=self._image_meta.paths)
+        progress = compute_label_progress(active_dlc_points, fallback_paths=self.layer_manager.image_paths)
         self._layer_status_panel.set_progress_summary(progress=progress)
 
     def _on_active_points_size_changed(self, size: int) -> None:
@@ -1292,24 +1238,12 @@ class KeypointControls(QWidget):
     def _refresh_video_panel_context(self) -> None:
         update_video_panel_context(self.viewer, self._video_group)
 
+    @deprecated(
+        details="Lifecycle-owned project-path caching has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._cache_project_path_from_image_layer(...)",
+    )
     def _cache_project_path_from_image_layer(self, layer: Image) -> None:
-        """Best-effort cache of project path from an image/video layer."""
-        project_path = resolve_project_path_from_image_layer(layer)
-        if project_path is None:
-            return
-
-        self._project_path = project_path
-        try:
-            layer.metadata = dict(layer.metadata or {})
-            layer.metadata.setdefault("project", self._project_path)
-        except Exception:
-            logger.debug(
-                "Failed to set project path metadata on image layer %r",
-                getattr(layer, "name", layer),
-                exc_info=True,
-            )
-
-        self._refresh_video_panel_context()
+        self.layer_manager._cache_project_path_from_image_layer(layer)
 
     def _extract_single_frame(self, *args):
         ok, msg = run_extract_current_frame(

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -780,9 +780,8 @@ class KeypointControls(QWidget):
         self._set_points_controls_enabled(True)
         self._update_color_scheme()
         logger.debug(
-            "Setup points layer=%r allow_merge=%s metadata_keys=%s",
+            "Setup points layer=%r metadata_keys=%s",
             getattr(layer, "name", layer),
-            allow_merge,
             sorted((layer.metadata or {}).keys()),
         )
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -17,10 +17,6 @@ NOTE: This file is generally already too long. For future development, please co
 TODO: And general dev notes:
 - The saving workflow is crammed into save_layers_dialog() right now,
   and should move to a dedicated  e.g. PointsLayerSaveFactory class in a dedicated file.
-- Project/root/paths/image-meta/points-meta synchronization should be centralized.
-  It is too distributed right now, and it can be unclear "which truth" is authoritative.
-  Some sort of context-manager class would likely help.
-- Maybe a dedicated layer lifecycle system would help, for layer adoption and setup.
 - Something that owns UI sync state (what to refresh, why, when) could help with the heavy wiring.
 - I'd suggest keeping in this file:
     - color/label mode, menu/help actions, widget visibility and user interaction hooks.
@@ -41,7 +37,6 @@ import numpy as np
 from napari.layers import Image, Points
 from napari.utils.events import Event
 from napari.utils.history import get_save_history
-from pydantic import ValidationError
 from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
@@ -206,14 +201,6 @@ class KeypointControls(ViewerSingletonWidget):
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
         ###########
-
-        # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
-        #     _get_and_try_preferred_reader,
-        #     self.viewer.window.qt_viewer,
-        # )
-        # Project data
-        # self._project_path: str | None = None # DEPRECATED, owned by LayerLifecycleManager
-
         status_bar = self.viewer.window._qt_window.statusBar()
         self.last_saved_label = QLabel("")
         self.last_saved_label.hide()
@@ -221,9 +208,6 @@ class KeypointControls(ViewerSingletonWidget):
 
         self._color_mode = keypoints.ColorMode.default()
         self._label_mode = keypoints.LabelMode.default()
-
-        # Hold references to the KeypointStores
-        # self._stores = {} # DEPRECATED, use self.layer_manager instead
 
         # Intercept close event if data were not saved
         qt_win = self.viewer.window._qt_window
@@ -245,7 +229,6 @@ class KeypointControls(ViewerSingletonWidget):
         # Storage for extra image metadata that are relevant to other layers.
         # These are updated anytime images are added to the Viewer
         # and passed on to the other layers upon creation.
-        # self._image_meta = ImageMetadata() # DEPRECATED, owned by LayerLifecycleManager
         # Storage for layers requiring recoloring
         self._recolor_pending = set()
 
@@ -384,17 +367,8 @@ class KeypointControls(ViewerSingletonWidget):
         # self.viewer.window._qt_viewer.layerButtons.newPointsButton.setDisabled(True)
         self.viewer.window._qt_viewer.layerButtons.newLabelsButton.setDisabled(True)
 
-        # Disable tutorial on first launch for now. Can be accessed any time from the button.
-        # if self.settings.value("first_launch", True) and not os.environ.get(
-        #     "NAPARI_DLC_HIDE_TUTORIAL", False
-        # ):
-        #     QTimer.singleShot(10, self.start_tutorial)
-        #     self.settings.setValue("first_launch", False)
-
         # Slightly delay docking so it is shown underneath the KeypointsControls widget
-        # NOTE while a timer may seem hacky, it is a simple, one-line solution that minimizes intrusion
-        # There are to my knowledge no other way that is as concise and clean
-        # (Of course this will be a problem if we start using it everywhere so do not reuse lightly)
+        # NOTE we may want to switch to timers owned by the widget instead of fire-and-forget
         QTimer.singleShot(10, self.silently_dock_canvas)
 
         # If layers already exist (user loaded data before opening this widget),
@@ -404,24 +378,6 @@ class KeypointControls(ViewerSingletonWidget):
 
         # Refresh layers stats widget
         QTimer.singleShot(0, self._refresh_layer_status_panel)
-
-        self.destroyed.connect(self._on_destroyed)
-
-    def _on_destroyed(self, *args) -> None:
-        canonical = getattr(self, "_viewer_identity", None)
-        if canonical is None:
-            return
-
-        ref = self.__class__._instances.get(canonical)
-        if ref is not None and ref() is self:
-            self.__class__._instances.pop(canonical, None)
-
-        # Optional: clear manager merge provider if this widget registered itself
-        try:
-            if getattr(self, "layer_manager", None) is not None:
-                self.layer_manager.set_merge_decision_provider(None)
-        except Exception:
-            pass
 
     @cached_property
     def settings(self):
@@ -548,7 +504,7 @@ class KeypointControls(ViewerSingletonWidget):
         if not request.added_keypoints:
             return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
 
-        shared = "Do you want to keep the existing keypoints visible and add the new ones as a separate layer?"
+        shared = "Do you want to hide the existing keypoints and add the new ones as a separate layer?"
         text = f"{request.message}\n\n{shared}" if request.message else shared
         answer = QMessageBox.question(
             self,
@@ -825,16 +781,6 @@ class KeypointControls(ViewerSingletonWidget):
         if {"selection", "active_layer", "layers"} & set(event.reasons):
             traj_canvas.sync_visible_lines_to_points_selection()
 
-    def _refresh_trajectory_plot_from_layers(self) -> None:
-        """
-        Refresh trajectory plot from the current viewer state.
-
-        Deferred through QTimer so it runs after layer adoption/remap settles.
-        """
-        traj_canvas = self._safe_get_traj_canvas()
-        if traj_canvas is not None:
-            QTimer.singleShot(0, traj_canvas.refresh_from_viewer_layers)
-
     def load_superkeypoints_diagram(self):
         points_layer = get_first_points_layer(self.viewer)
         if points_layer is None:
@@ -1055,7 +1001,8 @@ class KeypointControls(ViewerSingletonWidget):
         except Exception:
             return None
 
-        if isinstance(res, ValidationError):
+        # if isinstance(res, ValidationError):
+        if hasattr(res, "errors"):
             return None
 
         if getattr(res, "header", None) is None:
@@ -1347,7 +1294,8 @@ class KeypointControls(ViewerSingletonWidget):
             )
 
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
-        if isinstance(res, ValidationError):
+        # if isinstance(res, ValidationError):
+        if hasattr(res, "errors"):
             logger.warning(
                 "Points metadata validation failed for layer=%r during save target check: %s",
                 getattr(layer, "name", layer),

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -141,6 +141,10 @@ class KeypointControls(ViewerSingletonWidget):
         self.layer_manager.points_layers_merged_requested.connect(self._on_points_layers_merged_requested)
         self.layer_manager.points_layer_removed_requested.connect(self._on_points_layer_removed_requested)
         self.layer_manager.tracks_layer_removed_requested.connect(self._on_tracks_layer_removed_requested)
+        ## Timers
+        self._timers = {}
+        self._temp_timers = set()
+        self.destroyed.connect(self._cleanup_timers)
 
         ## Debug ##
         self._debug_recorder = install_debug_recorder()
@@ -195,7 +199,8 @@ class KeypointControls(ViewerSingletonWidget):
         self._video_group.apply_crop_cb.toggled.connect(self._on_apply_crop_toggled)
         self.viewer.dims.events.current_step.connect(lambda event: self._refresh_video_panel_context())
         self.viewer.layers.selection.events.active.connect(lambda event: self._refresh_video_panel_context())
-        QTimer.singleShot(0, self._refresh_video_panel_context)
+        # QTimer.singleShot(0, self._refresh_video_panel_context)
+        self._schedule_once("startup_video_panel_refresh", 0, self._refresh_video_panel_context)
 
         # form helper display
         self._keypoint_mapping_button = None
@@ -328,7 +333,8 @@ class KeypointControls(ViewerSingletonWidget):
 
         # Slightly delay docking so it is shown underneath the KeypointsControls widget
         # NOTE we may want to switch to timers owned by the widget instead of fire-and-forget
-        QTimer.singleShot(10, self.silently_dock_canvas)
+        # QTimer.singleShot(10, self.silently_dock_canvas)
+        self._schedule_once("startup_dock_canvas", 10, self.silently_dock_canvas)
 
         # If layers already exist (user loaded data before opening this widget),
         # adopt them so keypoint controls take ownership immediately.
@@ -336,11 +342,83 @@ class KeypointControls(ViewerSingletonWidget):
         self.layer_manager.schedule_initial_adoption()
 
         # Refresh layers stats widget
-        QTimer.singleShot(0, self._refresh_layer_status_panel)
+        # QTimer.singleShot(0, self._refresh_layer_status_panel)
+        self._schedule_once("initial_layer_status_refresh", 0, self._refresh_layer_status_panel)
 
     @cached_property
     def settings(self):
         return QSettings()
+
+    def _cleanup_timers(self, *_args) -> None:
+        """Stop/delete all timers owned by this widget.
+
+        This is intentionally defensive: by teardown time, some underlying
+        C++ objects may already be in the process of destruction.
+        """
+        for timer in list(getattr(self, "_timers", {}).values()):
+            try:
+                timer.stop()
+                timer.deleteLater()
+            except RuntimeError:
+                pass
+        self._timers = {}
+
+        for timer in list(getattr(self, "_temp_timers", set())):
+            try:
+                timer.stop()
+                timer.deleteLater()
+            except RuntimeError:
+                pass
+        self._temp_timers.clear()
+
+    def _schedule_once(self, name: str, msec: int, callback) -> None:
+        """Schedule/coalesce a named single-shot callback owned by this widget."""
+        timer = self._timers.get(name)
+        if timer is None:
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.timeout.connect(callback)
+            self._timers[name] = timer
+        try:
+            timer.start(msec)
+        except RuntimeError:
+            # Widget/timer already in teardown
+            pass
+
+    def _single_shot_owned(self, msec: int, callback) -> None:
+        """Schedule a one-off callback using a child QTimer tracked by this widget."""
+        timer = QTimer(self)
+        timer.setSingleShot(True)
+        self._temp_timers.add(timer)
+
+        def _fire():
+            try:
+                callback()
+            finally:
+                self._temp_timers.discard(timer)
+                try:
+                    timer.deleteLater()
+                except RuntimeError:
+                    pass
+
+        timer.timeout.connect(_fire)
+        try:
+            timer.start(msec)
+        except RuntimeError:
+            self._temp_timers.discard(timer)
+
+    def _flush_recolor_pending(self) -> None:
+        pending = tuple(self._recolor_pending)
+        self._recolor_pending.clear()
+        for layer in pending:
+            try:
+                if layer not in self.viewer.layers:
+                    continue
+                self._apply_points_coloring_from_metadata(layer)
+            except RuntimeError:
+                logger.debug("Skipping recolor for deleted/tearing-down layer", exc_info=True)
+            except Exception:
+                logger.debug("Failed deferred recolor", exc_info=True)
 
     @deprecated(details="Use the layer manager's project context.", replacement="layer_manager.image_meta")
     @property
@@ -652,13 +730,7 @@ class KeypointControls(ViewerSingletonWidget):
 
         self._recolor_pending.add(layer)
 
-        def _do():
-            try:
-                self._apply_points_coloring_from_metadata(layer)
-            finally:
-                self._recolor_pending.discard(layer)
-
-        QTimer.singleShot(0, _do)
+        self._schedule_once(f"recolor_{layer.name}", 0, self._flush_recolor_pending)
 
     def _ensure_traj_canvas_docked(self) -> None:
         """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -190,7 +190,8 @@ class KeypointControls(QWidget):
 
         self.viewer = napari_viewer
 
-        self.layer_manager = LayerLifecycleManager(self.viewer)
+        self.layer_manager = LayerLifecycleManager(owner=self)
+        self.layer_manager.attach()
         # self.viewer.layers.events.inserted.connect(self.on_insert)
         # self.viewer.layers.events.removed.connect(self.on_remove)
 
@@ -215,7 +216,8 @@ class KeypointControls(QWidget):
         self._label_mode = keypoints.LabelMode.default()
 
         # Hold references to the KeypointStores
-        self._stores = {}
+        # self._stores = {} # DEPRECATED, use self.layer_manager instead
+
         # Intercept close event if data were not saved
         qt_win = self.viewer.window._qt_window
         orig_close_event = qt_win.closeEvent
@@ -280,7 +282,7 @@ class KeypointControls(QWidget):
         self._trail_cb.stateChanged.connect(self._on_show_trails_toggled)
         self._trails_controller = TrailsController(
             self.viewer,
-            managed_points_layers_getter=lambda: tuple(self._stores.keys()),
+            managed_points_layers_getter=self.layer_manager.managed_points_layers,
             color_mode_getter=lambda: self.color_mode,
             resolved_cycle_getter=self._resolved_cycle_for_layer,
         )
@@ -437,7 +439,7 @@ class KeypointControls(QWidget):
     def color_mode(self, mode: str | keypoints.ColorMode):
         self._color_mode = keypoints.ColorMode(mode)
 
-        for layer in list(self._stores.keys()):
+        for layer in list(self.layer_manager.managed_points_layers()):
             if isinstance(layer, Points) and layer.metadata:
                 self._apply_points_coloring_from_metadata(layer)
 
@@ -548,9 +550,10 @@ class KeypointControls(QWidget):
             "Maybe merge config points layer=%r project=%r stores=%d",
             getattr(layer, "name", layer),
             md.get("project"),
-            len(self._stores),
+            self.layer_manager.managed_points_count(),
         )
-        if not md.get("project", "") or not self._stores:
+        managed = list(self.layer_manager.iter_managed_points())
+        if not md.get("project", "") or not managed:
             return False
 
         new_metadata = md.copy()
@@ -574,7 +577,7 @@ class KeypointControls(QWidget):
                 )
 
             self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
-            for _layer, store in self._stores.items():
+            for _layer, store in managed:
                 pts = read_points_meta(_layer, migrate_legacy=True, drop_controls=True, drop_header=False)
                 if not hasattr(pts, "errors"):
                     updated = pts.model_copy(update={"header": hdr})
@@ -588,7 +591,7 @@ class KeypointControls(QWidget):
         QTimer.singleShot(10, self.viewer.layers.pop)
 
         # apply the new color cycles + recolor safely
-        for _layer, store in self._stores.items():
+        for _layer, store in managed:
             _layer.metadata["config_colormap"] = new_metadata.get(
                 "config_colormap", _layer.metadata.get("config_colormap")
             )
@@ -638,7 +641,8 @@ class KeypointControls(QWidget):
             return None
         existing = getattr(layer, "_dlc_store", None)
         if existing is not None:
-            self._stores[layer] = existing
+            # self._stores[layer] = existing
+            self.layer_manager.register_managed_points_layer(layer, existing)
             layer._dlc_controls = self
             return existing
 
@@ -652,7 +656,7 @@ class KeypointControls(QWidget):
             )
 
         store = keypoints.KeypointStore(self.viewer, layer)
-        self._stores[layer] = store
+        # self._stores[layer] = store
         self.layer_manager.register_managed_points_layer(layer, store)
         layer._dlc_store = store
         layer._dlc_controls = self
@@ -683,7 +687,7 @@ class KeypointControls(QWidget):
         # Install keybinds
         install_points_layer_keybindings(layer, self, store)
 
-        if len(self._stores) == 1 and self._is_multianimal(layer):
+        if self.layer_manager.managed_points_count() == 1 and self._is_multianimal(layer):
             # set internal mode without triggering recolor storms
             self._color_mode = keypoints.ColorMode.INDIVIDUAL
             # update button state so UI matches (optional but good)
@@ -794,7 +798,7 @@ class KeypointControls(QWidget):
         if isinstance(layer, Image):
             self._setup_image_layer(layer, index, reorder=True)
         elif isinstance(layer, Points):
-            if layer not in self._stores:
+            if not self.layer_manager.is_managed(layer):
                 self._setup_points_layer(layer, allow_merge=False)  # typically don’t merge during adopt
         if not isinstance(layer, Image):
             self._remap_frame_indices(layer)
@@ -1634,8 +1638,8 @@ class KeypointControls(QWidget):
         n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
 
         if isinstance(layer, Points):
-            self._stores.pop(layer, None)
-            self._lifecycle.unregister_managed_layer(layer)
+            # self._stores.pop(layer, None)
+            self.layer_manager.unregister_managed_layer(layer)
 
             self._update_color_scheme()
             self._trails_controller.on_points_layer_removed(layer)
@@ -1915,7 +1919,7 @@ class KeypointControls(QWidget):
                     if selected:
                         candidate_layers = [ly for ly in selected_layers if isinstance(ly, Points)]
                     else:
-                        candidate_layers = list(self._stores.keys())
+                        candidate_layers = list(self.layer_manager.managed_points_layers())
 
                     for ly in candidate_layers:
                         if ly in self.viewer.layers:
@@ -1933,7 +1937,7 @@ class KeypointControls(QWidget):
         self.last_saved_label.show()
 
     def on_close(self, event):
-        if self._stores and not self._is_saved:
+        if self.layer_manager.has_managed_points() and not self._is_saved:
             choice = QMessageBox.warning(
                 self,
                 "Warning",

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -179,6 +179,8 @@ class KeypointControls(ViewerSingletonWidget):
 
         # Add some more controls
         self._layout = QVBoxLayout(self)
+        # TODO just use a single synced DropdownMenu instance instead of one per layer
+        # it would reduce tracking and centralize the menu logic. Updating should be cheap anyways.
         self._menus = []
         self._layer_to_menu = {}
         self.viewer.layers.selection.events.active.connect(self.on_active_layer_change)
@@ -987,6 +989,15 @@ class KeypointControls(ViewerSingletonWidget):
         show_debug_action.triggered.connect(self._show_debug_window)
         self.viewer.window.help_menu.addAction(show_debug_action)
 
+    def _sync_dropdown_visibility(self) -> None:
+        active = self.viewer.layers.selection.active
+        menu_idx = -1
+        if active is not None and isinstance(active, Points):
+            menu_idx = self._layer_to_menu.get(active, -1)
+
+        for idx, menu in enumerate(self._menus):
+            menu.setHidden(idx != menu_idx)
+
     def _form_dropdown_menus(self, store):
         menu = KeypointsDropdownMenu(store)
         self.viewer.dims.events.current_step.connect(
@@ -999,6 +1010,8 @@ class KeypointControls(ViewerSingletonWidget):
         layout = QVBoxLayout()
         layout.addWidget(menu)
         self._layout.addLayout(layout)
+
+        self._sync_dropdown_visibility()
 
     def _form_mode_radio_buttons(self):
         group_box = QGroupBox("Labeling mode")
@@ -1190,15 +1203,7 @@ class KeypointControls(ViewerSingletonWidget):
         ):
             self._color_grp.setVisible(self.layer_manager.is_multianimal(event.value))
             # self._update_color_scheme() # if needed
-            menu_idx = -1
-            if event.value is not None and isinstance(event.value, Points):
-                menu_idx = self._layer_to_menu.get(event.value, -1)
-
-            for idx, menu in enumerate(self._menus):
-                if idx == menu_idx:
-                    menu.setHidden(False)
-                else:
-                    menu.setHidden(True)
+            self._sync_dropdown_visibility()
 
             self._refresh_video_panel_context()
             self._refresh_layer_status_panel()

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -196,10 +196,11 @@ class KeypointControls(QWidget):
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
 
-        show_debug_action = QAction("&Generate debug log", self)
+        show_debug_action = QAction("&Generate napari-dlc log", self)
         show_debug_action.setToolTip("Show a debug report with recent plugin logs")
         show_debug_action.triggered.connect(self._show_debug_window)
         self.viewer.window.help_menu.addAction(show_debug_action)
+        ###########
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
         #     _get_and_try_preferred_reader,
@@ -367,12 +368,12 @@ class KeypointControls(QWidget):
                 self.viewer.window.file_menu.removeAction(action)
 
         # Add action to show the walkthrough again
-        launch_tutorial = QAction("&Launch Tutorial", self)
+        launch_tutorial = QAction("&Launch napari-dlc tutorial", self)
         launch_tutorial.triggered.connect(self.start_tutorial)
         self.viewer.window.view_menu.addAction(launch_tutorial)
 
         # Add action to view keyboard shortcuts
-        display_shortcuts_action = QAction("&Shortcuts", self)
+        display_shortcuts_action = QAction("&Show napari-dlc shortcuts", self)
         display_shortcuts_action.triggered.connect(self.display_shortcuts)
         self.viewer.window.help_menu.addAction(display_shortcuts_action)
         # Install global keybinds
@@ -501,7 +502,7 @@ class KeypointControls(QWidget):
                 self._debug_window = DebugTextWindow(
                     title="napari-deeplabcut debug info",
                     text_provider=provider,
-                    parent=self.viewer.window._qt_window,
+                    parent=self,
                     initial_hint="Read-only diagnostics. Paste this into a bug report if needed.",
                 )
                 self._debug_window.finished.connect(lambda _result: setattr(self, "_debug_window", None))

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -136,6 +136,7 @@ from napari_deeplabcut.ui.cropping import (
     run_store_crop_coordinates,
     update_video_panel_context,
 )
+from napari_deeplabcut.ui.debug_window import DebugTextWindow, make_issue_report_provider
 from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
 from napari_deeplabcut.ui.labels_and_dropdown import (
     DropdownMenu,
@@ -143,6 +144,7 @@ from napari_deeplabcut.ui.labels_and_dropdown import (
 )
 from napari_deeplabcut.ui.layer_stats import LayerStatusPanel
 from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
+from napari_deeplabcut.utils.debug import get_debug_recorder, install_debug_recorder
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -189,6 +191,15 @@ class KeypointControls(QWidget):
 
         self.viewer.layers.events.inserted.connect(self.on_insert)
         self.viewer.layers.events.removed.connect(self.on_remove)
+
+        ## Debug ##
+        self._debug_recorder = install_debug_recorder()
+        self._debug_window = None
+
+        show_debug_action = QAction("&Generate debug log", self)
+        show_debug_action.setToolTip("Show a debug report with recent plugin logs")
+        show_debug_action.triggered.connect(self._show_debug_window)
+        self.viewer.window.help_menu.addAction(show_debug_action)
 
         # self.viewer.window.qt_viewer._get_and_try_preferred_reader = MethodType(
         #     _get_and_try_preferred_reader,
@@ -399,6 +410,109 @@ class KeypointControls(QWidget):
     @cached_property
     def settings(self):
         return QSettings()
+
+    @register_points_action("Change labeling mode")
+    def cycle_through_label_modes(self, *args):
+        self.label_mode = next(keypoints.LabelMode)
+
+    @register_points_action("Change color mode")
+    def cycle_through_color_modes(self, *args):
+        if self._active_layer_is_multianimal() or self.color_mode != str(keypoints.ColorMode.BODYPART):
+            self.color_mode = next(keypoints.ColorMode)
+
+    @property
+    def label_mode(self):
+        return str(self._label_mode)
+
+    @label_mode.setter
+    def label_mode(self, mode: str | keypoints.LabelMode):
+        self._label_mode = keypoints.LabelMode(mode)
+        self.viewer.status = self.label_mode
+        mode_ = str(mode).lower()
+        if mode_ == keypoints.LabelMode.LOOP.value.lower():
+            for menu in self._menus:
+                menu._locked = True
+        else:
+            for menu in self._menus:
+                menu._locked = False
+        for btn in self._radio_group.buttons():
+            if btn.text().lower() == mode_:
+                btn.setChecked(True)
+                break
+
+    @property
+    def color_mode(self):
+        return str(self._color_mode)
+
+    @color_mode.setter
+    def color_mode(self, mode: str | keypoints.ColorMode):
+        self._color_mode = keypoints.ColorMode(mode)
+
+        for layer in list(self._stores.keys()):
+            if isinstance(layer, Points) and layer.metadata:
+                self._apply_points_coloring_from_metadata(layer)
+
+        for btn in self._color_mode_selector.buttons():
+            if btn.text().lower() == str(mode).lower():
+                btn.setChecked(True)
+                break
+
+        traj_canvas = self._safe_get_traj_canvas()
+        if traj_canvas is not None:
+            try:
+                traj_canvas.refresh_from_viewer_layers()
+            except Exception:
+                logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
+
+        self._update_color_scheme()
+        self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
+
+    def _is_multianimal(self, layer) -> bool:
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        md = layer.metadata or {}
+        hdr = self._get_header_model_from_metadata(md)
+        if hdr is None:
+            return False
+
+        try:
+            inds = hdr.individuals
+            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+        except Exception:
+            return False
+
+    def _active_layer_is_multianimal(self) -> bool:
+        """Returns: whether the active layer is a multi-animal points layer"""
+        for layer in self.viewer.layers.selection:
+            if self._is_multianimal(layer):
+                return True
+
+        return False
+
+    def _show_debug_window(self) -> None:
+        try:
+            if self._debug_window is None:
+                provider = make_issue_report_provider(
+                    viewer=self.viewer,
+                    recorder=get_debug_recorder(),
+                    log_limit=300,
+                )
+                self._debug_window = DebugTextWindow(
+                    title="napari-deeplabcut debug info",
+                    text_provider=provider,
+                    parent=self.viewer.window._qt_window,
+                    initial_hint="Read-only diagnostics. Paste this into a bug report if needed.",
+                )
+                self._debug_window.finished.connect(lambda _result: setattr(self, "_debug_window", None))
+
+            self._debug_window.show()
+            self._debug_window.raise_()
+            self._debug_window.activateWindow()
+
+        except Exception:
+            logger.debug("Failed to open debug window", exc_info=True)
+            self.viewer.status = "Could not open debug window"
 
     # ######################## #
     # Layer setup core methods #
@@ -1802,85 +1916,6 @@ class KeypointControls(QWidget):
 
             self._update_color_scheme()
             self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
-
-    @register_points_action("Change labeling mode")
-    def cycle_through_label_modes(self, *args):
-        self.label_mode = next(keypoints.LabelMode)
-
-    @register_points_action("Change color mode")
-    def cycle_through_color_modes(self, *args):
-        if self._active_layer_is_multianimal() or self.color_mode != str(keypoints.ColorMode.BODYPART):
-            self.color_mode = next(keypoints.ColorMode)
-
-    @property
-    def label_mode(self):
-        return str(self._label_mode)
-
-    @label_mode.setter
-    def label_mode(self, mode: str | keypoints.LabelMode):
-        self._label_mode = keypoints.LabelMode(mode)
-        self.viewer.status = self.label_mode
-        mode_ = str(mode).lower()
-        if mode_ == keypoints.LabelMode.LOOP.value.lower():
-            for menu in self._menus:
-                menu._locked = True
-        else:
-            for menu in self._menus:
-                menu._locked = False
-        for btn in self._radio_group.buttons():
-            if btn.text().lower() == mode_:
-                btn.setChecked(True)
-                break
-
-    @property
-    def color_mode(self):
-        return str(self._color_mode)
-
-    @color_mode.setter
-    def color_mode(self, mode: str | keypoints.ColorMode):
-        self._color_mode = keypoints.ColorMode(mode)
-
-        for layer in list(self._stores.keys()):
-            if isinstance(layer, Points) and layer.metadata:
-                self._apply_points_coloring_from_metadata(layer)
-
-        for btn in self._color_mode_selector.buttons():
-            if btn.text().lower() == str(mode).lower():
-                btn.setChecked(True)
-                break
-
-        traj_canvas = self._safe_get_traj_canvas()
-        if traj_canvas is not None:
-            try:
-                traj_canvas.refresh_from_viewer_layers()
-            except Exception:
-                logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
-
-        self._update_color_scheme()
-        self._trails_controller.on_points_visual_inputs_changed(checkbox_checked=self._trail_cb.isChecked())
-
-    def _is_multianimal(self, layer) -> bool:
-        if layer is None or not isinstance(layer, Points):
-            return False
-
-        md = layer.metadata or {}
-        hdr = self._get_header_model_from_metadata(md)
-        if hdr is None:
-            return False
-
-        try:
-            inds = hdr.individuals
-            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
-        except Exception:
-            return False
-
-    def _active_layer_is_multianimal(self) -> bool:
-        """Returns: whether the active layer is a multi-animal points layer"""
-        for layer in self.viewer.layers.selection:
-            if self._is_multianimal(layer):
-                return True
-
-        return False
 
     def _resolved_cycle_for_layer(self, layer: Points) -> dict:
         """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -510,6 +510,7 @@ class KeypointControls(QWidget):
     # Layer setup core methods #
     # ######################## #
 
+    @deprecated("This should be moved to LayerLifecycleManager. It is currently used there but should be moved.")
     def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
         md = layer.metadata or {}
         paths = md.get("paths")
@@ -637,6 +638,7 @@ class KeypointControls(QWidget):
     def get_layer_store(layer: Points) -> keypoints.KeypointStore | None:
         return getattr(layer, "_dlc_store", None)
 
+    @deprecated("This should be moved to LayerLifecycleManager.")
     def _wire_points_layer(self, layer: Points) -> keypoints.KeypointStore | None:
         if not self._validate_header(layer):
             return None
@@ -730,6 +732,10 @@ class KeypointControls(QWidget):
 
         return store
 
+    @deprecated(
+        "This is still used in LayerLifecycleManager.on_insert(), "
+        "but should be instead moved to the LayerLifecycleManager itself instead."
+    )
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
         if not self._validate_header(layer):
             return

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1950,6 +1950,12 @@ class KeypointControls(QWidget):
                 event.ignore()
         else:
             event.accept()
+        cleared = self.layer_manager.clear_dead_entries(log=True)
+        if cleared:
+            logger.debug("Cleared %d dead entries from layer manager on close", cleared)
+        report = self.layer_manager.audit_registry()
+        if report.issues:
+            logger.warning("Layer manager audit on close reported issues:\n%s", report.format_for_logging())
 
     def on_active_layer_change(self, event) -> None:
         """Updates the GUI when the active layer changes

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -108,6 +108,7 @@ from .ui.layer_stats import LayerStatusPanel
 from .ui.plots.trajectory import TrajectoryMatplotlibCanvas
 from .ui.ui_dialogs.save import PointsLayerSaveWorkflow
 from .utils.debug import get_debug_recorder, install_debug_recorder, log_timing
+from .utils.deprecations import deprecated
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -289,8 +290,8 @@ class KeypointControls(ViewerSingletonWidget):
             trails_controller=self._trails_controller,
             trail_checkbox_getter=lambda: self._trail_cb.isChecked(),
             resolve_config_path_for_layer=self._resolve_config_path_for_layer,
-            current_project_path_getter=lambda: self._project_path,
-            current_image_meta_getter=lambda: self._image_meta,
+            current_project_path_getter=lambda: self.layer_manager.project_path,
+            current_image_meta_getter=lambda: self.layer_manager.image_meta,
             logger=logger,
         )
         ### UI setup ends here
@@ -339,23 +340,17 @@ class KeypointControls(ViewerSingletonWidget):
     def settings(self):
         return QSettings()
 
+    @deprecated(details="Use the layer manager's project context.", replacement="layer_manager.image_meta")
     @property
     def _image_meta(self) -> ImageMetadata:
         """Compatibility shim: lifecycle-owned image context now lives in manager."""
         return self.layer_manager.image_meta
 
-    @_image_meta.setter
-    def _image_meta(self, value: ImageMetadata) -> None:
-        self.layer_manager._image_meta = value
-
+    @deprecated(details="Use the layer manager's project context.", replacement="layer_manager.project_path")
     @property
     def _project_path(self) -> str | None:
         """Compatibility shim: lifecycle-owned project path now lives in manager."""
         return self.layer_manager.project_path
-
-    @_project_path.setter
-    def _project_path(self, value: str | None) -> None:
-        self.layer_manager.project_path = value
 
     @register_points_action("Change labeling mode")
     def cycle_through_label_modes(self, *args):
@@ -868,6 +863,12 @@ class KeypointControls(ViewerSingletonWidget):
         active_layer = self.viewer.layers.selection.active
         active_dlc_points = self._current_dlc_points_layer()
         active_image = self.layer_manager.active_dlc_image_layer()
+        fallback_n_frames = None
+        try:
+            if active_image is not None and active_image.data.ndim == 4:  # (T, H, W, C)
+                fallback_n_frames = int(active_image.data.shape[0])
+        except Exception:
+            logger.debug("Refresh layer stats - Failed to determine frame count from active image layer", exc_info=True)
 
         folder_name = infer_folder_display_name(
             active_image if active_image is not None else active_layer,
@@ -889,7 +890,11 @@ class KeypointControls(ViewerSingletonWidget):
         self._layer_status_panel.set_point_size_enabled(True)
         self._layer_status_panel.set_point_size(get_uniform_point_size(active_dlc_points))
 
-        progress = compute_label_progress(active_dlc_points, fallback_paths=self.layer_manager.image_paths)
+        progress = compute_label_progress(
+            active_dlc_points,
+            fallback_paths=self.layer_manager.image_paths,
+            fallback_n_frames=fallback_n_frames,
+        )
         self._layer_status_panel.set_progress_summary(progress=progress)
 
     def _on_active_points_size_changed(self, size: int) -> None:
@@ -1070,11 +1075,11 @@ class KeypointControls(ViewerSingletonWidget):
         ok, msg, project_path = run_store_crop_coordinates(
             self.viewer,
             self._video_group,
-            explicit_project_path=self._project_path,
-            fallback_video_name=self._image_meta.name,
+            explicit_project_path=self.layer_manager.project_path,
+            fallback_video_name=self.layer_manager.image_meta.name,
         )
         if project_path is not None:
-            self._project_path = project_path
+            self.layer_manager.project_path = project_path
         self.viewer.status = msg
         self._refresh_video_panel_context()
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -179,8 +179,13 @@ class KeypointControls(QWidget):
 
         self.viewer = napari_viewer
 
+        # Layer lifecycle manager
         self.layer_manager = LayerLifecycleManager(owner=self)
         self.layer_manager.attach()
+        ## Hook up signals for layer lifecycle events as needed, e.g.:
+        self.layer_manager.session_conflict_rejected.connect(
+            self._on_session_conflict_detected,
+        )
         # self.viewer.layers.events.inserted.connect(self.on_insert)
         # self.viewer.layers.events.removed.connect(self.on_remove)
 
@@ -487,6 +492,14 @@ class KeypointControls(QWidget):
                 return True
 
         return False
+
+    def _on_session_conflict_detected(self, reason: str) -> None:
+        QMessageBox.warning(
+            self,
+            "A labeled data folder is already loaded!",
+            f"{reason}\n\n",
+            QMessageBox.Ok,
+        )
 
     def _show_debug_window(self) -> None:
         try:

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -33,17 +33,16 @@ import logging
 from contextlib import contextmanager
 from copy import deepcopy
 from datetime import datetime
-from functools import cached_property, partial
+from functools import cached_property
 from pathlib import Path
-from types import MethodType
 
 import matplotlib.pyplot as plt
 import numpy as np
-from napari.layers import Image, Points, Tracks
+from napari.layers import Image, Points
 from napari.utils.events import Event
-from napari.utils.history import get_save_history, update_save_history
+from napari.utils.history import get_save_history
 from pydantic import ValidationError
-from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
+from qtpy.QtCore import QSettings, Qt, QTimer
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -61,24 +60,22 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-import napari_deeplabcut.core.io as io
-from napari_deeplabcut import misc
-from napari_deeplabcut.config import settings
-from napari_deeplabcut.config.keybinds import (
+from . import misc
+from .config import settings
+from .config.keybinds import (
     install_global_points_keybindings,
-    install_points_layer_keybindings,
 )
-from napari_deeplabcut.config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
-from napari_deeplabcut.core import keypoints
-from napari_deeplabcut.core.config_sync import (
+from .config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
+from .core import io, keypoints
+from .core.config_sync import (
     load_point_size_from_config,
     resolve_config_path_from_layer,
     save_point_size_to_config,
 )
-from napari_deeplabcut.core.conflicts import compute_overwrite_report_for_points_save
-from napari_deeplabcut.core.layer_lifecycle import LayerLifecycleManager
-from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
-from napari_deeplabcut.core.layers import (
+from .core.conflicts import compute_overwrite_report_for_points_save
+from .core.layer_lifecycle import LayerLifecycleManager
+from .core.layer_versioning import mark_layer_presentation_changed
+from .core.layers import (
     PointsInteractionEvent,
     PointsInteractionObserver,
     compute_label_progress,
@@ -90,7 +87,7 @@ from napari_deeplabcut.core.layers import (
     is_machine_layer,
     set_uniform_point_size,
 )
-from napari_deeplabcut.core.metadata import (
+from .core.metadata import (
     MergePolicy,
     apply_project_paths_override_to_points_meta,
     infer_image_root,
@@ -99,37 +96,32 @@ from napari_deeplabcut.core.metadata import (
     sync_points_from_image,
     write_points_meta,
 )
-from napari_deeplabcut.core.project_paths import (
-    PathMatchPolicy,
+from .core.project_paths import (
     coerce_paths_to_dlc_row_keys,
     dataset_folder_has_files,
     find_nearest_config,
     resolve_project_root_from_config,
     target_dataset_folder_for_config,
 )
-from napari_deeplabcut.core.provenance import (
+from .core.provenance import (
     apply_gt_save_target,
     is_projectless_folder_association_candidate,
     requires_gt_promotion,
     suggest_human_placeholder,
 )
-from napari_deeplabcut.core.remap import remap_layer_data_by_paths
-from napari_deeplabcut.core.sidecar import (
+from .core.sidecar import (
     get_default_scorer,
     set_default_scorer,
 )
-from napari_deeplabcut.core.trails import TrailsController, safe_folder_anchor_from_points_layer
-from napari_deeplabcut.napari_compat import (
+from .core.trails import TrailsController, safe_folder_anchor_from_points_layer
+from .napari_compat import (
     apply_points_layer_ui_tweaks,
-    install_add_wrapper,
-    install_paste_patch,
     patch_color_manager_guess_continuous,
     register_points_action,
 )
-from napari_deeplabcut.napari_compat.points_layer import make_paste_data
-from napari_deeplabcut.ui import dialogs as ui_dialogs
-from napari_deeplabcut.ui.color_scheme_display import ColorSchemePanel
-from napari_deeplabcut.ui.cropping import (
+from .ui import dialogs as ui_dialogs
+from .ui.color_scheme_display import ColorSchemePanel
+from .ui.cropping import (
     build_video_action_menu,
     handle_apply_crop_toggled,
     resolve_project_path_from_image_layer,
@@ -137,16 +129,16 @@ from napari_deeplabcut.ui.cropping import (
     run_store_crop_coordinates,
     update_video_panel_context,
 )
-from napari_deeplabcut.ui.debug_window import DebugTextWindow, make_issue_report_provider
-from napari_deeplabcut.ui.dialogs import Shortcuts, Tutorial
-from napari_deeplabcut.ui.labels_and_dropdown import (
+from .ui.debug_window import DebugTextWindow, make_issue_report_provider
+from .ui.dialogs import Shortcuts, Tutorial
+from .ui.labels_and_dropdown import (
     DropdownMenu,
     KeypointsDropdownMenu,
 )
-from napari_deeplabcut.ui.layer_stats import LayerStatusPanel
-from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
-from napari_deeplabcut.utils.debug import get_debug_recorder, install_debug_recorder
-from napari_deeplabcut.utils.deprecations import deprecated
+from .ui.layer_stats import LayerStatusPanel
+from .ui.plots.trajectory import TrajectoryMatplotlibCanvas
+from .utils.debug import get_debug_recorder, install_debug_recorder
+from .utils.deprecations import deprecated
 
 logger = logging.getLogger("napari-deeplabcut._widgets")
 # logger.setLevel(logging.DEBUG)  # FIXME @C-Achard temp remove before merging
@@ -511,42 +503,11 @@ class KeypointControls(QWidget):
     # ######################## #
 
     @deprecated(
-        details="This should be moved to LayerLifecycleManager. It is currently used there but should be moved."
+        details="Lifecycle-owned image setup has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._setup_image_layer(...)",
     )
     def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
-        md = layer.metadata or {}
-        paths = md.get("paths")
-        if paths is None and io.is_video(layer.name):
-            self.video_widget.setVisible(True)
-
-        self._update_image_meta_from_layer(layer)
-
-        if not self._project_path:
-            self._cache_project_path_from_image_layer(layer)
-            if self._project_path is not None:
-                try:
-                    layer.metadata = dict(layer.metadata or {})
-                    layer.metadata.setdefault("project", self._project_path)
-                except Exception:
-                    logger.debug(
-                        "Failed to set project path metadata on image layer %r",
-                        getattr(layer, "name", layer),
-                        exc_info=True,
-                    )
-
-        self._sync_points_layers_from_image_meta()
-        self._refresh_video_panel_context()
-        logger.debug(
-            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r",
-            getattr(layer, "name", layer),
-            index,
-            reorder,
-            len(md.get("paths") or []),
-            md.get("root"),
-        )
-
-        if reorder and index is not None:
-            QTimer.singleShot(10, partial(self._move_image_layer_to_bottom, index))
+        self.layer_manager._setup_image_layer(layer, index=index, reorder=reorder)
 
     def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
         md = layer.metadata or {}
@@ -640,117 +601,27 @@ class KeypointControls(QWidget):
     def get_layer_store(layer: Points) -> keypoints.KeypointStore | None:
         return getattr(layer, "_dlc_store", None)
 
-    @deprecated(details="This should be moved to LayerLifecycleManager.")
-    def _wire_points_layer(self, layer: Points) -> keypoints.KeypointStore | None:
-        if not self._validate_header(layer):
-            return None
-        existing = getattr(layer, "_dlc_store", None)
-        if existing is not None:
-            # self._stores[layer] = existing
-            self.layer_manager.register_managed_points_layer(layer, existing)
-            layer._dlc_controls = self
-            return existing
-
-        # ensure presence of IO metadata for saving & routing
-        mig = migrate_points_layer_metadata(layer)
-        if hasattr(mig, "errors"):
-            logger.warning(
-                "Points metadata validation failed during wiring for layer=%r: %s",
-                getattr(layer, "name", layer),
-                mig,
-            )
-
-        store = keypoints.KeypointStore(self.viewer, layer)
-        # self._stores[layer] = store
-        self.layer_manager.register_managed_points_layer(layer, store)
-        layer._dlc_store = store
-        layer._dlc_controls = self
-
-        # default root/paths from current image meta if missing
-        if not layer.metadata.get("root") and self._image_meta.root:
-            layer.metadata["root"] = self._image_meta.root
-        if not layer.metadata.get("paths") and self._image_meta.paths:
-            layer.metadata["paths"] = self._image_meta.paths
-
-        # save history
-        if root := layer.metadata.get("root"):
-            update_save_history(root)
-
-        store._get_label_mode = lambda: self._label_mode
-        layer.text.visible = False
-
-        paste_func = make_paste_data(self, store=store)
-        install_paste_patch(layer, paste_func=paste_func)
-
-        add_impl = MethodType(keypoints._add, store)  # bind store to add implementation
-        install_add_wrapper(layer, add_impl=add_impl, schedule_recolor=self._schedule_recolor)
-
-        # store events / navigation
-        layer.events.add(query_next_frame=Event)
-        layer.events.query_next_frame.connect(store._advance_step)
-
-        # Install keybinds
-        install_points_layer_keybindings(layer, self, store)
-
-        if self.layer_manager.managed_points_count() == 1 and self._is_multianimal(layer):
-            # set internal mode without triggering recolor storms
-            self._color_mode = keypoints.ColorMode.INDIVIDUAL
-            # update button state so UI matches (optional but good)
-            for btn in self._color_mode_selector.buttons():
-                if btn.text().lower() == str(self._color_mode).lower():
-                    btn.setChecked(True)
-                    break
-
-        # apply cycles (works even if empty; see method)
-        self._apply_points_coloring_from_metadata(layer)
-        self._maybe_initialize_layer_point_size_from_config(layer)
-        self._connect_layer_status_events(layer)
-        # refresh trails if enabled (e.g. when merging a config points layer with trails metadata)
-        self._trails_controller.on_points_layer_added_or_rewired(checkbox_checked=self._trail_cb.isChecked())
-
-        # menus
-        self._form_dropdown_menus(store)
-
-        # project path
-        proj = layer.metadata.get("project")
-        if proj:
-            self._project_path = proj
-
-        # enable GUI groups
-        self._radio_box.setEnabled(True)
-        self._color_grp.setEnabled(True)
-        self._trail_cb.setEnabled(True)
-        self._show_traj_plot_cb.setEnabled(True)
-
-        md = layer.metadata or {}
-        logger.debug(
-            "Wire points layer=%r existing_store=%s project=%s root=%s len_paths=%s",
-            getattr(layer, "name", layer),
-            getattr(layer, "_dlc_store", None) is not None,
-            md.get("project"),
-            md.get("root"),
-            len(md.get("paths", [])),
-        )
-
-        return store
-
     @deprecated(
-        details="This is still used in LayerLifecycleManager.on_insert(), "
-        "but should be instead moved to the LayerLifecycleManager itself instead."
+        details="Lifecycle-owned points wiring has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._wire_points_layer(...)",
     )
-    def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
-        if not self._validate_header(layer):
-            return
+    def _wire_points_layer(self, layer: Points) -> keypoints.KeypointStore | None:
+        return self.layer_manager._wire_points_layer(layer)
 
-        if allow_merge and self._maybe_merge_config_points_layer(layer):
-            return
+    # ------------------------------------------------------------------ #
+    # UI-only hooks used by LayerLifecycleManager                        #
+    # ------------------------------------------------------------------ #
 
+    def _set_points_controls_enabled(self, enabled: bool) -> None:
+        self._radio_box.setEnabled(enabled)
+        self._color_grp.setEnabled(enabled)
+        self._trail_cb.setEnabled(enabled)
+        self._show_traj_plot_cb.setEnabled(enabled)
+
+    def _complete_points_layer_ui_setup(self, layer: Points, store: keypoints.KeypointStore) -> None:
+        """UI-only completion after lifecycle manager finished points setup."""
         if layer.metadata.get("tables", ""):
             self._keypoint_mapping_button.show()
-
-        store = self._wire_points_layer(layer)
-        if store is None:
-            return
 
         selector = apply_points_layer_ui_tweaks(self.viewer, layer, dropdown_cls=DropdownMenu, plt_module=plt)
         if selector is not None:
@@ -759,66 +630,54 @@ class KeypointControls(QWidget):
             except Exception:
                 pass
 
+        self._apply_points_coloring_from_metadata(layer)
+        self._trails_controller.on_points_layer_added_or_rewired(checkbox_checked=self._trail_cb.isChecked())
+
+        self._form_dropdown_menus(store)
+
+        proj = layer.metadata.get("project")
+        if proj:
+            self._project_path = proj
+
+        self._set_points_controls_enabled(True)
         self._update_color_scheme()
-        logger.debug(
-            "Setup points layer=%r allow_merge=%s metadata_keys=%s",
-            getattr(layer, "name", layer),
-            allow_merge,
-            sorted((layer.metadata or {}).keys()),
-        )
+
+    def _on_points_layer_removed_ui(self, layer: Points, *, remaining_points_layers: int) -> None:
+        """UI-only cleanup after lifecycle manager removed a managed Points layer."""
+        self._update_color_scheme()
+        self._trails_controller.on_points_layer_removed(layer)
+
+        if remaining_points_layers == 0:
+            while self._menus:
+                menu = self._menus.pop()
+                self._layout.removeWidget(menu)
+                menu.deleteLater()
+                menu.destroy()
+
+            self._layer_to_menu = {}
+            self._set_points_controls_enabled(False)
+            self.last_saved_label.hide()
 
     @deprecated(
-        details="This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
+        details="Lifecycle-owned points setup has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._setup_points_layer(...)",
+    )
+    def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
+        self.layer_manager._setup_points_layer(layer, allow_merge=allow_merge)
+
+    @deprecated(
+        details="Layer adoption is now handled by LayerLifecycleManager.",
         replacement="self.layer_manager.schedule_initial_adoption()",
     )
     def _adopt_existing_layers(self) -> None:
-        """
-        When the widget is opened after layers already exist, we need to
-        run the same initialization as if they had been inserted.
-        """
-        # Iterate over a snapshot, because on_insert may modify layer order
-        logger.debug("Adopting existing layers count=%d", len(self.viewer.layers))
-        layers_snapshot = list(self.viewer.layers)
-
-        for idx, layer in enumerate(layers_snapshot):
-            self._adopt_layer(layer, idx)
-
-        # After adoption, refresh UI state
-        try:
-            active = self.viewer.layers.selection.active
-            if active is not None:
-                # Force the GUI to update visibility of menus, etc.
-                self.on_active_layer_change(Event(type_name="active", value=active))
-        except Exception:
-            pass
-
-        # Important: refresh the trajectory plot from the final adopted state.
-        # This fixes the case where layers were loaded before the plugin opened
-        # (e.g. drag-and-drop DLC data triggering the reader automatically).
-        self._refresh_trajectory_plot_from_layers()
+        self.layer_manager.adopt_existing_layers()
 
     @deprecated(
-        details="This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
-        replacement="LayerLifecycleManager.on_insert()",
+        details="Layer adoption is now handled by LayerLifecycleManager.",
+        replacement="LayerLifecycleManager._adopt_layer(...)",
     )
     def _adopt_layer(self, layer, index: int) -> None:
-        """
-        Run the relevant portion of on_insert() for an already-existing layer.
-        This avoids duplicating your logic and prevents reliance on napari's Event object.
-        """
-        logger.debug(
-            "Adopt layer=%r type=%s index=%s",
-            getattr(layer, "name", layer),
-            type(layer).__name__,
-            index,
-        )
-        if isinstance(layer, Image):
-            self._setup_image_layer(layer, index, reorder=True)
-        elif isinstance(layer, Points):
-            if not self.layer_manager.is_managed(layer):
-                self._setup_points_layer(layer, allow_merge=False)  # typically don’t merge during adopt
-        if not isinstance(layer, Image):
-            self._remap_frame_indices(layer)
+        self.layer_manager._adopt_layer(layer, index)
 
     def _validate_header(self, layer) -> bool:
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
@@ -973,7 +832,7 @@ class KeypointControls(QWidget):
         xy = points_layer.data[:, 1:3]
         superkpts_dict = io.load_superkeypoints(super_animal)
         xy_ref = np.asarray(list(superkpts_dict.values()), dtype=float)
-        neighbors = keypoints._find_nearest_neighbors(xy, xy_ref)
+        neighbors = keypoints.find_nearest_neighbors(xy, xy_ref)
         found = neighbors != -1
         if not np.any(found):
             return
@@ -1528,168 +1387,26 @@ class KeypointControls(QWidget):
             except Exception:
                 pass
 
-    def _remap_frame_indices(self, layer):
-        """
-        Best-effort remap of time/frame indices in non-Image layers to match current Image order.
-
-        Safety principles
-        -----------------
-        - Never delete or silently corrupt user data.
-        - Only write back to layer.data after a remap has been accepted as safe.
-        - Always sync non-path image metadata when possible.
-        - Do NOT replace metadata["paths"] unless remap is accepted as safe.
-        - Specifically reject ambiguous basename-only remaps (depth=1 with duplicate /
-        non-bijective warnings), which commonly happen when data are moved out of the
-        standard DLC labeled-data layout.
-        """
-        try:
-            new_paths = self._image_meta.paths
-            if not new_paths:
-                return
-
-            if layer.metadata is None:
-                layer.metadata = {}
-
-            md = layer.metadata
-            old_paths = md.get("paths") or []
-
-            # Always sync safe non-path metadata from image meta.
-            # Do NOT sync "paths" yet; that is only safe after we decide remap is acceptable.
-            try:
-                safe_image_meta = self._image_meta.model_dump(exclude_none=True)
-                safe_image_meta.pop("paths", None)
-                layer.metadata.update(safe_image_meta)
-            except Exception:
-                logger.debug(
-                    "Failed to sync non-path image metadata for layer=%r",
-                    getattr(layer, "name", str(layer)),
-                    exc_info=True,
-                )
-
-            if not old_paths:
-                logger.debug(
-                    "Skipping remap for layer=%r: no existing layer metadata paths.",
-                    getattr(layer, "name", str(layer)),
-                )
-                return
-
-            # Determine time column (napari-specific choice)
-            time_col = 1 if isinstance(layer, Tracks) else 0
-
-            if logger.isEnabledFor(logging.DEBUG):
-                arr_before = np.asarray(layer.data)
-                logger.debug(
-                    "Remap start layer=%r old_paths_len=%s new_paths_len=%s data_shape=%s frame_min=%s frame_max=%s",
-                    getattr(layer, "name", str(layer)),
-                    len(old_paths),
-                    len(new_paths or []),
-                    getattr(arr_before, "shape", None),
-                    int(np.nanmin(arr_before[:, time_col])) if arr_before.size else None,
-                    int(np.nanmax(arr_before[:, time_col])) if arr_before.size else None,
-                )
-
-            res = remap_layer_data_by_paths(
-                data=layer.data,
-                old_paths=old_paths,
-                new_paths=new_paths,
-                time_col=time_col,
-                policy=PathMatchPolicy.ORDERED_DEPTHS,
-            )
-
-            logger.debug(
-                "Remap result layer=%r changed=%s mapped_count=%s depth=%s message=%s warnings=%s",
-                getattr(layer, "name", str(layer)),
-                res.changed,
-                res.mapped_count,
-                res.depth_used,
-                res.message,
-                res.warnings,
-            )
-
-            if res.applied and res.data is not None:
-                layer.data = res.data
-
-            if res.accept_paths_update:
-                layer.metadata["paths"] = list(new_paths)
-                if isinstance(layer, Points):
-                    mark_layer_presentation_changed(layer)
-
-            # Final debug logging
-            if res.depth_used is None:
-                logger.debug("Remap skipped for %s: %s", getattr(layer, "name", str(layer)), res.message)
-            else:
-                logger.debug(
-                    "Remap %s for %s (depth=%s, mapped=%s): %s",
-                    "applied" if res.changed else "accepted-noop",
-                    getattr(layer, "name", str(layer)),
-                    res.depth_used,
-                    res.mapped_count,
-                    res.message,
-                )
-
-        except Exception:
-            logger.exception("Failed to remap frame indices for layer %s", getattr(layer, "name", str(layer)))
-            return
+    @deprecated(
+        details="Lifecycle-owned remap orchestration has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._remap_frame_indices(...)",
+    )
+    def _remap_frame_indices(self, layer) -> None:
+        self.layer_manager._remap_frame_indices(layer)
 
     @deprecated(
-        replacement="self.layer_manager", details="Direct layer management is now handled by LayerLifecycleManager"
+        replacement="self.layer_manager.on_insert(...)",
+        details="Direct layer management is now handled by LayerLifecycleManager",
     )
     def on_insert(self, event):
-        logger.debug("on_insert event received: event=%r", event)
-        layer = event.source[-1]
-        logger.debug(
-            "on_insert layer=%r type=%s index=%s",
-            getattr(layer, "name", layer),
-            type(layer).__name__,
-            getattr(event, "index", None),
-        )
-        if isinstance(layer, Image):
-            self._setup_image_layer(layer, event.index, reorder=True)
-        elif isinstance(layer, Points):
-            self._setup_points_layer(layer, allow_merge=True)
+        self.layer_manager.on_insert(event)
 
-        for layer_ in self.viewer.layers:
-            if not isinstance(layer_, Image):
-                self._remap_frame_indices(layer_)
-        self._refresh_video_panel_context()
-        self._refresh_layer_status_panel()
-
+    @deprecated(
+        details="Lifecycle-owned remove handling has moved to LayerLifecycleManager.",
+        replacement="self.layer_manager._handle_removed_layer(...)",
+    )
     def _handle_removed_layer(self, layer) -> None:
-        n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
-
-        if isinstance(layer, Points):
-            # self._stores.pop(layer, None)
-            self.layer_manager.unregister_managed_layer(layer)
-
-            self._update_color_scheme()
-            self._trails_controller.on_points_layer_removed(layer)
-
-            if n_points_layer == 0:
-                while self._menus:
-                    menu = self._menus.pop()
-                    self._layout.removeWidget(menu)
-                    menu.deleteLater()
-                    menu.destroy()
-
-                self._layer_to_menu = {}
-                self._trail_cb.setEnabled(False)
-                self._show_traj_plot_cb.setEnabled(False)
-                self.last_saved_label.hide()
-
-        elif isinstance(layer, Image):
-            self._image_meta = ImageMetadata()
-            paths = layer.metadata.get("paths")
-            if paths is None:
-                self.video_widget.setVisible(False)
-
-        elif isinstance(layer, Tracks):
-            was_trails = self._trails_controller.on_tracks_layer_removed(layer)
-            if was_trails:
-                with QSignalBlocker(self._trail_cb):
-                    self._trail_cb.setChecked(False)
-
-        self._refresh_video_panel_context()
-        self._refresh_layer_status_panel()
+        self.layer_manager._handle_removed_layer(layer)
 
     def _on_show_trails_toggled(self, state):
         self._trails_controller.toggle(Qt.CheckState(state) == Qt.CheckState.Checked)
@@ -1972,10 +1689,10 @@ class KeypointControls(QWidget):
             event.accept()
         cleared = self.layer_manager.clear_dead_entries(log=True)
         if cleared:
-            logger.debug("Cleared %d dead entries from layer manager on close", cleared)
+            logger.debug("Cleared %d dead entries from layer manager on close", len(cleared))
         report = self.layer_manager.audit_registry()
         if report.issues:
-            logger.warning("Layer manager audit on close reported issues:\n%s", report.format_for_logging())
+            logger.warning("Layer manager audit on close reported issues:\n%s", report.issues)
 
     def on_active_layer_change(self, event) -> None:
         """Updates the GUI when the active layer changes

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -510,7 +510,9 @@ class KeypointControls(QWidget):
     # Layer setup core methods #
     # ######################## #
 
-    @deprecated("This should be moved to LayerLifecycleManager. It is currently used there but should be moved.")
+    @deprecated(
+        details="This should be moved to LayerLifecycleManager. It is currently used there but should be moved."
+    )
     def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
         md = layer.metadata or {}
         paths = md.get("paths")
@@ -638,7 +640,7 @@ class KeypointControls(QWidget):
     def get_layer_store(layer: Points) -> keypoints.KeypointStore | None:
         return getattr(layer, "_dlc_store", None)
 
-    @deprecated("This should be moved to LayerLifecycleManager.")
+    @deprecated(details="This should be moved to LayerLifecycleManager.")
     def _wire_points_layer(self, layer: Points) -> keypoints.KeypointStore | None:
         if not self._validate_header(layer):
             return None
@@ -733,7 +735,7 @@ class KeypointControls(QWidget):
         return store
 
     @deprecated(
-        "This is still used in LayerLifecycleManager.on_insert(), "
+        details="This is still used in LayerLifecycleManager.on_insert(), "
         "but should be instead moved to the LayerLifecycleManager itself instead."
     )
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
@@ -766,7 +768,7 @@ class KeypointControls(QWidget):
         )
 
     @deprecated(
-        "This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
+        details="This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
         replacement="self.layer_manager.schedule_initial_adoption()",
     )
     def _adopt_existing_layers(self) -> None:
@@ -796,7 +798,7 @@ class KeypointControls(QWidget):
         self._refresh_trajectory_plot_from_layers()
 
     @deprecated(
-        "This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
+        details="This method is no longer used. Layer adoption is now handled by LayerLifecycleManager.",
         replacement="LayerLifecycleManager.on_insert()",
     )
     def _adopt_layer(self, layer, index: int) -> None:
@@ -1630,7 +1632,7 @@ class KeypointControls(QWidget):
             return
 
     @deprecated(
-        replacement="self.layer_manager", reason="Direct layer management is now handled by LayerLifecycleManager"
+        replacement="self.layer_manager", details="Direct layer management is now handled by LayerLifecycleManager"
     )
     def on_insert(self, event):
         logger.debug("on_insert event received: event=%r", event)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -350,6 +350,7 @@ class KeypointControls(ViewerSingletonWidget):
         return QSettings()
 
     def _cleanup_timers(self, *_args) -> None:
+        # FIXME @C-Achard move to singleton base class for other widgets to reuse, and maybe add logs
         """Stop/delete all timers owned by this widget.
 
         This is intentionally defensive: by teardown time, some underlying

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -76,6 +76,7 @@ from napari_deeplabcut.core.config_sync import (
     save_point_size_to_config,
 )
 from napari_deeplabcut.core.conflicts import compute_overwrite_report_for_points_save
+from napari_deeplabcut.core.layer_lifecycle import LayerLifecycleManager
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
 from napari_deeplabcut.core.layers import (
     PointsInteractionEvent,
@@ -189,8 +190,9 @@ class KeypointControls(QWidget):
 
         self.viewer = napari_viewer
 
-        self.viewer.layers.events.inserted.connect(self.on_insert)
-        self.viewer.layers.events.removed.connect(self.on_remove)
+        self.layer_manager = LayerLifecycleManager(self.viewer)
+        # self.viewer.layers.events.inserted.connect(self.on_insert)
+        # self.viewer.layers.events.removed.connect(self.on_remove)
 
         ## Debug ##
         self._debug_recorder = install_debug_recorder()
@@ -388,7 +390,8 @@ class KeypointControls(QWidget):
 
         # If layers already exist (user loaded data before opening this widget),
         # adopt them so keypoint controls take ownership immediately.
-        QTimer.singleShot(0, self._adopt_existing_layers)
+        # QTimer.singleShot(0, self._adopt_existing_layers)
+        self.layer_manager.schedule_initial_adoption()
 
         # Refresh layers stats widget
         QTimer.singleShot(0, self._refresh_layer_status_panel)
@@ -650,6 +653,7 @@ class KeypointControls(QWidget):
 
         store = keypoints.KeypointStore(self.viewer, layer)
         self._stores[layer] = store
+        self.layer_manager.register_managed_points_layer(layer, store)
         layer._dlc_store = store
         layer._dlc_controls = self
 
@@ -1607,6 +1611,7 @@ class KeypointControls(QWidget):
             return
 
     def on_insert(self, event):
+        logger.debug("on_insert event received: event=%r", event)
         layer = event.source[-1]
         logger.debug(
             "on_insert layer=%r type=%s index=%s",
@@ -1625,14 +1630,13 @@ class KeypointControls(QWidget):
         self._refresh_video_panel_context()
         self._refresh_layer_status_panel()
 
-    def on_remove(self, event):
-        layer = event.value
+    def _handle_removed_layer(self, layer) -> None:
         n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
 
         if isinstance(layer, Points):
             self._stores.pop(layer, None)
+            self._lifecycle.unregister_managed_layer(layer)
 
-            # Refresh color scheme panel regardless; it will clear itself if no valid target remains.
             self._update_color_scheme()
             self._trails_controller.on_points_layer_removed(layer)
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -79,7 +79,6 @@ from .core.layers import (
     PointsInteractionEvent,
     PointsInteractionObserver,
     compute_label_progress,
-    find_relevant_image_layer,
     get_first_points_layer,
     get_points_layer_with_tables,
     get_uniform_point_size,
@@ -546,14 +545,28 @@ class KeypointControls(QWidget):
         new_keypoint_set = set(hdr.bodyparts)
         diff = new_keypoint_set.difference(current_keypoint_set)
 
+        placeholder_layer = layer  # newly inserted temporary config layer
+        visible_existing_layer = None
+        for managed_layer, _store in managed:
+            if managed_layer is placeholder_layer:
+                continue
+            try:
+                if getattr(managed_layer, "visible", True):
+                    visible_existing_layer = managed_layer
+                    break
+            except Exception:
+                visible_existing_layer = managed_layer
+                break
+
         if diff:
             answer = QMessageBox.question(self, "", "Do you want to display the new keypoints only?")
-            if answer == QMessageBox.Yes:
-                self.viewer.layers[-2].shown = False
+            if answer == QMessageBox.Yes and visible_existing_layer is not None:
+                self.layer_manager._set_layer_visible(visible_existing_layer, False)
                 logger.debug(
-                    "Merging config points layer=%r new_keypoints=%s",
+                    "Merging config points layer=%r new_keypoints=%s hid_existing_layer=%r",
                     getattr(layer, "name", layer),
                     sorted(diff),
+                    getattr(visible_existing_layer, "name", visible_existing_layer),
                 )
 
             self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
@@ -568,7 +581,7 @@ class KeypointControls(QWidget):
                 menu._map_individuals_to_bodyparts()
                 menu._update_items()
 
-        QTimer.singleShot(10, self.viewer.layers.pop)
+        QTimer.singleShot(0, lambda: self.layer_manager._remove_layer_if_present(placeholder_layer))
 
         # apply the new color cycles + recolor safely
         for _layer, store in managed:
@@ -877,10 +890,18 @@ class KeypointControls(QWidget):
     def display_shortcuts(self):
         Shortcuts(self.viewer.window._qt_window.current(), viewer=self.viewer).show()
 
-    def _move_image_layer_to_bottom(self, index):
-        if (ind := index) != 0:
-            self.viewer.layers.move_selected(ind, 0)
-            self.viewer.layers.select_next()  # Auto-select the Points layer
+    def _move_image_layer_to_bottom(self, layer: Image):
+        try:
+            if layer not in self.viewer.layers:
+                return
+            ind = list(self.viewer.layers).index(layer)
+            if ind != 0:
+                self.viewer.layers.selection.clear()
+                self.viewer.layers.selection.add(layer)
+                self.viewer.layers.move_selected(ind, 0)
+                self.viewer.layers.select_next()
+        except Exception:
+            logger.debug("Failed to move image layer to bottom", exc_info=True)
 
     # ------------------------------------------------------------------
     # Metadata helpers (authoritative models + napari-friendly dict sync)
@@ -916,7 +937,7 @@ class KeypointControls(QWidget):
         if layer is None:
             return None
 
-        image_layer = find_relevant_image_layer(self.viewer)
+        image_layer = self.layer_manager.active_dlc_image_layer()
 
         return resolve_config_path_from_layer(
             layer,
@@ -1053,7 +1074,7 @@ class KeypointControls(QWidget):
     def _refresh_layer_status_panel(self) -> None:
         active_layer = self.viewer.layers.selection.active
         active_dlc_points = self._current_dlc_points_layer()
-        active_image = find_relevant_image_layer(self.viewer)
+        active_image = self.layer_manager.active_dlc_image_layer()
 
         folder_name = infer_folder_display_name(
             active_image if active_image is not None else active_layer,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -542,15 +542,30 @@ class KeypointControls(QWidget):
 
         self._sync_points_layers_from_image_meta()
         self._refresh_video_panel_context()
+        logger.debug(
+            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r",
+            getattr(layer, "name", layer),
+            index,
+            reorder,
+            len(md.get("paths") or []),
+            md.get("root"),
+        )
 
         if reorder and index is not None:
             QTimer.singleShot(10, partial(self._move_image_layer_to_bottom, index))
 
     def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
-        if not layer.metadata.get("project", "") or not self._stores:
+        md = layer.metadata or {}
+        logger.debug(
+            "Maybe merge config points layer=%r project=%r stores=%d",
+            getattr(layer, "name", layer),
+            md.get("project"),
+            len(self._stores),
+        )
+        if not md.get("project", "") or not self._stores:
             return False
 
-        new_metadata = layer.metadata.copy()
+        new_metadata = md.copy()
 
         keypoints_menu = self._menus[0].menus["label"]
         current_keypoint_set = {keypoints_menu.itemText(i) for i in range(keypoints_menu.count())}
@@ -564,6 +579,11 @@ class KeypointControls(QWidget):
             answer = QMessageBox.question(self, "", "Do you want to display the new keypoints only?")
             if answer == QMessageBox.Yes:
                 self.viewer.layers[-2].shown = False
+                logger.debug(
+                    "Merging config points layer=%r new_keypoints=%s",
+                    getattr(layer, "name", layer),
+                    sorted(diff),
+                )
 
             self.viewer.status = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found."
             for _layer, store in self._stores.items():
@@ -704,6 +724,16 @@ class KeypointControls(QWidget):
         self._trail_cb.setEnabled(True)
         self._show_traj_plot_cb.setEnabled(True)
 
+        md = layer.metadata or {}
+        logger.debug(
+            "Wire points layer=%r existing_store=%s project=%s root=%s len_paths=%s",
+            getattr(layer, "name", layer),
+            getattr(layer, "_dlc_store", None) is not None,
+            md.get("project"),
+            md.get("root"),
+            len(md.get("paths", [])),
+        )
+
         return store
 
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
@@ -728,6 +758,12 @@ class KeypointControls(QWidget):
                 pass
 
         self._update_color_scheme()
+        logger.debug(
+            "Setup points layer=%r allow_merge=%s metadata_keys=%s",
+            getattr(layer, "name", layer),
+            allow_merge,
+            sorted((layer.metadata or {}).keys()),
+        )
 
     def _adopt_existing_layers(self) -> None:
         """
@@ -735,6 +771,7 @@ class KeypointControls(QWidget):
         run the same initialization as if they had been inserted.
         """
         # Iterate over a snapshot, because on_insert may modify layer order
+        logger.debug("Adopting existing layers count=%d", len(self.viewer.layers))
         layers_snapshot = list(self.viewer.layers)
 
         for idx, layer in enumerate(layers_snapshot):
@@ -759,6 +796,12 @@ class KeypointControls(QWidget):
         Run the relevant portion of on_insert() for an already-existing layer.
         This avoids duplicating your logic and prevents reliance on napari's Event object.
         """
+        logger.debug(
+            "Adopt layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            index,
+        )
         if isinstance(layer, Image):
             self._setup_image_layer(layer, index, reorder=True)
         elif isinstance(layer, Points):
@@ -1556,6 +1599,12 @@ class KeypointControls(QWidget):
 
     def on_insert(self, event):
         layer = event.source[-1]
+        logger.debug(
+            "on_insert layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            getattr(event, "index", None),
+        )
         if isinstance(layer, Image):
             self._setup_image_layer(layer, event.index, reorder=True)
         elif isinstance(layer, Points):

--- a/src/napari_deeplabcut/config/_autostart.py
+++ b/src/napari_deeplabcut/config/_autostart.py
@@ -8,9 +8,9 @@ from napari.layers import Points
 from napari.utils.events import Event
 from qtpy.QtCore import QTimer
 
-from napari_deeplabcut._widgets import KeypointControls
 from napari_deeplabcut.config.settings import get_auto_open_keypoint_controls
 from napari_deeplabcut.core.metadata import read_points_meta
+from napari_deeplabcut.widget_factory import get_existing_keypoint_controls
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +27,6 @@ def _is_dlc_points_layer(layer) -> bool:
     if hasattr(res, "errors"):
         return False
     return res.header is not None
-
-
-def get_existing_keypoint_controls(viewer):
-    for widget in viewer.window.dock_widgets.values():
-        if isinstance(widget, KeypointControls):
-            return widget
-    return None
 
 
 def _ensure_keypoint_controls_open(viewer) -> None:

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -430,7 +430,7 @@ class IOProvenance(BaseModel):
         description="Project-relative POSIX path to the source .h5 (forward slashes).",
     )
     kind: AnnotationKind | None = Field(default=None, description="Annotation kind for routing", strict=True)
-    dataset_key: str = Field(default="keypoints", description="HDF5 key for keypoints table")
+    dataset_key: str = Field(default="df_with_missing", description="HDF5 key for keypoints table")
 
     @field_validator("source_relpath_posix")
     @classmethod

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -313,9 +313,14 @@ class DLCHeaderModel(BaseModel):
 
         Replaces legacy `header.scorer = ...`.
         """
-        canon = self._canonical_4()
-        new_cols = [(str(scorer), ind, bp, coord) for _, ind, bp, coord in canon]
-        return self.model_copy(update={"columns": new_cols, "names": ["scorer", "individuals", "bodyparts", "coords"]})
+        new_cols = []
+        for col in self.columns:
+            t = tuple(map(str, col))
+            if len(t) >= 1:
+                new_cols.append((str(scorer), *t[1:]))
+            else:
+                new_cols.append((str(scorer),))
+        return self.model_copy(update={"columns": new_cols, "names": self.names})
 
     def form_individual_bodypart_pairs(self) -> list[tuple[str, str]]:
         """

--- a/src/napari_deeplabcut/core/conflicts.py
+++ b/src/napari_deeplabcut/core/conflicts.py
@@ -9,6 +9,7 @@ from napari_deeplabcut.config.models import AnnotationKind, OverwriteConflictRep
 from napari_deeplabcut.core import schemas as dlc_schemas
 from napari_deeplabcut.core.dataframes import set_df_scorer
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
+from napari_deeplabcut.core.io import DLC_CANONICAL_H5_KEY
 from napari_deeplabcut.core.metadata import parse_points_metadata
 from napari_deeplabcut.core.project_paths import infer_dlc_project_from_points_meta
 from napari_deeplabcut.core.provenance import (
@@ -143,7 +144,7 @@ def compute_overwrite_report_for_points_save(
         return None
 
     try:
-        df_old = pd.read_hdf(out, key="keypoints")
+        df_old = pd.read_hdf(out, key=DLC_CANONICAL_H5_KEY)
     except (KeyError, ValueError):
         df_old = pd.read_hdf(out)
 

--- a/src/napari_deeplabcut/core/conflicts.py
+++ b/src/napari_deeplabcut/core/conflicts.py
@@ -194,7 +194,7 @@ def compute_overwrite_report_for_extracted_labels_row(
         return None
 
     try:
-        df_old = pd.read_hdf(out, key="df_with_missing")
+        df_old = pd.read_hdf(out, key=DLC_CANONICAL_H5_KEY)
     except (KeyError, ValueError):
         df_old = pd.read_hdf(out)
 

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -13,24 +13,31 @@ from napari_deeplabcut.core.schemas import DLCHeaderModel, PointsWriteInputModel
 logger = logging.getLogger(__name__)
 
 
-def _is_logical_single_animal_header(header: DLCHeaderModel | None) -> bool:
+def _is_logical_single_animal_header(
+    header: DLCHeaderModel | None,
+    *,
+    is_ma_project: bool | None = None,
+) -> bool:
     """
-    Determine whether the authoritative header represents a single-animal project.
+    Determine whether the target should be written in canonical single-animal format.
 
-    Important:
-    - Use the original header shape (nlevels / names), NOT the normalized in-memory
-      canonical_4 representation.
-    - A legacy/canonical SA header is 3-level: (scorer, bodyparts, coords).
+    Priority
+    --------
+    1) Explicit project-mode signal from DLC config (is_ma_project)
+    2) Original header shape
+    3) Blank-individuals fallback
     """
+    if is_ma_project is not None:
+        return not bool(is_ma_project)
+
     if header is None:
         return False
 
-    # Canonical SA in this codebase is represented originally as 3-level
+    # Canonical/original SA header
     if header.nlevels == 3:
         return True
 
-    # Defensive fallback: if a 4-level header somehow exists but all individuals are blank,
-    # treat it as effectively SA for writing.
+    # Fallback for normalized 4-level headers that still represent SA
     if header.nlevels == 4:
         inds = [str(i) for i in header.individuals if str(i) != ""]
         return len(inds) == 0
@@ -38,8 +45,15 @@ def _is_logical_single_animal_header(header: DLCHeaderModel | None) -> bool:
     return False
 
 
-def restore_dlc_on_disk_header_shape(df: pd.DataFrame, header: DLCHeaderModel) -> pd.DataFrame:
+def restore_dlc_on_disk_header_shape(
+    df: pd.DataFrame, header: DLCHeaderModel, *, is_ma_project: bool | None = None
+) -> pd.DataFrame:
     """
+    Args:
+        df: DataFrame with arbitrary column structure produced from napari Points + metadata.
+        header: Authoritative DLCHeaderModel that defines the expected column structure on disk.
+        is_ma_from_config: Optional boolean indicating if the project is multi-animal based on DLC config.
+
     Restore the DataFrame column structure to match the authoritative DLC header
     that should be used on disk.
 
@@ -51,7 +65,7 @@ def restore_dlc_on_disk_header_shape(df: pd.DataFrame, header: DLCHeaderModel) -
 
     df_out = df.copy()
 
-    if _is_logical_single_animal_header(header):
+    if _is_logical_single_animal_header(header, is_ma_project=is_ma_project):
         # If the normalized dataframe has an empty individuals level, collapse it.
         if df_out.columns.nlevels == 4 and "individuals" in (df_out.columns.names or []):
             inds = pd.Index(df_out.columns.get_level_values("individuals")).astype(str)

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -389,7 +389,9 @@ def harmonize_keypoint_column_index(df: pd.DataFrame) -> pd.DataFrame:
         df2.columns = cols.set_names(["scorer", "individuals", "bodyparts", "coords"])
         return df2
 
-    # Legacy 3-level: (scorer, bodyparts, coords) -> insert individuals=""
+    # Single animal 3-level: (scorer, bodyparts, coords) -> insert individuals=""
+    # THIS IS ONLY FOR INTERNAL COMPARISONS; we do NOT want to write an SA header
+    # with an empty individuals level to disk.
     if cols.nlevels == 3:
         # We only insert individuals if it looks like the DLC pattern
         # (names might be missing/None depending on earlier ops)

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -52,7 +52,7 @@ def restore_dlc_on_disk_header_shape(
     Args:
         df: DataFrame with arbitrary column structure produced from napari Points + metadata.
         header: Authoritative DLCHeaderModel that defines the expected column structure on disk.
-        is_ma_from_config: Optional boolean indicating if the project is multi-animal based on DLC config.
+        is_ma_project: Optional boolean indicating if the project is multi-animal based on DLC config.
 
     Restore the DataFrame column structure to match the authoritative DLC header
     that should be used on disk.

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -213,6 +213,9 @@ def guarantee_multiindex_rows(df: pd.DataFrame) -> None:
     Legacy DLC data may use an index with pathto/video/file.png strings as Index.
     The new format uses a MultiIndex with each path component as a level.
     """
+    if len(df.index) == 0:
+        return
+
     # Make paths platform-agnostic if they are not already
     if not isinstance(df.index, pd.MultiIndex):  # Backwards compatibility
         path = df.index[0]

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -8,9 +8,84 @@ import numpy as np
 import pandas as pd
 
 from napari_deeplabcut.config.models import ConflictEntry, OverwriteConflictReport
-from napari_deeplabcut.core.schemas import PointsWriteInputModel
+from napari_deeplabcut.core.schemas import DLCHeaderModel, PointsWriteInputModel
 
 logger = logging.getLogger(__name__)
+
+
+def _is_logical_single_animal_header(header: DLCHeaderModel | None) -> bool:
+    """
+    Determine whether the authoritative header represents a single-animal project.
+
+    Important:
+    - Use the original header shape (nlevels / names), NOT the normalized in-memory
+      canonical_4 representation.
+    - A legacy/canonical SA header is 3-level: (scorer, bodyparts, coords).
+    """
+    if header is None:
+        return False
+
+    # Canonical SA in this codebase is represented originally as 3-level
+    if header.nlevels == 3:
+        return True
+
+    # Defensive fallback: if a 4-level header somehow exists but all individuals are blank,
+    # treat it as effectively SA for writing.
+    if header.nlevels == 4:
+        inds = [str(i) for i in header.individuals if str(i) != ""]
+        return len(inds) == 0
+
+    return False
+
+
+def restore_dlc_on_disk_header_shape(df: pd.DataFrame, header: DLCHeaderModel) -> pd.DataFrame:
+    """
+    Restore the DataFrame column structure to match the authoritative DLC header
+    that should be used on disk.
+
+    - If the logical target is single-animal, collapse an empty 'individuals' level.
+    - Reindex to the authoritative header order.
+    """
+    if not isinstance(df.columns, pd.MultiIndex):
+        return df
+
+    df_out = df.copy()
+
+    if _is_logical_single_animal_header(header):
+        # If the normalized dataframe has an empty individuals level, collapse it.
+        if df_out.columns.nlevels == 4 and "individuals" in (df_out.columns.names or []):
+            inds = pd.Index(df_out.columns.get_level_values("individuals")).astype(str)
+            non_empty_inds = {x for x in inds if x != ""}
+            if non_empty_inds:
+                raise ValueError(
+                    "Refusing to write single-animal format because dataframe contains "
+                    f"non-empty individuals: {sorted(non_empty_inds)}"
+                )
+
+            df_out = df_out.droplevel("individuals", axis=1)
+            df_out.columns = df_out.columns.set_names(["scorer", "bodyparts", "coords"])
+
+        # Reindex to the original authoritative 3-level header order
+        try:
+            # For an SA header, header.columns is the original 3-level tuples
+            target_cols = pd.MultiIndex.from_tuples(
+                header.columns,
+                names=header.names or ["scorer", "bodyparts", "coords"],
+            )
+            df_out = df_out.reindex(target_cols, axis=1)
+        except Exception:
+            logger.debug("Could not reindex collapsed SA dataframe to authoritative header", exc_info=True)
+
+        return df_out
+
+    # Multi-animal: use canonical 4-level ordering
+    try:
+        target_cols = header.as_multiindex()
+        df_out = df_out.reindex(target_cols, axis=1)
+    except Exception:
+        logger.debug("Could not reindex MA dataframe to authoritative header", exc_info=True)
+
+    return df_out
 
 
 def set_df_scorer(df: pd.DataFrame, scorer: str) -> pd.DataFrame:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -162,6 +162,10 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     temp = merge_multiple_scorers(temp)
     header = DLCHeaderModel(columns=temp.columns)
     temp = temp.droplevel("scorer", axis=1)
+    logger.debug("READ_HDF file=%s", file)
+    logger.debug("READ_HDF raw column names=%s", getattr(temp.columns, "names", None))
+    logger.debug("READ_HDF raw first columns=%s", list(temp.columns[:10]))
+    logger.debug("READ_HDF header.bodyparts=%s", header.bodyparts)
 
     # Handle legacy/single-animal column layout by inserting empty "individuals" level.
     # Colormap selection also falls back to config when possible.
@@ -211,6 +215,8 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     data = data[finite]
     df = df.loc[finite].reset_index(drop=True)
 
+    logger.debug("STACKED df bodyparts unique=%s", list(dict.fromkeys(df["bodyparts"].astype(str)))[:30])
+    logger.debug("STACKED df individuals unique=%s", list(dict.fromkeys(df["individuals"].astype(str)))[:30])
     layer_props = populate_keypoint_layer_properties(
         header,
         labels=df["bodyparts"],
@@ -403,6 +409,8 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
     logger.debug("HEADER names: %s", ctx.meta.header.as_multiindex().names)
 
     # Build df from points + plugin metadata + layer properties
+    logger.debug("WRITE header bodyparts=%s", ctx.meta.header.bodyparts)
+    logger.debug("WRITE props labels unique=%s", list(dict.fromkeys(map(str, attrs.properties.get("label", []))))[:30])
     df_new = form_df_from_validated(ctx)
 
     logger.debug("DF_NEW columns nlevels: %s", df_new.columns.nlevels)
@@ -505,8 +513,16 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
     )
     df_out = restore_dlc_on_disk_header_shape(df_out, header_for_write, is_ma_project=is_ma_project)
 
+    logger.debug("FINAL WRITE first columns=%s", list(df_out.columns[:10]))
+    logger.debug(
+        "FINAL WRITE bodyparts unique=%s",
+        list(dict.fromkeys(df_out.columns.get_level_values("bodyparts").astype(str)))[:30]
+        if isinstance(df_out.columns, pd.MultiIndex) and "bodyparts" in df_out.columns.names
+        else None,
+    )
     logger.debug("FINAL WRITE columns nlevels: %s", getattr(df_out.columns, "nlevels", None))
     logger.debug("FINAL WRITE columns names: %s", getattr(df_out.columns, "names", None))
+
     if isinstance(df_out.columns, pd.MultiIndex) and "individuals" in (df_out.columns.names or []):
         logger.debug(
             "FINAL WRITE individuals values: %s",

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 _GLOB_MAGIC = set("*?[")
 _SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
-DLC_CANONICAL_H5_KEY = "df_with_missing"
+DLC_CANONICAL_H5_KEY = "df_with_missing"  # TODO use this key instead of str literal in all places
 
 
 def _has_glob_magic(name: str) -> bool:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -43,6 +43,7 @@ from napari_deeplabcut.core.dataframes import (
     harmonize_keypoint_column_index,
     harmonize_keypoint_row_index,
     merge_multiple_scorers,
+    restore_dlc_on_disk_header_shape,
     set_df_scorer,
 )
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
@@ -62,6 +63,7 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------
 _GLOB_MAGIC = set("*?[")
 _SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
+DLC_CANONICAL_H5_KEY = "df_with_missing"
 
 
 def _has_glob_magic(name: str) -> bool:
@@ -116,6 +118,26 @@ def write_config(config_path: str | Path, params: dict[str, Any]) -> None:
 # and attaches provenance via attach_source_and_io_to_layer_kwargs.
 
 
+def _read_hdf_any_key(file: Path) -> pd.DataFrame:
+    """Read an HDF file without knowing the key in advance. Try common DLC keys."""
+    file = str(file)
+    try:
+        return pd.read_hdf(file, key=DLC_CANONICAL_H5_KEY)
+    except (KeyError, ValueError):
+        logger.error(f"Key '{DLC_CANONICAL_H5_KEY}' not found in {file}. Trying to read without specifying a key.")
+    fallback_keys = ["keypoints"]
+    for k in fallback_keys:
+        try:
+            return pd.read_hdf(file, key=k)
+        except (KeyError, ValueError):
+            logger.error(f"Key '{k}' not found in {file}.")
+    logger.error(
+        f"None of the expected keys {fallback_keys + [DLC_CANONICAL_H5_KEY]} were found in {file}. "
+        "Falling back to default read_hdf which may raise its own error if no valid key is found."
+    )
+    return pd.read_hdf(file)  # Let pandas guess instead
+
+
 def read_hdf(filename: str) -> list[LayerData]:
     layers = []
     for file in Path(filename).parent.glob(Path(filename).name):
@@ -125,13 +147,16 @@ def read_hdf(filename: str) -> list[LayerData]:
 
 def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[LayerData]:
     """Read a single H5 file and attach provenance with optional explicit kind.
+    Dataset may be under keypoints/ or df_with_missing/ for compatibility with various DLC versions.
+    We use read_hdf without specifying a key to allow pandas to auto-detect the correct one.
 
     - Produces one Points layer per H5 file
     - Points.data contains only finite coordinates
     - Unlabeled keypoints are omitted from Points.data
     - Empty Points layers are valid
     """
-    temp = pd.read_hdf(str(file))
+    # temp = pd.read_hdf(str(file))
+    temp = _read_hdf_any_key(file)
     temp = merge_multiple_scorers(temp)
     header = DLCHeaderModel(columns=temp.columns)
     temp = temp.droplevel("scorer", axis=1)
@@ -288,7 +313,7 @@ def form_df(
     return df
 
 
-def _atomic_to_hdf(df: pd.DataFrame, out_path: Path, key: str = "keypoints") -> None:
+def _atomic_to_hdf(df: pd.DataFrame, out_path: Path, key: str = DLC_CANONICAL_H5_KEY) -> None:
     """Best-effort atomic write: write to temp and replace."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = out_path.with_suffix(out_path.suffix + ".tmp")
@@ -351,6 +376,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
     # If promoting to GT and scorer is known, rewrite scorer level
     if target_scorer:
         df_new = set_df_scorer(df_new, target_scorer)
+    header_for_write = pts_meta.header.with_scorer(target_scorer) if target_scorer else pts_meta.header
 
     # Never write back to machine sources without an explicit promotion target
     if not out_path and source_kind == AnnotationKind.MACHINE:
@@ -404,10 +430,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
 
     # Merge-on-save for GT
     if destination_kind == AnnotationKind.GT and out.exists():
-        try:
-            df_old = pd.read_hdf(out, key="keypoints")
-        except (KeyError, ValueError):
-            df_old = pd.read_hdf(out)
+        df_old = _read_hdf_any_key(out)
 
         # Harmonize indices and merge
         try:
@@ -420,25 +443,30 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
         df_new = harmonize_keypoint_column_index(df_new)
         df_old = harmonize_keypoint_column_index(df_old)
         df_out = df_new.combine_first(df_old)
-
-        # Normalize columns to DLC header if possible
-        try:
-            header = DLCHeaderModel(columns=df_out.columns)
-            df_out = df_out.reindex(header.columns, axis=1)
-        except Exception:
-            pass
     else:
         df_out = df_new
 
-    # Final cleanup
+    # Final cleanup of rows
     try:
         guarantee_multiindex_rows(df_out)
     except Exception:
         pass
     df_out.sort_index(inplace=True)
 
+    # IMPORTANT:
+    # Restore canonical on-disk DLC header shape from the authoritative header.
+    df_out = restore_dlc_on_disk_header_shape(df_out, header_for_write)
+
+    logger.debug("FINAL WRITE columns nlevels: %s", getattr(df_out.columns, "nlevels", None))
+    logger.debug("FINAL WRITE columns names: %s", getattr(df_out.columns, "names", None))
+    if isinstance(df_out.columns, pd.MultiIndex) and "individuals" in (df_out.columns.names or []):
+        logger.debug(
+            "FINAL WRITE individuals values: %s",
+            list(dict.fromkeys(df_out.columns.get_level_values("individuals").astype(str))),
+        )
+
     # Write .h5 and .csv
-    _atomic_to_hdf(df_out, out, key="keypoints")
+    _atomic_to_hdf(df_out, out, key=DLC_CANONICAL_H5_KEY)
     csv_path = out.with_suffix(".csv")
     df_out.to_csv(csv_path)
 

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -124,14 +124,14 @@ def _read_hdf_any_key(file: Path) -> pd.DataFrame:
     try:
         return pd.read_hdf(file, key=DLC_CANONICAL_H5_KEY)
     except (KeyError, ValueError):
-        logger.error(f"Key '{DLC_CANONICAL_H5_KEY}' not found in {file}. Trying to read without specifying a key.")
+        logger.warning(f"Key '{DLC_CANONICAL_H5_KEY}' not found in {file}. Trying to read without specifying a key.")
     fallback_keys = ["keypoints"]
     for k in fallback_keys:
         try:
             return pd.read_hdf(file, key=k)
         except (KeyError, ValueError):
-            logger.error(f"Key '{k}' not found in {file}.")
-    logger.error(
+            logger.warning(f"Key '{k}' not found in {file}.")
+    logger.warning(
         f"None of the expected keys {fallback_keys + [DLC_CANONICAL_H5_KEY]} were found in {file}. "
         "Falling back to default read_hdf which may raise its own error if no valid key is found."
     )
@@ -345,7 +345,9 @@ def _resolve_multianimalproject_for_write(
             cfg_path = find_nearest_config(candidate, max_levels=3)
             cfg = load_config(str(cfg_path))
             if isinstance(cfg, dict) and "multianimalproject" in cfg:
-                logger.debug("Resolved multianimalproject=True from config at %s", cfg_path)
+                logger.debug(
+                    "Resolved multianimalproject=%s from config at %s", cfg.get("multianimalproject"), cfg_path
+                )
                 return bool(cfg.get("multianimalproject", False))
         except Exception:
             continue

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -661,65 +661,44 @@ def _lazy_imread(
         ) from e
 
 
+def _build_image_layer_kwargs(
+    *,
+    filepaths: list[Path],
+    dlc_meta: dict | None = None,
+    name: str = "images",
+) -> dict[str, Any]:
+    metadata = {
+        "paths": [canonicalize_path(fp, 3) for fp in filepaths],
+        "root": str(filepaths[0].parent),
+    }
+    if dlc_meta is not None:
+        metadata["dlc"] = dlc_meta
+
+    return {
+        "name": name,
+        "metadata": metadata,
+    }
+
+
 # Read images from a list of files or a glob/string path
-def read_images(path: str | Path | list[str | Path]):
-    """Reads one or multiple images and returns a Napari Image layer.
-
-    Uses `_expand_image_paths` to resolve the input into a list of valid
-    image files. Supports single paths, glob expressions, directories,
-    and lists or tuples of such paths.
-
-    Behavior:
-        * If one file is found:
-            - Loaded using `dask_image.imread.imread`.
-        * If multiple files are found:
-            - Loaded lazily using `lazy_imread` into a stacked image
-              layer.
-
-    Args:
-        path (str | Path | list[str | Path]):
-            Input path(s), directory, or glob pattern(s) to expand into
-            supported image files.
-
-    Returns:
-        list[LayerData]:
-            A list containing one Napari layer tuple of the form
-            `(data, metadata, "image")`.
-
-    Raises:
-        OSError: If no supported images are found after expansion.
-    """
+def read_images(
+    path: str | Path | list[str | Path],
+    *,
+    dlc_meta: dict | None = None,
+) -> list[LayerData]:
     filepaths = _expand_image_paths(path)
-
     if not filepaths:
         raise OSError(f"No supported images were found in {path}")
 
     filepaths = natsorted(filepaths, key=str)
+    kwargs = _build_image_layer_kwargs(filepaths=filepaths, dlc_meta=dlc_meta, name="images")
 
-    # Multiple images → lazy-imread stack
     if len(filepaths) > 1:
-        # NOTE: canonicalize_path(fp, 3) stores a stable relative-ish path for the UI/metadata.
-        relative_paths = [canonicalize_path(fp, 3) for fp in filepaths]
-        params = {
-            "name": "images",
-            "metadata": {
-                "paths": relative_paths,
-                "root": str(filepaths[0].parent),
-            },
-        }
         data = _lazy_imread(filepaths, use_dask=True, stack=True)
-        return [(data, params, "image")]
+    else:
+        data = imread(str(filepaths[0]))
 
-    # Single image → old behavior
-    image_path = filepaths[0]
-    params = {
-        "name": "images",
-        "metadata": {
-            "paths": [canonicalize_path(image_path, 3)],
-            "root": str(image_path.parent),
-        },
-    }
-    return [(imread(str(image_path)), params, "image")]
+    return [(data, kwargs, "image")]
 
 
 # =============================================================================
@@ -772,7 +751,7 @@ class Video:
         self.stream.release()
 
 
-def read_video(filename: str, opencv: bool = True):
+def read_video(filename: str, opencv: bool = True, *, dlc_meta: dict | None = None):
     if opencv:
         stream = Video(filename)
         # NOTE construct output shape tuple in (H, W, C) order to match read_frame() data
@@ -805,4 +784,7 @@ def read_video(filename: str, opencv: bool = True):
             "root": root,
         },
     }
+    if dlc_meta is not None:
+        params["metadata"]["dlc"] = dlc_meta
+
     return [(movie, params, "image")]

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -313,6 +313,47 @@ def form_df(
     return df
 
 
+def _resolve_multianimalproject_for_write(
+    *,
+    out_path: Path,
+    pts_meta: PointsMetadata,
+) -> bool | None:
+    """
+    Best-effort resolve of DLC config multianimalproject flag for save.
+
+    Resolution order
+    ----------------
+    1) pts_meta.project / explicit project context if available
+    2) config near output path
+    3) config near pts_meta.root
+    4) None if not resolvable
+    """
+    candidates: list[Path] = []
+
+    project = getattr(pts_meta, "project", None)
+    if project:
+        candidates.append(Path(project) / "config.yaml")
+
+    candidates.append(out_path.parent)
+
+    root = getattr(pts_meta, "root", None)
+    if root:
+        candidates.append(Path(root))
+
+    for candidate in candidates:
+        try:
+            cfg_path = find_nearest_config(candidate, max_levels=3)
+            cfg = load_config(str(cfg_path))
+            if isinstance(cfg, dict) and "multianimalproject" in cfg:
+                logger.debug("Resolved multianimalproject=True from config at %s", cfg_path)
+                return bool(cfg.get("multianimalproject", False))
+        except Exception:
+            continue
+
+    logger.debug("Could not resolve multianimalproject flag from any candidate configs.")
+    return None
+
+
 def _atomic_to_hdf(df: pd.DataFrame, out_path: Path, key: str = DLC_CANONICAL_H5_KEY) -> None:
     """Best-effort atomic write: write to temp and replace."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -453,9 +494,12 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
         pass
     df_out.sort_index(inplace=True)
 
-    # IMPORTANT:
-    # Restore canonical on-disk DLC header shape from the authoritative header.
-    df_out = restore_dlc_on_disk_header_shape(df_out, header_for_write)
+    # Restore canonical on-disk DLC header shape from the header.
+    is_ma_project = _resolve_multianimalproject_for_write(
+        out_path=out,
+        pts_meta=pts_meta,
+    )
+    df_out = restore_dlc_on_disk_header_shape(df_out, header_for_write, is_ma_project=is_ma_project)
 
     logger.debug("FINAL WRITE columns nlevels: %s", getattr(df_out.columns, "nlevels", None))
     logger.debug("FINAL WRITE columns names: %s", getattr(df_out.columns, "names", None))

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -148,7 +148,9 @@ def read_hdf(filename: str) -> list[LayerData]:
 def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[LayerData]:
     """Read a single H5 file and attach provenance with optional explicit kind.
     Dataset may be under keypoints/ or df_with_missing/ for compatibility with various DLC versions.
-    We use read_hdf without specifying a key to allow pandas to auto-detect the correct one.
+    We use _read_hdf_any_key with df_with_missing and other legacy keys,
+    and then without specifying a key to allow pandas to auto-detect the correct one.
+    See _read_hdf_any_key for details.
 
     - Produces one Points layer per H5 file
     - Points.data contains only finite coordinates

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -312,11 +312,41 @@ class KeypointStore:
         else:
             self.viewer.dims.set_current_step(0, min(unlabeled_inds))
 
+    def _clear_stale_selection_if_off_frame(self) -> None:
+        layer = self.layer
+        if not len(layer.selected_data):
+            return
+
+        try:
+            sel = np.fromiter(layer.selected_data, dtype=int)
+        except Exception:
+            layer.selected_data = set()
+            return
+
+        if sel.size == 0:
+            layer.selected_data = set()
+            return
+
+        try:
+            selected_steps = np.asarray(layer.data[sel, 0])
+        except Exception:
+            layer.selected_data = set()
+            return
+
+        # If none of the selected points belong to the current frame, clear selection.
+        if not np.any(selected_steps == self.current_step):
+            layer.selected_data = set()
+
     def add(self, coord):
         coord = np.atleast_2d(coord)
 
+        # Clear stale cross-frame selection before any logic
+        self._clear_stale_selection_if_off_frame()
+
         get_mode = getattr(self, "_get_label_mode", None)
         label_mode = get_mode() if callable(get_mode) else None
+
+        changed = False
 
         if self.current_keypoint not in self.annotated_keypoints:
             layer = self.layer
@@ -354,6 +384,7 @@ class KeypointStore:
             props["likelihood"] = np.concatenate([lik_arr, np.ones(n_new, dtype=float)])
 
             layer.properties = props
+            changed = True
 
         elif label_mode is LabelMode.QUICK:
             layer = self.layer
@@ -361,13 +392,16 @@ class KeypointStore:
             data = layer.data
             data[np.flatnonzero(self.current_mask)[ind]] = coord.squeeze()
             layer.data = data
+            changed = True
 
         self.layer.selected_data = set()
 
         if label_mode is LabelMode.LOOP:
-            self.layer.events.query_next_frame()
+            if changed:
+                self.layer.events.query_next_frame()
         else:
-            self.next_keypoint()
+            if changed:
+                self.next_keypoint()
 
 
 @deprecated(details="Temporary compat shim, remove once KeypointStore.add is properly integrated.")

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -360,7 +360,7 @@ class KeypointStore:
 
 
 @deprecated(details="Temporary compat shuim, remove once KeypointStore.add is properly integrated.")
-def _add(store: KeypointStore, coord):
+def add(store: KeypointStore, coord):
     return store.add(coord)
 
 

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -179,6 +179,8 @@ class KeypointStore:
 
     @layer.setter
     def layer(self, layer: Points):
+        same_layer = self._layer_id == id(layer)
+
         self._layer_id = id(layer)
 
         try:
@@ -188,6 +190,15 @@ class KeypointStore:
             # Fallback if a given object cannot be weak-referenced.
             self._layer_ref = None
             self._strong_layer_ref = layer
+
+        # Avoid repeated validated metadata reads when rebinding the same live layer.
+        if same_layer:
+            logger.debug(
+                "Skipping KeypointStore header refresh for same layer_id=%r name=%r",
+                self._layer_id,
+                getattr(layer, "name", layer),
+            )
+            return
 
         self._refresh_header_from_layer(layer)
 

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -370,7 +370,7 @@ class KeypointStore:
             self.next_keypoint()
 
 
-@deprecated(details="Temporary compat shuim, remove once KeypointStore.add is properly integrated.")
+@deprecated(details="Temporary compat shim, remove once KeypointStore.add is properly integrated.")
 def add(store: KeypointStore, coord):
     return store.add(coord)
 

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -179,8 +179,6 @@ class KeypointStore:
 
     @layer.setter
     def layer(self, layer: Points):
-        same_layer = self._layer_id == id(layer)
-
         self._layer_id = id(layer)
 
         try:
@@ -192,13 +190,15 @@ class KeypointStore:
             self._strong_layer_ref = layer
 
         # Avoid repeated validated metadata reads when rebinding the same live layer.
-        if same_layer:
-            logger.debug(
-                "Skipping KeypointStore header refresh for same layer_id=%r name=%r",
-                self._layer_id,
-                getattr(layer, "name", layer),
-            )
-            return
+        # NOTE: metadata/header may have changed even when layer is the same,
+        # therefore this is unsafe. Properly skipping would require checking header signatures
+        # if same_layer:
+        #     logger.debug(
+        #         "Skipping KeypointStore header refresh for same layer_id=%r name=%r",
+        #         self._layer_id,
+        #         getattr(layer, "name", layer),
+        #     )
+        #     return
 
         self._refresh_header_from_layer(layer)
 

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -1,7 +1,8 @@
 # src/napari_deeplabcut/keypoints.py
 import logging
+import weakref
 from collections import namedtuple
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from enum import auto
 
 import numpy as np
@@ -17,8 +18,13 @@ from scipy.spatial import cKDTree
 from napari_deeplabcut.config.models import DLCHeaderModel
 from napari_deeplabcut.core.metadata import read_points_meta
 from napari_deeplabcut.misc import CycleEnum, HeaderLike
+from napari_deeplabcut.utils.deprecations import deprecated
 
 logger = logging.getLogger(__name__)
+
+
+class LayerUnavailableError(RuntimeError):
+    """Raised when a KeypointStore can no longer resolve its backing layer."""
 
 
 # Monkeypatch the point size slider
@@ -44,9 +50,9 @@ QtPointsControls.changeCurrentSize = _change_size
 QtPointsControls.changeCurrentSymbol = _change_symbol
 
 
+@deprecated(details="Unused currently, should be removed.")
 def _validate_points_meta_best_effort(layer) -> bool:
     """
-    Phase-2 friendly: validate points metadata without mutating it.
     We drop header + controls during validation to avoid runtime-object issues.
     """
     res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=True)
@@ -106,21 +112,86 @@ Keypoint = namedtuple("Keypoint", ["label", "id"])
 
 
 class KeypointStore:
-    def __init__(self, viewer, layer: Points):
+    def __init__(
+        self,
+        viewer,
+        layer: Points,
+        *,
+        resolve_layer_by_id: Callable[[int], Points] | None = None,
+    ):
         self.viewer = viewer
         self._keypoints = []
         self._header: DLCHeaderModel | None = None
-        self.layer = layer
+
+        self._layer_id: int | None = None
+        self._resolve_layer_by_id = resolve_layer_by_id
+
+        # Fallback if no resolver is provided
+        self._layer_ref: weakref.ReferenceType[Points] | None = None
+        self._strong_layer_ref: Points | None = None  # Used to keep the layer alive if no resolver is provided
+
+        self.layer = layer  # Use the setter to initialize keypoints and header
+
         self.viewer.dims.set_current_step(0, 0)
 
+    def set_label_mode_getter(self, getter: Callable[[], LabelMode]):
+        self._get_label_mode = getter
+
     @property
-    def layer(self):
-        return self._layer
+    def layer_id(self) -> int | None:
+        return self._layer_id
+
+    def attach_layer_resolver(self, resolve_layer_by_id: Callable[[int], Points | None]) -> None:
+        """Attach a narrow lifecycle-owned resolver.
+
+        The resolver should accept a layer_id and return the currently live layer,
+        or None if the layer is no longer available.
+        """
+        self._resolve_layer_by_id = resolve_layer_by_id
+
+    def maybe_layer(self) -> Points | None:
+        """Resolve the current layer if still available, else return None."""
+        if self._layer_id is None:
+            return None
+
+        # Lifecycle resolver is authoritative when present.
+        if self._resolve_layer_by_id is not None:
+            try:
+                return self._resolve_layer_by_id(self._layer_id)
+            except Exception:
+                logger.debug("Layer resolver failed for layer_id=%r", self._layer_id, exc_info=True)
+                return None
+
+        # Fallback for tests / legacy contexts.
+        if self._layer_ref is not None:
+            return self._layer_ref()
+        return self._strong_layer_ref
+
+    def require_layer(self) -> Points:
+        layer = self.maybe_layer()
+        if layer is None:
+            raise LayerUnavailableError(f"Layer is no longer available for KeypointStore layer_id={self._layer_id}")
+        return layer
+
+    @property
+    def layer(self) -> Points:
+        return self.require_layer()
 
     @layer.setter
-    def layer(self, layer):
-        self._layer = layer
+    def layer(self, layer: Points):
+        self._layer_id = id(layer)
 
+        try:
+            self._layer_ref = weakref.ref(layer)
+            self._strong_layer_ref = None
+        except TypeError:
+            # Fallback if a given object cannot be weak-referenced.
+            self._layer_ref = None
+            self._strong_layer_ref = layer
+
+        self._refresh_header_from_layer(layer)
+
+    def _refresh_header_from_layer(self, layer: Points) -> None:
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
         if isinstance(res, ValidationError) or res.header is None:
             self._header = None
@@ -149,14 +220,16 @@ class KeypointStore:
 
     @property
     def annotated_keypoints(self) -> list[Keypoint]:
+        layer = self.layer
         mask = self.current_mask
-        labels = self.layer.properties["label"][mask]
-        ids = self.layer.properties["id"][mask]
+        labels = layer.properties["label"][mask]
+        ids = layer.properties["id"][mask]
         return [Keypoint(label, id_) for label, id_ in zip(labels, ids, strict=False)]
 
     @property
     def current_mask(self) -> Sequence[bool]:
-        return np.asarray(self.layer.data[:, 0] == self.current_step)
+        layer = self.layer
+        return np.asarray(layer.data[:, 0] == self.current_step)
 
     @property
     def current_keypoint(self) -> Keypoint:
@@ -173,12 +246,13 @@ class KeypointStore:
 
     @current_keypoint.setter
     def current_keypoint(self, keypoint: Keypoint):
+        layer = self.layer
         # Avoid changing the properties of a selected point
-        if not len(self.layer.selected_data):
-            current_properties = self.layer.current_properties
+        if not len(layer.selected_data):
+            current_properties = layer.current_properties
             current_properties["label"] = np.asarray([keypoint.label])
             current_properties["id"] = np.asarray([keypoint.id])
-            self.layer.current_properties = current_properties
+            layer.current_properties = current_properties
 
     def next_keypoint(self, *args):
         ind = self._keypoints.index(self.current_keypoint) + 1
@@ -196,10 +270,11 @@ class KeypointStore:
 
     @current_label.setter
     def current_label(self, label: str):
-        if not len(self.layer.selected_data):
-            current_properties = self.layer.current_properties
+        layer = self.layer
+        if not len(layer.selected_data):
+            current_properties = layer.current_properties
             current_properties["label"] = np.asarray([label])
-            self.layer.current_properties = current_properties
+            layer.current_properties = current_properties
 
     @property
     def current_id(self) -> str:
@@ -207,84 +282,89 @@ class KeypointStore:
 
     @current_id.setter
     def current_id(self, id_: str):
-        if not len(self.layer.selected_data):
-            current_properties = self.layer.current_properties
+        layer = self.layer
+        if not len(layer.selected_data):
+            current_properties = layer.current_properties
             current_properties["id"] = np.asarray([id_])
-            self.layer.current_properties = current_properties
+            layer.current_properties = current_properties
 
     def _advance_step(self, event):
         ind = (self.current_step + 1) % self.n_steps
         self.viewer.dims.set_current_step(0, ind)
 
     def _find_first_unlabeled_frame(self, event):
+        layer = self.layer
         inds = set(range(self.n_steps))
-        unlabeled_inds = inds.difference(self.layer.data[:, 0].astype(int))
+        unlabeled_inds = inds.difference(layer.data[:, 0].astype(int))
         if not unlabeled_inds:
             self.viewer.dims.set_current_step(0, self.n_steps - 1)
         else:
             self.viewer.dims.set_current_step(0, min(unlabeled_inds))
 
+    def add(self, coord):
+        coord = np.atleast_2d(coord)
 
-def _add(store, coord):
-    coord = np.atleast_2d(coord)
+        get_mode = getattr(self, "_get_label_mode", None)
+        label_mode = get_mode() if callable(get_mode) else None
 
-    # Controls are runtime-only; prefer layer attribute, fall back to metadata.
-    get_mode = getattr(store, "_get_label_mode", None)
-    label_mode = get_mode() if callable(get_mode) else None
+        if self.current_keypoint not in self.annotated_keypoints:
+            layer = self.layer
 
-    if store.current_keypoint not in store.annotated_keypoints:
-        # 1) append data
-        store.layer.data = np.append(store.layer.data, coord, axis=0)
+            # 1) append data
+            layer.data = np.append(layer.data, coord, axis=0)
 
-        # 2) append/align properties to match number of points
-        kp = store.current_keypoint
-        n_new = coord.shape[0]
-        n_total = len(store.layer.data)
-        n_old = n_total - n_new
+            # 2) append/align properties to match number of points
+            kp = self.current_keypoint
+            n_new = coord.shape[0]
+            n_total = len(layer.data)
+            n_old = n_total - n_new
 
-        props = store.layer.properties.copy()
+            props = layer.properties.copy()
 
-        def _as_array(key, dtype):
-            arr = props.get(key, None)
-            if arr is None:
-                return np.array([], dtype=dtype)
-            return np.asarray(arr, dtype=dtype)
+            def _as_array(key, dtype):
+                arr = props.get(key, None)
+                if arr is None:
+                    return np.array([], dtype=dtype)
+                return np.asarray(arr, dtype=dtype)
 
-        # Existing values truncated/padded to n_old, then append new rows
-        label_arr = _as_array("label", object)[:n_old]
-        id_arr = _as_array("id", object)[:n_old]
-        lik_arr = _as_array("likelihood", float)[:n_old]
+            label_arr = _as_array("label", object)[:n_old]
+            id_arr = _as_array("id", object)[:n_old]
+            lik_arr = _as_array("likelihood", float)[:n_old]
 
-        # If any are shorter than n_old, pad (rare but safe)
-        if label_arr.size < n_old:
-            label_arr = np.concatenate([label_arr, np.array([kp.label] * (n_old - label_arr.size), dtype=object)])
-        if id_arr.size < n_old:
-            id_arr = np.concatenate([id_arr, np.array([kp.id] * (n_old - id_arr.size), dtype=object)])
-        if lik_arr.size < n_old:
-            lik_arr = np.concatenate([lik_arr, np.ones(n_old - lik_arr.size, dtype=float)])
+            if label_arr.size < n_old:
+                label_arr = np.concatenate([label_arr, np.array([kp.label] * (n_old - label_arr.size), dtype=object)])
+            if id_arr.size < n_old:
+                id_arr = np.concatenate([id_arr, np.array([kp.id] * (n_old - id_arr.size), dtype=object)])
+            if lik_arr.size < n_old:
+                lik_arr = np.concatenate([lik_arr, np.ones(n_old - lik_arr.size, dtype=float)])
 
-        props["label"] = np.concatenate([label_arr, np.array([kp.label] * n_new, dtype=object)])
-        props["id"] = np.concatenate([id_arr, np.array([kp.id] * n_new, dtype=object)])
-        props["likelihood"] = np.concatenate([lik_arr, np.ones(n_new, dtype=float)])
+            props["label"] = np.concatenate([label_arr, np.array([kp.label] * n_new, dtype=object)])
+            props["id"] = np.concatenate([id_arr, np.array([kp.id] * n_new, dtype=object)])
+            props["likelihood"] = np.concatenate([lik_arr, np.ones(n_new, dtype=float)])
 
-        store.layer.properties = props
+            layer.properties = props
 
-    elif label_mode is LabelMode.QUICK:
-        ind = store.annotated_keypoints.index(store.current_keypoint)
-        data = store.layer.data
-        data[np.flatnonzero(store.current_mask)[ind]] = coord.squeeze()
-        store.layer.data = data
+        elif label_mode is LabelMode.QUICK:
+            layer = self.layer
+            ind = self.annotated_keypoints.index(self.current_keypoint)
+            data = layer.data
+            data[np.flatnonzero(self.current_mask)[ind]] = coord.squeeze()
+            layer.data = data
 
-    store.layer.selected_data = set()
+        self.layer.selected_data = set()
 
-    # If controls are missing, behave like the default mode (advance keypoint)
-    if label_mode is LabelMode.LOOP:
-        store.layer.events.query_next_frame()
-    else:
-        store.next_keypoint()
+        if label_mode is LabelMode.LOOP:
+            self.layer.events.query_next_frame()
+        else:
+            self.next_keypoint()
 
 
-def _find_nearest_neighbors(xy_true, xy_pred, k=5):
+@deprecated(details="Temporary compat shuim, remove once KeypointStore.add is properly integrated.")
+def _add(store: KeypointStore, coord):
+    return store.add(coord)
+
+
+def find_nearest_neighbors(xy_true, xy_pred, k=5):
     n_preds = xy_pred.shape[0]
     tree = cKDTree(xy_pred)
     dist, inds = tree.query(xy_true, k=k)

--- a/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
@@ -1,0 +1,18 @@
+from .manager import LayerLifecycleManager
+from .merge import (
+    MergeDecisionProvider,
+    MergeDecisionRequest,
+    MergeDecisionResult,
+    MergeDisposition,
+)
+from .registry import ManagedPointsRuntime, RuntimeRegistry
+
+__all__ = [
+    "LayerLifecycleManager",
+    "ManagedPointsRuntime",
+    "RuntimeRegistry",
+    "MergeDecisionProvider",
+    "MergeDecisionRequest",
+    "MergeDecisionResult",
+    "MergeDisposition",
+]

--- a/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
@@ -5,14 +5,18 @@ from .merge import (
     MergeDecisionResult,
     MergeDisposition,
 )
-from .registry import ManagedPointsRuntime, RuntimeRegistry
+from .registry import ManagedPointsRuntime, PointsLayerSetupRequest, RuntimeRegistry
+from .spawn import get_layer_manager, get_or_create_layer_manager
 
 __all__ = [
     "LayerLifecycleManager",
     "ManagedPointsRuntime",
     "RuntimeRegistry",
     "MergeDecisionProvider",
+    "PointsLayerSetupRequest",
     "MergeDecisionRequest",
     "MergeDecisionResult",
     "MergeDisposition",
+    "get_layer_manager",
+    "get_or_create_layer_manager",
 ]

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
 
-from napari.layers import Image, Points
+from napari.layers import Image, Layer, Points
 from qtpy.QtCore import QObject, QTimer, Signal
 
 from .registry import ManagedPointsRuntime, RuntimeRegistry
+
+if TYPE_CHECKING:
+    from ..keypoints import KeypointStore
 
 logger = logging.getLogger("napari-deeplabcut.lifecycle")
 
@@ -32,10 +36,13 @@ class LayerLifecycleManager(QObject):
     layer_insert_processed = Signal(object)
     layer_remove_processed = Signal(object)
 
-    def __init__(self, viewer: Any, *, owner: Any) -> None:
-        super().__init__(parent=owner)
-        self.viewer = viewer
+    def __init__(self, owner: Any) -> None:
+        if isinstance(owner, QObject):
+            super().__init__(parent=owner)
+        else:
+            super().__init__()
         self.owner = owner
+        self.viewer = owner.viewer
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
 
         self._initial_adopt_timer = QTimer(self)
@@ -43,6 +50,25 @@ class LayerLifecycleManager(QObject):
         self._initial_adopt_timer.timeout.connect(self.adopt_existing_layers)
 
         self._attached = False
+
+    def iter_managed_points(self) -> Iterator[tuple[Points, KeypointStore]]:
+        """Iterate (layer, store) pairs of currently managed points layers."""
+        for layer, runtime in self.registry.items():
+            if isinstance(layer, Points):
+                yield layer, runtime.store
+
+    def managed_points_layers(self) -> tuple[Points, ...]:
+        return tuple(layer for layer, _ in self.iter_managed_points())
+
+    def managed_points_count(self) -> int:
+        """Number of currently managed layers."""
+        # registry len() could later have non-Points entries,
+        # so this is safer
+        return sum(1 for layer, _ in self.iter_managed_points())
+
+    def has_managed_points(self) -> bool:
+        """Whether there are any currently managed layers."""
+        return self.managed_points_count() > 0
 
     # ------------------------------------------------------------------ #
     # lifecycle wiring                                                    #
@@ -86,7 +112,14 @@ class LayerLifecycleManager(QObject):
         """Check if a layer is managed here."""
         return self.registry.is_managed(layer)
 
-    def register_managed_points_layer(self, layer: Points, store: Any, **resources: Any) -> None:
+    def register_managed_layer(self, layer: Layer, store: KeypointStore, **resources: Any) -> None:
+        if isinstance(layer, Points):
+            self.register_managed_points_layer(layer, store, **resources)
+        # elif: future managed layer types
+        else:
+            raise ValueError(f"Unsupported layer type for management: {type(layer).__name__}")
+
+    def register_managed_points_layer(self, layer: Points, store: KeypointStore, **resources: Any) -> None:
         """Register a managed Points layer."""
         if self.registry.is_managed(layer):
             return
@@ -104,10 +137,6 @@ class LayerLifecycleManager(QObject):
         """Unregister a managed layer."""
         runtime = self.registry.unregister(layer)
         return None if runtime is None else runtime.store
-
-    def managed_points_layers(self) -> tuple[Points, ...]:
-        """Get all managed Points layers."""
-        return tuple(layer for layer in self.registry.layers() if isinstance(layer, Points))
 
     # ------------------------------------------------------------------ #
     # event entry points                                                 #

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -7,7 +7,12 @@ from typing import TYPE_CHECKING, Any
 from napari.layers import Image, Layer, Points
 from qtpy.QtCore import QObject, QTimer, Signal
 
-from .registry import ManagedPointsRuntime, RuntimeRegistry
+from .registry import (
+    ClearedRegistryEntry,
+    ManagedPointsRuntime,
+    RegistryAuditReport,
+    RuntimeRegistry,
+)
 
 if TYPE_CHECKING:
     from ..keypoints import KeypointStore
@@ -19,14 +24,14 @@ class LayerLifecycleManager(QObject):
     """Lifecycle wrapper around existing widget behavior.
 
     Goals
-    ----------------
-    - put a clear boundary in place
+    -----
     - centralize viewer layer event entry points
-    - keep current behavior by delegating back into small widget-owned hooks
     - own the runtime registry for managed Points layers
+    - centralize layer liveness / store resolution
+    - keep current behavior by delegating back into widget-owned hooks
 
     Non-goals (for now)
-    --------------------
+    -------------------
     - full reconciliation engine
     - moving all logic out of the widget
     - changing merge/remap policies
@@ -41,6 +46,7 @@ class LayerLifecycleManager(QObject):
             super().__init__(parent=owner)
         else:
             super().__init__()
+
         self.owner = owner
         self.viewer = owner.viewer
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
@@ -51,9 +57,28 @@ class LayerLifecycleManager(QObject):
 
         self._attached = False
 
+    # ------------------------------------------------------------------ #
+    # Centralized access API                                             #
+    # ------------------------------------------------------------------ #
+
+    def resolve_live_layer(self, layer_or_id: Any) -> Layer | None:
+        layer = self.registry.resolve_live_layer(layer_or_id)
+        return layer if isinstance(layer, Layer) else None
+
+    def get_live_runtime(self, layer_or_id: Any) -> ManagedPointsRuntime[Any] | None:
+        return self.registry.get_live_runtime(layer_or_id)
+
+    def get_store(self, layer_or_id: Any) -> KeypointStore | None:
+        store = self.registry.get_store(layer_or_id)
+        return store  # typed via TYPE_CHECKING
+
+    def require_store(self, layer_or_id: Any) -> KeypointStore:
+        store = self.registry.require_store(layer_or_id)
+        return store  # typed via TYPE_CHECKING
+
     def iter_managed_points(self) -> Iterator[tuple[Points, KeypointStore]]:
-        """Iterate (layer, store) pairs of currently managed points layers."""
-        for layer, runtime in self.registry.items():
+        """Iterate only live managed Points layers and their stores."""
+        for layer, runtime in self.registry.iter_live_items():
             if isinstance(layer, Points):
                 yield layer, runtime.store
 
@@ -61,17 +86,19 @@ class LayerLifecycleManager(QObject):
         return tuple(layer for layer, _ in self.iter_managed_points())
 
     def managed_points_count(self) -> int:
-        """Number of currently managed layers."""
-        # registry len() could later have non-Points entries,
-        # so this is safer
-        return sum(1 for layer, _ in self.iter_managed_points())
+        return sum(1 for _ in self.iter_managed_points())
 
     def has_managed_points(self) -> bool:
-        """Whether there are any currently managed layers."""
-        return self.managed_points_count() > 0
+        return any(True for _ in self.iter_managed_points())
+
+    def clear_dead_entries(self, *, log: bool = True) -> tuple[ClearedRegistryEntry[Any], ...]:
+        return self.registry.clear_dead_entries(log=log)
+
+    def audit_registry(self) -> RegistryAuditReport:
+        return self.registry.audit()
 
     # ------------------------------------------------------------------ #
-    # lifecycle wiring                                                    #
+    # Lifecycle wiring                                                   #
     # ------------------------------------------------------------------ #
 
     def attach(self) -> None:
@@ -101,45 +128,44 @@ class LayerLifecycleManager(QObject):
         self._attached = False
 
     def schedule_initial_adoption(self) -> None:
-        """Schedule adoption of existing layers after event loop starts."""
+        """Schedule adoption of existing layers after the event loop starts."""
         self._initial_adopt_timer.start(0)
 
     # ------------------------------------------------------------------ #
-    # registry façade                                                    #
+    # Registry facade                                                    #
     # ------------------------------------------------------------------ #
 
     def is_managed(self, layer: Any) -> bool:
-        """Check if a layer is managed here."""
+        """Whether this exact currently live layer is registered."""
         return self.registry.is_managed(layer)
 
     def register_managed_layer(self, layer: Layer, store: KeypointStore, **resources: Any) -> None:
         if isinstance(layer, Points):
             self.register_managed_points_layer(layer, store, **resources)
-        # elif: future managed layer types
         else:
             raise ValueError(f"Unsupported layer type for management: {type(layer).__name__}")
 
     def register_managed_points_layer(self, layer: Points, store: KeypointStore, **resources: Any) -> None:
-        """Register a managed Points layer."""
+        """Register a managed Points layer if not already registered."""
         if self.registry.is_managed(layer):
             return
 
         self.registry.register(
             layer,
             ManagedPointsRuntime(
-                layer=layer,
+                layer_id=id(layer),
                 store=store,
                 resources=dict(resources),
             ),
         )
 
-    def unregister_managed_layer(self, layer: Any) -> Any | None:
-        """Unregister a managed layer."""
-        runtime = self.registry.unregister(layer)
+    def unregister_managed_layer(self, layer_or_id: Any) -> Any | None:
+        """Unregister a managed layer by layer object or layer id."""
+        runtime = self.registry.unregister(layer_or_id)
         return None if runtime is None else runtime.store
 
     # ------------------------------------------------------------------ #
-    # event entry points                                                 #
+    # Event entry points                                                 #
     # ------------------------------------------------------------------ #
 
     def adopt_existing_layers(self) -> None:

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterator
-from functools import partial
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
@@ -75,6 +74,7 @@ class LayerLifecycleManager(QObject):
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
 
         # Lifecycle-owned viewer/image context
+        self._active_dlc_image_layer_id: int | None = None
         self._image_meta = ImageMetadata()
         self._project_path: str | None = None
 
@@ -185,6 +185,48 @@ class LayerLifecycleManager(QObject):
     def schedule_initial_adoption(self) -> None:
         """Schedule adoption of existing layers after the event loop starts."""
         self._initial_adopt_timer.start(0)
+
+    def _dlc_meta_for_layer(self, layer: Layer) -> dict | None:
+        md = layer.metadata or {}
+        if not isinstance(md, dict):
+            return None
+        payload = md.get("dlc", None)
+        return payload if isinstance(payload, dict) else None
+
+    def is_dlc_session_image_layer(self, layer: Image) -> bool:
+        payload = self._dlc_meta_for_layer(layer)
+        if not payload:
+            return False
+
+        role = payload.get("session_role", None)
+        ctx = payload.get("project_context", None)
+
+        return role in {"image", "video"} and isinstance(ctx, dict) and bool(ctx)
+
+    def active_dlc_image_layer(self) -> Image | None:
+        if self._active_dlc_image_layer_id is None:
+            return None
+        layer = self.resolve_live_layer(self._active_dlc_image_layer_id)
+        return layer if isinstance(layer, Image) else None
+
+    def can_accept_dlc_session_image(self, layer: Image) -> tuple[bool, str | None]:
+        active = self.active_dlc_image_layer()
+        if active is None:
+            return True, None
+        if active is layer:
+            return True, None
+        return (
+            False,
+            "A DLC project/video is already open. Clear the viewer layers first before opening another project.",
+        )
+
+    def _reject_conflicting_dlc_image_layer(self, layer: Image, reason: str) -> None:
+        self.viewer.status = reason
+        try:
+            if layer in self.viewer.layers:
+                self.viewer.layers.remove(layer)
+        except Exception:
+            logger.debug("Failed to remove conflicting DLC image layer", exc_info=True)
 
     # ------------------------------------------------------------------ #
     # Layer setup managers                                               #
@@ -298,6 +340,7 @@ class LayerLifecycleManager(QObject):
             except Exception:
                 pass
 
+        self._active_dlc_image_layer_id = id(layer)
         self._update_image_meta_from_layer(layer)
 
         if not self._project_path:
@@ -326,7 +369,7 @@ class LayerLifecycleManager(QObject):
         )
 
         if reorder and index is not None:
-            QTimer.singleShot(10, partial(self.owner._move_image_layer_to_bottom, index))
+            QTimer.singleShot(10, lambda ly=layer: self.owner._move_image_layer_to_bottom(ly))
 
     def _wire_points_layer(self, layer: Points) -> KeypointStore | None:
         """Lifecycle-owned wiring of a managed Points layer.
@@ -428,6 +471,23 @@ class LayerLifecycleManager(QObject):
 
         return store
 
+    def _remove_layer_if_present(self, layer: Layer) -> None:
+        try:
+            if layer in self.viewer.layers:
+                self.viewer.layers.remove(layer)
+        except Exception:
+            logger.debug("Failed to remove layer=%r", getattr(layer, "name", layer), exc_info=True)
+
+    @staticmethod
+    def _set_layer_visible(layer: Layer, visible: bool) -> None:
+        try:
+            layer.visible = visible
+        except Exception:
+            try:
+                layer.shown = visible
+            except Exception:
+                logger.debug("Failed to set visibility for layer=%r", getattr(layer, "name", layer), exc_info=True)
+
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
         """Lifecycle-owned setup for an inserted/adopted Points layer."""
         if not self.owner._validate_header(layer):
@@ -465,10 +525,19 @@ class LayerLifecycleManager(QObject):
             self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
 
         elif isinstance(layer, Image):
-            self._image_meta = ImageMetadata()
-            paths = layer.metadata.get("paths")
-            if paths is None:
-                self.owner.video_widget.setVisible(False)
+            if self._active_dlc_image_layer_id == id(layer):
+                self._active_dlc_image_layer_id = None
+                self._image_meta = ImageMetadata()
+                self._project_path = None
+
+                paths = layer.metadata.get("paths")
+                if paths is None:
+                    self.owner.video_widget.setVisible(False)
+            else:
+                logger.debug(
+                    "Removed non-session or inactive image layer=%r; keeping current DLC session context.",
+                    getattr(layer, "name", layer),
+                )
 
         elif isinstance(layer, Tracks):
             was_trails = self.owner._trails_controller.on_tracks_layer_removed(layer)
@@ -688,7 +757,7 @@ class LayerLifecycleManager(QObject):
         )
 
         if isinstance(layer, Image):
-            self._setup_image_layer(layer, getattr(event, "index", None), reorder=True)
+            self._maybe_accept_and_setup_image_layer(layer, getattr(event, "index", None))
         elif isinstance(layer, Points):
             self._setup_points_layer(layer, allow_merge=True)
 
@@ -715,6 +784,25 @@ class LayerLifecycleManager(QObject):
         self._handle_removed_layer(layer)
         self.layer_remove_processed.emit(layer)
 
+    def _maybe_accept_and_setup_image_layer(self, layer: Image, index: int | None) -> bool:
+        if not self.is_dlc_session_image_layer(layer):
+            logger.debug(
+                "Ignoring non-DLC image layer during lifecycle setup: %r",
+                getattr(layer, "name", layer),
+            )
+            return False
+
+        ok, reason = self.can_accept_dlc_session_image(layer)
+        if not ok:
+            self._reject_conflicting_dlc_image_layer(
+                layer,
+                reason or "Conflicting DLC project/video layer",
+            )
+            return False
+
+        self._setup_image_layer(layer, index, reorder=True)
+        return True
+
     def _adopt_layer(self, layer: Any, index: int) -> None:
         logger.debug(
             "Lifecycle manager adopt layer=%r type=%s index=%s",
@@ -724,7 +812,7 @@ class LayerLifecycleManager(QObject):
         )
 
         if isinstance(layer, Image):
-            self._setup_image_layer(layer, index, reorder=True)
+            self._maybe_accept_and_setup_image_layer(layer, index)
         elif isinstance(layer, Points):
             if not self.registry.is_managed(layer):
                 self._setup_points_layer(layer, allow_merge=False)

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -223,7 +223,7 @@ class LayerLifecycleManager(QObject):
                 resolve_layer_by_id=self.resolve_live_layer,
                 get_label_mode=lambda: self.owner._label_mode,
                 schedule_recolor=self.owner._schedule_recolor,
-                existing=existing_resources,
+                existing_resources=existing_resources,
             )
 
             runtime = self.get_live_runtime(layer)

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from napari.layers import Image, Points
+from qtpy.QtCore import QObject, QTimer, Signal
+
+from .registry import ManagedPointsRuntime, RuntimeRegistry
+
+logger = logging.getLogger("napari-deeplabcut.lifecycle")
+
+
+class LayerLifecycleManager(QObject):
+    """Lifecycle wrapper around existing widget behavior.
+
+    Goals
+    ----------------
+    - put a clear boundary in place
+    - centralize viewer layer event entry points
+    - keep current behavior by delegating back into small widget-owned hooks
+    - own the runtime registry for managed Points layers
+
+    Non-goals (for now)
+    --------------------
+    - full reconciliation engine
+    - moving all logic out of the widget
+    - changing merge/remap policies
+    """
+
+    adopted_existing_layers = Signal()
+    layer_insert_processed = Signal(object)
+    layer_remove_processed = Signal(object)
+
+    def __init__(self, viewer: Any, *, owner: Any) -> None:
+        super().__init__(parent=owner)
+        self.viewer = viewer
+        self.owner = owner
+        self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
+
+        self._initial_adopt_timer = QTimer(self)
+        self._initial_adopt_timer.setSingleShot(True)
+        self._initial_adopt_timer.timeout.connect(self.adopt_existing_layers)
+
+        self._attached = False
+
+    # ------------------------------------------------------------------ #
+    # lifecycle wiring                                                    #
+    # ------------------------------------------------------------------ #
+
+    def attach(self) -> None:
+        """Attach to viewer layer events."""
+        if self._attached:
+            return
+
+        self.viewer.layers.events.inserted.connect(self.on_insert)
+        self.viewer.layers.events.removed.connect(self.on_remove)
+        self._attached = True
+
+    def detach(self) -> None:
+        """Detach from viewer layer events."""
+        if not self._attached:
+            return
+
+        try:
+            self.viewer.layers.events.inserted.disconnect(self.on_insert)
+        except Exception:
+            pass
+
+        try:
+            self.viewer.layers.events.removed.disconnect(self.on_remove)
+        except Exception:
+            pass
+
+        self._attached = False
+
+    def schedule_initial_adoption(self) -> None:
+        """Schedule adoption of existing layers after event loop starts."""
+        self._initial_adopt_timer.start(0)
+
+    # ------------------------------------------------------------------ #
+    # registry façade                                                    #
+    # ------------------------------------------------------------------ #
+
+    def is_managed(self, layer: Any) -> bool:
+        """Check if a layer is managed here."""
+        return self.registry.is_managed(layer)
+
+    def register_managed_points_layer(self, layer: Points, store: Any, **resources: Any) -> None:
+        """Register a managed Points layer."""
+        if self.registry.is_managed(layer):
+            return
+
+        self.registry.register(
+            layer,
+            ManagedPointsRuntime(
+                layer=layer,
+                store=store,
+                resources=dict(resources),
+            ),
+        )
+
+    def unregister_managed_layer(self, layer: Any) -> Any | None:
+        """Unregister a managed layer."""
+        runtime = self.registry.unregister(layer)
+        return None if runtime is None else runtime.store
+
+    def managed_points_layers(self) -> tuple[Points, ...]:
+        """Get all managed Points layers."""
+        return tuple(layer for layer in self.registry.layers() if isinstance(layer, Points))
+
+    # ------------------------------------------------------------------ #
+    # event entry points                                                 #
+    # ------------------------------------------------------------------ #
+
+    def adopt_existing_layers(self) -> None:
+        logger.debug("Lifecycle manager adopting existing layers count=%d", len(self.viewer.layers))
+
+        layers_snapshot = list(self.viewer.layers)
+        for idx, layer in enumerate(layers_snapshot):
+            self._adopt_layer(layer, idx)
+
+        self.adopted_existing_layers.emit()
+
+    def on_insert(self, event: Any) -> None:
+        layer = self._resolve_inserted_layer(event)
+        if layer is None:
+            logger.debug("Lifecycle manager could not resolve inserted layer for event=%r", event)
+            return
+
+        logger.debug(
+            "Lifecycle manager processing insert layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            getattr(event, "index", None),
+        )
+
+        if isinstance(layer, Image):
+            self.owner._setup_image_layer(layer, getattr(event, "index", None), reorder=True)
+        elif isinstance(layer, Points):
+            self.owner._setup_points_layer(layer, allow_merge=True)
+
+        for layer_ in self.viewer.layers:
+            if not isinstance(layer_, Image):
+                self.owner._remap_frame_indices(layer_)
+
+        self.owner._refresh_video_panel_context()
+        self.owner._refresh_layer_status_panel()
+        self.layer_insert_processed.emit(layer)
+
+    def on_remove(self, event: Any) -> None:
+        layer = getattr(event, "value", None)
+        if layer is None:
+            logger.debug("Lifecycle manager received remove event without value: %r", event)
+            return
+
+        logger.debug(
+            "Lifecycle manager processing remove layer=%r type=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+        )
+
+        self.owner._handle_removed_layer(layer)
+        self.layer_remove_processed.emit(layer)
+
+    # ------------------------------------------------------------------ #
+    # internals                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _adopt_layer(self, layer: Any, index: int) -> None:
+        logger.debug(
+            "Lifecycle manager adopt layer=%r type=%s index=%s",
+            getattr(layer, "name", layer),
+            type(layer).__name__,
+            index,
+        )
+
+        if isinstance(layer, Image):
+            self.owner._setup_image_layer(layer, index, reorder=True)
+        elif isinstance(layer, Points):
+            if not self.registry.is_managed(layer):
+                self.owner._setup_points_layer(layer, allow_merge=False)
+
+        if not isinstance(layer, Image):
+            self.owner._remap_frame_indices(layer)
+
+    def _resolve_inserted_layer(self, event: Any) -> Any | None:
+        # Best case: event carries the inserted value directly
+        layer = getattr(event, "value", None)
+        if layer is not None:
+            return layer
+
+        # Prefer explicit event index over “last item in source”
+        index = getattr(event, "index", None)
+        if isinstance(index, int):
+            try:
+                return self.viewer.layers[index]
+            except Exception:
+                pass
+
+        # Conservative fallback only
+        source = getattr(event, "source", None)
+        try:
+            if source:
+                return source[-1]
+        except Exception:
+            pass
+
+        return None

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -13,14 +13,22 @@ from napari.utils.history import update_save_history
 from qtpy.QtCore import QObject, QSignalBlocker, QTimer, Signal
 
 from ...config.keybinds import install_points_layer_keybindings
-from ...config.models import ImageMetadata
+from ...config.models import ImageMetadata, PointsMetadata
 from ...core import keypoints
 from ...core.layer_versioning import mark_layer_presentation_changed
-from ...core.metadata import migrate_points_layer_metadata
+from ...core.metadata import (
+    MergePolicy,
+    infer_image_root,
+    migrate_points_layer_metadata,
+    read_points_meta,
+    sync_points_from_image,
+    write_points_meta,
+)
 from ...core.project_paths import PathMatchPolicy
 from ...core.remap import remap_layer_data_by_paths
 from ...napari_compat import install_add_wrapper, install_paste_patch
 from ...napari_compat.points_layer import make_paste_data
+from ...ui.cropping import resolve_project_path_from_image_layer
 from .registry import (
     ClearedRegistryEntry,
     ManagedPointsRuntime,
@@ -65,6 +73,10 @@ class LayerLifecycleManager(QObject):
         self.owner = owner
         self.viewer = owner.viewer
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
+
+        # Lifecycle-owned viewer/image context
+        self._image_meta = ImageMetadata()
+        self._project_path: str | None = None
 
         self._initial_adopt_timer = QTimer(self)
         self._initial_adopt_timer.setSingleShot(True)
@@ -113,6 +125,34 @@ class LayerLifecycleManager(QObject):
         return self.registry.audit()
 
     # ------------------------------------------------------------------ #
+    # lifecycle-owned image/project context                              #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def image_meta(self) -> ImageMetadata:
+        return self._image_meta
+
+    @property
+    def project_path(self) -> str | None:
+        return self._project_path
+
+    @project_path.setter
+    def project_path(self, value: str | None) -> None:
+        self._project_path = value
+
+    @property
+    def image_root(self) -> str | None:
+        return self._image_meta.root
+
+    @property
+    def image_paths(self) -> list[str] | None:
+        return self._image_meta.paths
+
+    @property
+    def image_name(self) -> str | None:
+        return self._image_meta.name
+
+    # ------------------------------------------------------------------ #
     # Lifecycle wiring                                                   #
     # ------------------------------------------------------------------ #
 
@@ -149,32 +189,123 @@ class LayerLifecycleManager(QObject):
     # ------------------------------------------------------------------ #
     # Layer setup managers                                               #
     # ------------------------------------------------------------------ #
-    def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
-        """Lifecycle-owned setup for an inserted/adopted Image layer.
+    @staticmethod
+    def _layer_source_path(layer) -> str | None:
+        """Best-effort access to napari layer source path (may not exist)."""
+        try:
+            src = getattr(layer, "source", None)
+            p = getattr(src, "path", None) if src is not None else None
+            return str(p) if p else None
+        except Exception:
+            return None
 
-        Transitional note:
-        ------------------
-        For now this still uses owner-held image/project context fields and UI hooks.
-        Step 2 should move image/project context ownership into the manager itself.
-        """
+    def _update_image_meta_from_layer(self, layer: Image) -> None:
+        """Update lifecycle-owned image metadata from an Image layer."""
+        md = layer.metadata or {}
+
+        paths = md.get("paths")
+        try:
+            shape = layer.level_shapes[0]
+        except Exception:
+            shape = None
+
+        root = infer_image_root(
+            explicit_root=md.get("root"),
+            paths=paths,
+            source_path=self._layer_source_path(layer),
+        )
+
+        incoming = ImageMetadata(
+            paths=list(paths) if paths else None,
+            root=str(root) if root else None,
+            shape=tuple(shape) if shape is not None else None,
+            name=getattr(layer, "name", None),
+        )
+
+        base = self._image_meta
+        merged = base.model_copy(deep=True)
+        for field, value in incoming.model_dump().items():
+            if getattr(merged, field) in (None, "", []) and value not in (None, "", []):
+                setattr(merged, field, value)
+
+        self._image_meta = merged
+
+    def _sync_points_layers_from_image_meta(self) -> None:
+        """Sync managed/all points metadata from lifecycle-owned image context."""
+        if self._image_meta is None:
+            return
+
+        for ly in list(self.viewer.layers):
+            if not isinstance(ly, Points):
+                continue
+
+            if ly.metadata is None:
+                ly.metadata = {}
+
+            res = read_points_meta(ly, migrate_legacy=True, drop_controls=False, drop_header=False)
+            if hasattr(res, "errors"):
+                logger.warning(
+                    "Points metadata validation failed during sync for layer=%r: %s",
+                    getattr(ly, "name", ly),
+                    res,
+                )
+                continue
+
+            pts_model: PointsMetadata = res
+            synced = sync_points_from_image(self._image_meta, pts_model)
+
+            out = write_points_meta(
+                ly,
+                synced,
+                merge_policy=MergePolicy.MERGE_MISSING,
+                migrate_legacy=True,
+                validate=True,
+            )
+            if hasattr(out, "errors"):
+                logger.warning(
+                    "Failed to write synced points metadata for layer=%r: %s",
+                    getattr(ly, "name", ly),
+                    out,
+                )
+
+    def _cache_project_path_from_image_layer(self, layer: Image) -> None:
+        """Best-effort lifecycle-owned cache of project path from an image/video layer."""
+        project_path = resolve_project_path_from_image_layer(layer)
+        if project_path is None:
+            return
+
+        self._project_path = project_path
+        try:
+            layer.metadata = dict(layer.metadata or {})
+            layer.metadata.setdefault("project", self._project_path)
+        except Exception:
+            logger.debug(
+                "Failed to set project path metadata on image layer %r",
+                getattr(layer, "name", layer),
+                exc_info=True,
+            )
+
+        self.owner._refresh_video_panel_context()
+
+    def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
+        """Lifecycle-owned setup for an inserted/adopted Image layer."""
         md = layer.metadata or {}
         paths = md.get("paths")
         if paths is None:
             try:
-                if self.owner.io.is_video(layer.name):  # optional if owner exposes io
+                if self.owner.io.is_video(layer.name):
                     self.owner.video_widget.setVisible(True)
             except Exception:
                 pass
 
-        # Transitional: owner still stores image/project context.
-        self.owner._update_image_meta_from_layer(layer)
+        self._update_image_meta_from_layer(layer)
 
-        if not self.owner._project_path:
-            self.owner._cache_project_path_from_image_layer(layer)
-            if self.owner._project_path is not None:
+        if not self._project_path:
+            self._cache_project_path_from_image_layer(layer)
+            if self._project_path is not None:
                 try:
                     layer.metadata = dict(layer.metadata or {})
-                    layer.metadata.setdefault("project", self.owner._project_path)
+                    layer.metadata.setdefault("project", self._project_path)
                 except Exception:
                     logger.debug(
                         "Failed to set project path metadata on image layer %r",
@@ -182,7 +313,7 @@ class LayerLifecycleManager(QObject):
                         exc_info=True,
                     )
 
-        self.owner._sync_points_layers_from_image_meta()
+        self._sync_points_layers_from_image_meta()
         self.owner._refresh_video_panel_context()
 
         logger.debug(
@@ -260,11 +391,14 @@ class LayerLifecycleManager(QObject):
         layer._dlc_store = store
         layer._dlc_controls = self.owner
 
-        # Transitional: owner still stores image/project context.
-        if not layer.metadata.get("root") and self.owner._image_meta.root:
-            layer.metadata["root"] = self.owner._image_meta.root
-        if not layer.metadata.get("paths") and self.owner._image_meta.paths:
-            layer.metadata["paths"] = self.owner._image_meta.paths
+        proj = layer.metadata.get("project")
+        if proj:
+            self._project_path = proj
+
+        if not layer.metadata.get("root") and self._image_meta.root:
+            layer.metadata["root"] = self._image_meta.root
+        if not layer.metadata.get("paths") and self._image_meta.paths:
+            layer.metadata["paths"] = self._image_meta.paths
 
         if root := layer.metadata.get("root"):
             update_save_history(root)
@@ -331,8 +465,7 @@ class LayerLifecycleManager(QObject):
             self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
 
         elif isinstance(layer, Image):
-            # Transitional: owner still stores image context.
-            self.owner._image_meta = ImageMetadata()
+            self._image_meta = ImageMetadata()
             paths = layer.metadata.get("paths")
             if paths is None:
                 self.owner.video_widget.setVisible(False)
@@ -349,7 +482,7 @@ class LayerLifecycleManager(QObject):
     def _remap_frame_indices(self, layer: Any) -> None:
         """Lifecycle-owned remap of non-Image layer time/frame indices."""
         try:
-            new_paths = self.owner._image_meta.paths
+            new_paths = self._image_meta.paths
             if not new_paths:
                 return
 
@@ -360,7 +493,7 @@ class LayerLifecycleManager(QObject):
             old_paths = md.get("paths") or []
 
             try:
-                safe_image_meta = self.owner._image_meta.model_dump(exclude_none=True)
+                safe_image_meta = self._image_meta.model_dump(exclude_none=True)
                 safe_image_meta.pop("paths", None)
                 layer.metadata.update(safe_image_meta)
             except Exception:

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -63,6 +63,9 @@ class LayerLifecycleManager(QObject):
     layer_insert_processed = Signal(object)
     layer_remove_processed = Signal(object)
 
+    # Session management
+    session_conflict_rejected = Signal(str)  # if a new DLC folder is loaded on top of the current one
+
     def __init__(self, owner: Any) -> None:
         if isinstance(owner, QObject):
             super().__init__(parent=owner)
@@ -221,16 +224,36 @@ class LayerLifecycleManager(QObject):
             return True, None
         return (
             False,
-            "A DLC project/video is already open. Clear the viewer layers first before opening another project.",
+            "A DLC project/video is already open.\n"
+            "The plugin will attempt to load annotations from the new project, "
+            "but will not load the video.\n\n"
+            "If you meant to load extra annotations for the current video, "
+            "please only load the corresponding h5 files.\n"
+            "If you meant to switch to a different project/video, "
+            "please save and clear the current layers before loading the new labeled data folder.",
         )
 
     def _reject_conflicting_dlc_image_layer(self, layer: Image, reason: str) -> None:
+        """Reject a conflicting DLC session image safely.
+
+        Do not remove synchronously inside the insert callback:
+        napari may still be finalizing list insertion / selection.
+        """
         self.viewer.status = reason
-        try:
-            if layer in self.viewer.layers:
-                self.viewer.layers.remove(layer)
-        except Exception:
-            logger.debug("Failed to remove conflicting DLC image layer", exc_info=True)
+        self.session_conflict_rejected.emit(reason)
+
+        def _remove_later(ly=layer):
+            try:
+                if ly in self.viewer.layers:
+                    self.viewer.layers.remove(ly)
+            except Exception:
+                logger.debug(
+                    "Failed to remove conflicting DLC image layer %r",
+                    getattr(ly, "name", ly),
+                    exc_info=True,
+                )
+
+        QTimer.singleShot(0, _remove_later)
 
     # ------------------------------------------------------------------ #
     # Layer setup managers                                               #

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -9,11 +9,12 @@ import numpy as np
 from napari.layers import Image, Layer, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import update_save_history
-from qtpy.QtCore import QObject, QSignalBlocker, QTimer, Signal
+from qtpy.QtCore import QObject, QTimer, Signal
 
 from ...config.keybinds import install_points_layer_keybindings
-from ...config.models import ImageMetadata, PointsMetadata
+from ...config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
 from ...core import keypoints
+from ...core.io import is_video
 from ...core.layer_versioning import mark_layer_presentation_changed
 from ...core.metadata import (
     MergePolicy,
@@ -29,15 +30,19 @@ from ...napari_compat import install_add_wrapper, install_paste_patch
 from ...napari_compat.points_layer import make_paste_data
 from ...ui.cropping import resolve_project_path_from_image_layer
 from ...utils.debug import log_timing
+from .merge import MergeDecisionProvider, MergeDecisionRequest, MergeDecisionResult, MergeDisposition
 from .registry import (
     ClearedRegistryEntry,
     ManagedPointsRuntime,
+    PointsLayerSetupRequest,
     PointsRuntimeResources,
     RegistryAuditReport,
     RuntimeRegistry,
 )
 
 if TYPE_CHECKING:
+    import napari
+
     from ..keypoints import KeypointStore
 
 logger = logging.getLogger("napari-deeplabcut.lifecycle")
@@ -60,6 +65,19 @@ class LayerLifecycleManager(QObject):
     - changing merge/remap policies
     """
 
+    # UI signals for widget hooks
+    refresh_video_panel_requested = Signal()
+    refresh_layer_status_requested = Signal()
+    video_widget_visibility_requested = Signal(bool)
+    move_image_layer_to_bottom_requested = Signal(object)
+
+    # Layer setup/teardown
+    points_layer_setup_requested = Signal(object)  # PointsLayerSetupRequest
+    points_layers_merged_requested = Signal(object)  # tuple[Points, ...]
+    points_layer_removed_requested = Signal(object, int)  # layer, remaining_points_layers
+    tracks_layer_removed_requested = Signal(object)
+
+    # Layer insertion/adoption
     adopted_existing_layers = Signal()
     layer_insert_processed = Signal(object)
     layer_remove_processed = Signal(object)
@@ -67,15 +85,12 @@ class LayerLifecycleManager(QObject):
     # Session management
     session_conflict_rejected = Signal(str)  # if a new DLC folder is loaded on top of the current one
 
-    def __init__(self, owner: Any) -> None:
-        if isinstance(owner, QObject):
-            super().__init__(parent=owner)
-        else:
-            super().__init__()
+    def __init__(self, viewer: napari.Viewer, *, parent: QObject | None = None) -> None:
+        super().__init__(parent=parent)
 
-        self.owner = owner
-        self.viewer = owner.viewer
+        self.viewer = viewer
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
+        self._merge_decision_provider: MergeDecisionProvider | None = None
 
         # Lifecycle-owned viewer/image context
         self._active_dlc_image_layer_id: int | None = None
@@ -133,6 +148,9 @@ class LayerLifecycleManager(QObject):
 
     def audit_registry(self) -> RegistryAuditReport:
         return self.registry.audit()
+
+    def set_merge_decision_provider(self, provider: MergeDecisionProvider | None) -> None:
+        self._merge_decision_provider = provider
 
     # ------------------------------------------------------------------ #
     # lifecycle-owned image/project context                              #
@@ -275,6 +293,85 @@ class LayerLifecycleManager(QObject):
         except Exception:
             return None
 
+    @staticmethod
+    def get_header_model_from_metadata(md: dict) -> DLCHeaderModel | None:
+        """Return DLCHeaderModel from metadata payload, if possible."""
+        if not isinstance(md, dict):
+            return None
+
+        hdr = md.get("header", None)
+        if hdr is None:
+            return None
+
+        if isinstance(hdr, DLCHeaderModel):
+            return hdr
+
+        if isinstance(hdr, dict):
+            try:
+                return DLCHeaderModel.model_validate(hdr)
+            except Exception:
+                return None
+
+        try:
+            return DLCHeaderModel(columns=hdr)
+        except Exception:
+            return None
+
+    @staticmethod
+    def is_multianimal(layer) -> bool:
+        """Return True if this layer looks like a multi-animal Points layer."""
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        md = layer.metadata or {}
+        hdr = LayerLifecycleManager.get_header_model_from_metadata(md)
+        if hdr is None:
+            return False
+
+        try:
+            inds = hdr.individuals
+            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+        except Exception:
+            return False
+
+    @staticmethod
+    def is_config_placeholder_points_layer(layer: Points) -> bool:
+        """Return True if this looks like the temporary config placeholder layer.
+
+        - must be a Points layer
+        - must carry a project hint
+        - must not already be tied to image/root/paths context
+        - must not contain actual point data
+        """
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        md = layer.metadata or {}
+        if not md.get("project"):
+            return False
+
+        # Real labeled/prediction layers usually carry image/root/paths context.
+        if md.get("root") or md.get("paths"):
+            return False
+
+        try:
+            data = np.asarray(layer.data) if layer.data is not None else np.empty((0, 3))
+        except Exception:
+            data = np.empty((0, 3))
+
+        return data.size == 0
+
+    @staticmethod
+    def validate_header(layer: Points) -> bool:
+        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
+        if hasattr(res, "errors") or getattr(res, "header", None) is None:
+            # self.viewer.status = (
+            #     "This Points layer does not look like a DLC keypoints layer. Missing a valid DLC header."
+            # )
+            logger.debug("Points layer %r failed DLC header validation: %s", getattr(layer, "name", layer), res)
+            return False
+        return True
+
     def _update_image_meta_from_layer(self, layer: Image) -> bool:
         """Update lifecycle-owned image metadata from an Image layer.
 
@@ -369,7 +466,7 @@ class LayerLifecycleManager(QObject):
                 exc_info=True,
             )
 
-        self.owner._refresh_video_panel_context()
+        self.refresh_video_panel_requested.emit()
 
     def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
         """Lifecycle-owned setup for an inserted/adopted Image layer."""
@@ -377,8 +474,8 @@ class LayerLifecycleManager(QObject):
         paths = md.get("paths")
         if paths is None:
             try:
-                if self.owner.io.is_video(layer.name):
-                    self.owner.video_widget.setVisible(True)
+                if is_video(layer.name):
+                    self.video_widget_visibility_requested.emit(True)
             except Exception:
                 pass
 
@@ -401,7 +498,7 @@ class LayerLifecycleManager(QObject):
         if context_changed:
             self._sync_points_layers_from_image_meta()
 
-        self.owner._refresh_video_panel_context()
+        self.refresh_video_panel_requested.emit()
 
         logger.debug(
             "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r context_changed=%s",
@@ -414,16 +511,15 @@ class LayerLifecycleManager(QObject):
         )
 
         if reorder and index is not None:
-            QTimer.singleShot(10, lambda ly=layer: self.owner._move_image_layer_to_bottom(ly))
+            QTimer.singleShot(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
 
     def _wire_points_layer(self, layer: Points) -> KeypointStore | None:
         """Lifecycle-owned wiring of a managed Points layer.
 
-        Transitional note:
-        ------------------
-        The manager owns runtime attachment; the widget still owns UI completion hooks.
+        The manager owns registration and lifecycle sequencing.
+        Runtime/UI completion is delegated via points_layer_setup_requested.
         """
-        if not self.owner._validate_header(layer):
+        if not self.validate_header(layer):
             return None
 
         existing = getattr(layer, "_dlc_store", None)
@@ -435,21 +531,17 @@ class LayerLifecycleManager(QObject):
             if runtime is not None:
                 existing_resources = runtime.resources.get("points_runtime", None)
 
-            resources = self.attach_points_layer_runtime(
+            req = PointsLayerSetupRequest(
                 layer=layer,
                 store=existing,
-                controls=self.owner,
-                resolve_layer_by_id=self.resolve_live_layer,
-                get_label_mode=lambda: self.owner._label_mode,
-                schedule_recolor=self.owner._schedule_recolor,
                 existing_resources=existing_resources,
             )
+            self.points_layer_setup_requested.emit(req)
 
             runtime = self.get_live_runtime(layer)
-            if runtime is not None:
-                runtime.resources["points_runtime"] = resources
+            if runtime is not None and req.runtime_resources is not None:
+                runtime.resources["points_runtime"] = req.runtime_resources
 
-            layer._dlc_controls = self.owner
             return existing
 
         mig = migrate_points_layer_metadata(layer)
@@ -463,21 +555,7 @@ class LayerLifecycleManager(QObject):
         store = keypoints.KeypointStore(self.viewer, layer)
         self.register_managed_points_layer(layer, store)
 
-        resources = self.attach_points_layer_runtime(
-            layer=layer,
-            store=store,
-            controls=self.owner,
-            resolve_layer_by_id=self.resolve_live_layer,
-            get_label_mode=lambda: self.owner._label_mode,
-            schedule_recolor=self.owner._schedule_recolor,
-        )
-
-        runtime = self.get_live_runtime(layer)
-        if runtime is not None:
-            runtime.resources["points_runtime"] = resources
-
         layer._dlc_store = store
-        layer._dlc_controls = self.owner
 
         proj = layer.metadata.get("project")
         if proj:
@@ -493,16 +571,12 @@ class LayerLifecycleManager(QObject):
 
         layer.text.visible = False
 
-        if self.managed_points_count() == 1 and self.owner._is_multianimal(layer):
-            self.owner._color_mode = keypoints.ColorMode.INDIVIDUAL
-            for btn in self.owner._color_mode_selector.buttons():
-                if btn.text().lower() == str(self.owner._color_mode).lower():
-                    btn.setChecked(True)
-                    break
+        req = PointsLayerSetupRequest(layer=layer, store=store)
+        self.points_layer_setup_requested.emit(req)
 
-        # Transitional: widget still owns these UI-adjacent helpers.
-        self.owner._maybe_initialize_layer_point_size_from_config(layer)
-        self.owner._connect_layer_status_events(layer)
+        runtime = self.get_live_runtime(layer)
+        if runtime is not None and req.runtime_resources is not None:
+            runtime.resources["points_runtime"] = req.runtime_resources
 
         md = layer.metadata or {}
         logger.debug(
@@ -540,12 +614,11 @@ class LayerLifecycleManager(QObject):
 
     def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
         """Lifecycle-owned setup for an inserted/adopted Points layer."""
-        if not self.owner._validate_header(layer):
+        if not self.validate_header(layer):
             return
 
-        # Transitional: merge policy still lives in the widget for now.
         if allow_merge:
-            consumed = self.owner._maybe_merge_config_points_layer(layer)
+            consumed = self._maybe_merge_config_points_layer(layer)
             if consumed:
                 logger.debug(
                     "Consumed temporary config placeholder layer=%r during merge path",
@@ -556,9 +629,6 @@ class LayerLifecycleManager(QObject):
         store = self._wire_points_layer(layer)
         if store is None:
             return
-
-        # Widget owns UI completion only.
-        self.owner._complete_points_layer_ui_setup(layer, store)
 
         logger.debug(
             "Setup points layer=%r allow_merge=%s metadata_keys=%s",
@@ -573,17 +643,8 @@ class LayerLifecycleManager(QObject):
 
     def _flush_post_remove_refresh(self) -> None:
         with log_timing(logger, "_flush_post_remove_refresh total", threshold_ms=0.01):
-            try:
-                with log_timing(logger, "_refresh_video_panel_context", threshold_ms=0.01):
-                    self.owner._refresh_video_panel_context()
-            except Exception:
-                logger.debug("Failed to refresh video panel context after removal", exc_info=True)
-
-            try:
-                with log_timing(logger, "_refresh_layer_status_panel", threshold_ms=0.01):
-                    self.owner._refresh_layer_status_panel()
-            except Exception:
-                logger.debug("Failed to refresh layer status panel after removal", exc_info=True)
+            self.refresh_video_panel_requested.emit()
+            self.refresh_layer_status_requested.emit()
 
     def _handle_removed_layer(self, layer: Any) -> None:
         """Lifecycle-owned remove handling.
@@ -605,14 +666,15 @@ class LayerLifecycleManager(QObject):
                     f"unregister_managed_layer layer={getattr(layer, 'name', layer)!r}",
                     threshold_ms=0.01,
                 ):
-                    self.unregister_managed_layer(layer)
+                    store = self.unregister_managed_layer(layer)
 
-                with log_timing(
-                    logger,
-                    f"_on_points_layer_removed_ui layer={getattr(layer, 'name', layer)!r}",
-                    threshold_ms=0.01,
-                ):
-                    self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
+                if store is not None:
+                    with log_timing(
+                        logger,
+                        f"points_layer_removed_requested layer={getattr(layer, 'name', layer)!r}",
+                        threshold_ms=0.01,
+                    ):
+                        self.points_layer_removed_requested.emit(layer, n_points_layer)
 
             elif isinstance(layer, Image):
                 if self._active_dlc_image_layer_id == id(layer):
@@ -622,7 +684,7 @@ class LayerLifecycleManager(QObject):
 
                     paths = layer.metadata.get("paths")
                     if paths is None:
-                        self.owner.video_widget.setVisible(False)
+                        self.video_widget_visibility_requested.emit(False)
                 else:
                     logger.debug(
                         "Removed non-session or inactive image layer=%r; keeping current DLC session context.",
@@ -630,15 +692,7 @@ class LayerLifecycleManager(QObject):
                     )
 
             elif isinstance(layer, Tracks):
-                with log_timing(
-                    logger,
-                    f"tracks removal hook layer={getattr(layer, 'name', layer)!r}",
-                    threshold_ms=0.01,
-                ):
-                    was_trails = self.owner._trails_controller.on_tracks_layer_removed(layer)
-                if was_trails:
-                    with QSignalBlocker(self.owner._trail_cb):
-                        self.owner._trail_cb.setChecked(False)
+                self.tracks_layer_removed_requested.emit(layer)
 
             self._schedule_post_remove_refresh()
 
@@ -727,6 +781,177 @@ class LayerLifecycleManager(QObject):
 
         except Exception:
             logger.exception("Failed to remap frame indices for layer %s", getattr(layer, "name", str(layer)))
+
+    def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
+        """Merge a temporary config placeholder layer into existing managed layers.
+
+        Returns
+        -------
+        bool
+            True if the placeholder layer was consumed by the merge flow
+            (including explicit HIDE_NEW / CANCEL handling), else False.
+        """
+        if not self.is_config_placeholder_points_layer(layer):
+            return False
+
+        managed = list(self.iter_managed_points())
+        if not managed:
+            return False
+
+        md = layer.metadata or {}
+        logger.debug(
+            "Maybe merge config placeholder layer=%r project=%r managed_layers=%d",
+            getattr(layer, "name", layer),
+            md.get("project"),
+            len(managed),
+        )
+
+        new_metadata = md.copy()
+        new_header = self.get_header_model_from_metadata(new_metadata)
+        if new_header is None:
+            logger.debug(
+                "Skipping config placeholder merge for layer=%r: missing/invalid header",
+                getattr(layer, "name", layer),
+            )
+            return False
+
+        reference_layer, _reference_store = managed[0]
+        reference_header = self.get_header_model_from_metadata(reference_layer.metadata or {})
+        if reference_header is None:
+            logger.debug(
+                "Skipping config placeholder merge for layer=%r: reference managed layer has no valid header",
+                getattr(layer, "name", layer),
+            )
+            return False
+
+        current_keypoint_set = set(reference_header.bodyparts)
+        new_keypoint_set = set(new_header.bodyparts)
+        diff = tuple(sorted(new_keypoint_set.difference(current_keypoint_set)))
+
+        visible_existing_layer = None
+        for managed_layer, _store in managed:
+            if managed_layer is layer:
+                continue
+            try:
+                if getattr(managed_layer, "visible", True):
+                    visible_existing_layer = managed_layer
+                    break
+            except Exception:
+                visible_existing_layer = managed_layer
+                break
+
+        message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found." if diff else ""
+
+        decision = self._resolve_merge_decision(
+            new_layer=layer,
+            existing_layers=tuple(ly for ly, _ in managed if ly is not layer),
+            added_keypoints=diff,
+            message=message,
+        )
+
+        disposition = decision.disposition
+
+        # Optional visibility policy before merge
+        if disposition is MergeDisposition.HIDE_EXISTING and visible_existing_layer is not None:
+            self._set_layer_visible(visible_existing_layer, False)
+            logger.debug(
+                "Config placeholder merge layer=%r hid_existing_layer=%r",
+                getattr(layer, "name", layer),
+                getattr(visible_existing_layer, "name", visible_existing_layer),
+            )
+
+        if disposition is MergeDisposition.HIDE_NEW:
+            QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+            return True
+
+        if disposition is MergeDisposition.CANCEL:
+            # Conservative behavior: stop lifecycle setup and leave the placeholder
+            # layer untouched/unmanaged for now.
+            logger.debug(
+                "Config placeholder merge cancelled for layer=%r",
+                getattr(layer, "name", layer),
+            )
+            return True
+
+        if diff:
+            self.viewer.status = message
+
+        # Merge header into all managed layers.
+        affected_layers: list[Points] = []
+        for managed_layer, store in managed:
+            pts = read_points_meta(
+                managed_layer,
+                migrate_legacy=True,
+                drop_controls=True,
+                drop_header=False,
+            )
+            if not hasattr(pts, "errors"):
+                updated = pts.model_copy(update={"header": new_header})
+                write_points_meta(
+                    managed_layer,
+                    updated,
+                    merge_policy=MergePolicy.MERGE,
+                    fields={"header"},
+                )
+            store.layer = managed_layer
+            affected_layers.append(managed_layer)
+
+        # Apply updated presentation metadata to existing managed layers.
+        for managed_layer, store in managed:
+            managed_layer.metadata["config_colormap"] = new_metadata.get(
+                "config_colormap",
+                managed_layer.metadata.get("config_colormap"),
+            )
+            if "face_color_cycles" in new_metadata:
+                managed_layer.metadata["face_color_cycles"] = new_metadata["face_color_cycles"]
+            managed_layer.metadata["colormap_name"] = new_metadata.get(
+                "colormap_name",
+                managed_layer.metadata.get("colormap_name"),
+            )
+
+            mark_layer_presentation_changed(managed_layer)
+            store.layer = managed_layer
+
+        # Ask UI consumers to refresh menus/colors based on updated managed layers.
+        self.points_layers_merged_requested.emit(tuple(affected_layers))
+
+        # Remove the temporary placeholder layer explicitly by identity.
+        QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+
+        # General panel refreshes
+        self.refresh_layer_status_requested.emit()
+
+        return True
+
+    def _resolve_merge_decision(
+        self,
+        *,
+        new_layer: Any,
+        existing_layers: tuple[Any, ...],
+        added_keypoints: tuple[str, ...],
+        message: str,
+    ) -> MergeDecisionResult:
+        provider = self._merge_decision_provider
+        if provider is None:
+            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+
+        req = MergeDecisionRequest(
+            new_layer=new_layer,
+            existing_layers=existing_layers,
+            added_keypoints=added_keypoints,
+            message=message,
+        )
+
+        try:
+            result = provider.resolve_merge(req)
+        except Exception:
+            logger.debug("Merge decision provider failed; defaulting to KEEP_BOTH", exc_info=True)
+            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+
+        if result is None:
+            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+
+        return result
 
     def attach_points_layer_runtime(
         self,
@@ -866,8 +1091,8 @@ class LayerLifecycleManager(QObject):
                 if not isinstance(layer_, Image):
                     self._remap_frame_indices(layer_)
 
-        self.owner._refresh_video_panel_context()
-        self.owner._refresh_layer_status_panel()
+        self.refresh_video_panel_requested.emit()
+        self.refresh_layer_status_requested.emit()
         self.layer_insert_processed.emit(layer)
 
     def on_remove(self, event: Any) -> None:

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -330,7 +330,8 @@ class LayerLifecycleManager(QObject):
 
         try:
             inds = hdr.individuals
-            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+            # return bool(inds and len(inds) > 0 and str(inds[0]) != "")
+            return any(str(ind) != "" for ind in inds)
         except Exception:
             return False
 

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -81,9 +81,15 @@ class LayerLifecycleManager(QObject):
         self._image_meta = ImageMetadata()
         self._project_path: str | None = None
 
+        # Layers management
+        ## Layer insertion
         self._initial_adopt_timer = QTimer(self)
         self._initial_adopt_timer.setSingleShot(True)
         self._initial_adopt_timer.timeout.connect(self.adopt_existing_layers)
+        ## Layer removal
+        self._post_remove_refresh_timer = QTimer(self)
+        self._post_remove_refresh_timer.setSingleShot(True)
+        self._post_remove_refresh_timer.timeout.connect(self._flush_post_remove_refresh)
 
         self._attached = False
 
@@ -268,8 +274,14 @@ class LayerLifecycleManager(QObject):
         except Exception:
             return None
 
-    def _update_image_meta_from_layer(self, layer: Image) -> None:
-        """Update lifecycle-owned image metadata from an Image layer."""
+    def _update_image_meta_from_layer(self, layer: Image) -> bool:
+        """Update lifecycle-owned image metadata from an Image layer.
+
+        Returns
+        -------
+        bool
+            True if the authoritative image context changed, else False.
+        """
         md = layer.metadata or {}
 
         paths = md.get("paths")
@@ -297,7 +309,9 @@ class LayerLifecycleManager(QObject):
             if getattr(merged, field) in (None, "", []) and value not in (None, "", []):
                 setattr(merged, field, value)
 
+        changed = merged != self._image_meta
         self._image_meta = merged
+        return changed
 
     def _sync_points_layers_from_image_meta(self) -> None:
         """Sync managed/all points metadata from lifecycle-owned image context."""
@@ -368,7 +382,7 @@ class LayerLifecycleManager(QObject):
                 pass
 
         self._active_dlc_image_layer_id = id(layer)
-        self._update_image_meta_from_layer(layer)
+        context_changed = self._update_image_meta_from_layer(layer)
 
         if not self._project_path:
             self._cache_project_path_from_image_layer(layer)
@@ -383,16 +397,19 @@ class LayerLifecycleManager(QObject):
                         exc_info=True,
                     )
 
-        self._sync_points_layers_from_image_meta()
+        if context_changed:
+            self._sync_points_layers_from_image_meta()
+
         self.owner._refresh_video_panel_context()
 
         logger.debug(
-            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r",
+            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r context_changed=%s",
             getattr(layer, "name", layer),
             index,
             reorder,
             len(md.get("paths") or []),
             md.get("root"),
+            context_changed,
         )
 
         if reorder and index is not None:
@@ -544,6 +561,21 @@ class LayerLifecycleManager(QObject):
             sorted((layer.metadata or {}).keys()),
         )
 
+    def _schedule_post_remove_refresh(self) -> None:
+        """Coalesce repeated UI refreshes during layer removal bursts."""
+        self._post_remove_refresh_timer.start(0)
+
+    def _flush_post_remove_refresh(self) -> None:
+        try:
+            self.owner._refresh_video_panel_context()
+        except Exception:
+            logger.debug("Failed to refresh video panel context after removal", exc_info=True)
+
+        try:
+            self.owner._refresh_layer_status_panel()
+        except Exception:
+            logger.debug("Failed to refresh layer status panel after removal", exc_info=True)
+
     def _handle_removed_layer(self, layer: Any) -> None:
         """Lifecycle-owned remove handling.
 
@@ -578,8 +610,7 @@ class LayerLifecycleManager(QObject):
                 with QSignalBlocker(self.owner._trail_cb):
                     self.owner._trail_cb.setChecked(False)
 
-        self.owner._refresh_video_panel_context()
-        self.owner._refresh_layer_status_panel()
+        self._schedule_post_remove_refresh()
 
     def _remap_frame_indices(self, layer: Any) -> None:
         """Lifecycle-owned remap of non-Image layer time/frame indices."""
@@ -789,14 +820,21 @@ class LayerLifecycleManager(QObject):
             getattr(event, "index", None),
         )
 
+        should_remap = False
+
         if isinstance(layer, Image):
-            self._maybe_accept_and_setup_image_layer(layer, getattr(event, "index", None))
+            should_remap = self._maybe_accept_and_setup_image_layer(
+                layer,
+                getattr(event, "index", None),
+            )
         elif isinstance(layer, Points):
             self._setup_points_layer(layer, allow_merge=True)
+            should_remap = True
 
-        for layer_ in self.viewer.layers:
-            if not isinstance(layer_, Image):
-                self._remap_frame_indices(layer_)
+        if should_remap:
+            for layer_ in self.viewer.layers:
+                if not isinstance(layer_, Image):
+                    self._remap_frame_indices(layer_)
 
         self.owner._refresh_video_panel_context()
         self.owner._refresh_layer_status_panel()

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -1,15 +1,30 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from functools import partial
+from types import MethodType
 from typing import TYPE_CHECKING, Any
 
-from napari.layers import Image, Layer, Points
-from qtpy.QtCore import QObject, QTimer, Signal
+import numpy as np
+from napari.layers import Image, Layer, Points, Tracks
+from napari.utils.events import Event
+from napari.utils.history import update_save_history
+from qtpy.QtCore import QObject, QSignalBlocker, QTimer, Signal
 
+from ...config.keybinds import install_points_layer_keybindings
+from ...config.models import ImageMetadata
+from ...core import keypoints
+from ...core.layer_versioning import mark_layer_presentation_changed
+from ...core.metadata import migrate_points_layer_metadata
+from ...core.project_paths import PathMatchPolicy
+from ...core.remap import remap_layer_data_by_paths
+from ...napari_compat import install_add_wrapper, install_paste_patch
+from ...napari_compat.points_layer import make_paste_data
 from .registry import (
     ClearedRegistryEntry,
     ManagedPointsRuntime,
+    PointsRuntimeResources,
     RegistryAuditReport,
     RuntimeRegistry,
 )
@@ -132,6 +147,355 @@ class LayerLifecycleManager(QObject):
         self._initial_adopt_timer.start(0)
 
     # ------------------------------------------------------------------ #
+    # Layer setup managers                                               #
+    # ------------------------------------------------------------------ #
+    def _setup_image_layer(self, layer: Image, index: int | None = None, *, reorder: bool = True) -> None:
+        """Lifecycle-owned setup for an inserted/adopted Image layer.
+
+        Transitional note:
+        ------------------
+        For now this still uses owner-held image/project context fields and UI hooks.
+        Step 2 should move image/project context ownership into the manager itself.
+        """
+        md = layer.metadata or {}
+        paths = md.get("paths")
+        if paths is None:
+            try:
+                if self.owner.io.is_video(layer.name):  # optional if owner exposes io
+                    self.owner.video_widget.setVisible(True)
+            except Exception:
+                pass
+
+        # Transitional: owner still stores image/project context.
+        self.owner._update_image_meta_from_layer(layer)
+
+        if not self.owner._project_path:
+            self.owner._cache_project_path_from_image_layer(layer)
+            if self.owner._project_path is not None:
+                try:
+                    layer.metadata = dict(layer.metadata or {})
+                    layer.metadata.setdefault("project", self.owner._project_path)
+                except Exception:
+                    logger.debug(
+                        "Failed to set project path metadata on image layer %r",
+                        getattr(layer, "name", layer),
+                        exc_info=True,
+                    )
+
+        self.owner._sync_points_layers_from_image_meta()
+        self.owner._refresh_video_panel_context()
+
+        logger.debug(
+            "Setup image layer=%r index=%s reorder=%s paths_count=%s root=%r",
+            getattr(layer, "name", layer),
+            index,
+            reorder,
+            len(md.get("paths") or []),
+            md.get("root"),
+        )
+
+        if reorder and index is not None:
+            QTimer.singleShot(10, partial(self.owner._move_image_layer_to_bottom, index))
+
+    def _wire_points_layer(self, layer: Points) -> KeypointStore | None:
+        """Lifecycle-owned wiring of a managed Points layer.
+
+        Transitional note:
+        ------------------
+        The manager owns runtime attachment; the widget still owns UI completion hooks.
+        """
+        if not self.owner._validate_header(layer):
+            return None
+
+        existing = getattr(layer, "_dlc_store", None)
+        if existing is not None:
+            self.register_managed_points_layer(layer, existing)
+
+            runtime = self.get_live_runtime(layer)
+            existing_resources = None
+            if runtime is not None:
+                existing_resources = runtime.resources.get("points_runtime", None)
+
+            resources = self.attach_points_layer_runtime(
+                layer=layer,
+                store=existing,
+                controls=self.owner,
+                resolve_layer_by_id=self.resolve_live_layer,
+                get_label_mode=lambda: self.owner._label_mode,
+                schedule_recolor=self.owner._schedule_recolor,
+                existing=existing_resources,
+            )
+
+            runtime = self.get_live_runtime(layer)
+            if runtime is not None:
+                runtime.resources["points_runtime"] = resources
+
+            layer._dlc_controls = self.owner
+            return existing
+
+        mig = migrate_points_layer_metadata(layer)
+        if hasattr(mig, "errors"):
+            logger.warning(
+                "Points metadata validation failed during wiring for layer=%r: %s",
+                getattr(layer, "name", layer),
+                mig,
+            )
+
+        store = keypoints.KeypointStore(self.viewer, layer)
+        self.register_managed_points_layer(layer, store)
+
+        resources = self.attach_points_layer_runtime(
+            layer=layer,
+            store=store,
+            controls=self.owner,
+            resolve_layer_by_id=self.resolve_live_layer,
+            get_label_mode=lambda: self.owner._label_mode,
+            schedule_recolor=self.owner._schedule_recolor,
+        )
+
+        runtime = self.get_live_runtime(layer)
+        if runtime is not None:
+            runtime.resources["points_runtime"] = resources
+
+        layer._dlc_store = store
+        layer._dlc_controls = self.owner
+
+        # Transitional: owner still stores image/project context.
+        if not layer.metadata.get("root") and self.owner._image_meta.root:
+            layer.metadata["root"] = self.owner._image_meta.root
+        if not layer.metadata.get("paths") and self.owner._image_meta.paths:
+            layer.metadata["paths"] = self.owner._image_meta.paths
+
+        if root := layer.metadata.get("root"):
+            update_save_history(root)
+
+        layer.text.visible = False
+
+        if self.managed_points_count() == 1 and self.owner._is_multianimal(layer):
+            self.owner._color_mode = keypoints.ColorMode.INDIVIDUAL
+            for btn in self.owner._color_mode_selector.buttons():
+                if btn.text().lower() == str(self.owner._color_mode).lower():
+                    btn.setChecked(True)
+                    break
+
+        # Transitional: widget still owns these UI-adjacent helpers.
+        self.owner._maybe_initialize_layer_point_size_from_config(layer)
+        self.owner._connect_layer_status_events(layer)
+
+        md = layer.metadata or {}
+        logger.debug(
+            "Wire points layer=%r existing_store=%s project=%s root=%s len_paths=%s",
+            getattr(layer, "name", layer),
+            getattr(layer, "_dlc_store", None) is not None,
+            md.get("project"),
+            md.get("root"),
+            len(md.get("paths", [])),
+        )
+
+        return store
+
+    def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
+        """Lifecycle-owned setup for an inserted/adopted Points layer."""
+        if not self.owner._validate_header(layer):
+            return
+
+        # Transitional: merge policy still lives in the widget for now.
+        if allow_merge and self.owner._maybe_merge_config_points_layer(layer):
+            return
+
+        store = self._wire_points_layer(layer)
+        if store is None:
+            return
+
+        # Widget owns UI completion only.
+        self.owner._complete_points_layer_ui_setup(layer, store)
+
+        logger.debug(
+            "Setup points layer=%r allow_merge=%s metadata_keys=%s",
+            getattr(layer, "name", layer),
+            allow_merge,
+            sorted((layer.metadata or {}).keys()),
+        )
+
+    def _handle_removed_layer(self, layer: Any) -> None:
+        """Lifecycle-owned remove handling.
+
+        Transitional note:
+        ------------------
+        UI/menu cleanup still delegates to a widget-owned UI hook.
+        """
+        n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
+
+        if isinstance(layer, Points):
+            self.unregister_managed_layer(layer)
+            self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
+
+        elif isinstance(layer, Image):
+            # Transitional: owner still stores image context.
+            self.owner._image_meta = ImageMetadata()
+            paths = layer.metadata.get("paths")
+            if paths is None:
+                self.owner.video_widget.setVisible(False)
+
+        elif isinstance(layer, Tracks):
+            was_trails = self.owner._trails_controller.on_tracks_layer_removed(layer)
+            if was_trails:
+                with QSignalBlocker(self.owner._trail_cb):
+                    self.owner._trail_cb.setChecked(False)
+
+        self.owner._refresh_video_panel_context()
+        self.owner._refresh_layer_status_panel()
+
+    def _remap_frame_indices(self, layer: Any) -> None:
+        """Lifecycle-owned remap of non-Image layer time/frame indices."""
+        try:
+            new_paths = self.owner._image_meta.paths
+            if not new_paths:
+                return
+
+            if layer.metadata is None:
+                layer.metadata = {}
+
+            md = layer.metadata
+            old_paths = md.get("paths") or []
+
+            try:
+                safe_image_meta = self.owner._image_meta.model_dump(exclude_none=True)
+                safe_image_meta.pop("paths", None)
+                layer.metadata.update(safe_image_meta)
+            except Exception:
+                logger.debug(
+                    "Failed to sync non-path image metadata for layer=%r",
+                    getattr(layer, "name", str(layer)),
+                    exc_info=True,
+                )
+
+            if not old_paths:
+                logger.debug(
+                    "Skipping remap for layer=%r: no existing layer metadata paths.",
+                    getattr(layer, "name", str(layer)),
+                )
+                return
+
+            time_col = 1 if isinstance(layer, Tracks) else 0
+
+            if logger.isEnabledFor(logging.DEBUG):
+                arr_before = np.asarray(layer.data)
+                logger.debug(
+                    "Remap start layer=%r old_paths_len=%s new_paths_len=%s data_shape=%s frame_min=%s frame_max=%s",
+                    getattr(layer, "name", str(layer)),
+                    len(old_paths),
+                    len(new_paths or []),
+                    getattr(arr_before, "shape", None),
+                    int(np.nanmin(arr_before[:, time_col])) if arr_before.size else None,
+                    int(np.nanmax(arr_before[:, time_col])) if arr_before.size else None,
+                )
+
+            res = remap_layer_data_by_paths(
+                data=layer.data,
+                old_paths=old_paths,
+                new_paths=new_paths,
+                time_col=time_col,
+                policy=PathMatchPolicy.ORDERED_DEPTHS,
+            )
+
+            logger.debug(
+                "Remap result layer=%r changed=%s mapped_count=%s depth=%s message=%s warnings=%s",
+                getattr(layer, "name", str(layer)),
+                res.changed,
+                res.mapped_count,
+                res.depth_used,
+                res.message,
+                res.warnings,
+            )
+
+            if res.applied and res.data is not None:
+                layer.data = res.data
+
+            if res.accept_paths_update:
+                layer.metadata["paths"] = list(new_paths)
+                if isinstance(layer, Points):
+                    mark_layer_presentation_changed(layer)
+
+            if res.depth_used is None:
+                logger.debug("Remap skipped for %s: %s", getattr(layer, "name", str(layer)), res.message)
+            else:
+                logger.debug(
+                    "Remap %s for %s (depth=%s, mapped=%s): %s",
+                    "applied" if res.changed else "accepted-noop",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.message,
+                )
+
+        except Exception:
+            logger.exception("Failed to remap frame indices for layer %s", getattr(layer, "name", str(layer)))
+
+    def attach_points_layer_runtime(
+        self,
+        *,
+        layer: Points,
+        store: keypoints.KeypointStore,
+        controls: Any,
+        resolve_layer_by_id: Callable[[int], Points | None],
+        get_label_mode: Callable[[], Any],
+        schedule_recolor: Callable[[Points], None],
+        existing_resources: PointsRuntimeResources | None = None,
+    ) -> PointsRuntimeResources:
+        """Attach managed runtime behavior to a Points layer.
+
+        Responsibilities
+        ----------------
+        - bind lifecycle-backed layer resolution to the store
+        - bind label-mode getter to the store
+        - install paste patch
+        - install add wrapper
+        - add/connect query_next_frame event
+        - install points-layer keybindings
+
+        This helper does NOT:
+        - register the runtime in the lifecycle registry
+        - own UI/menu setup
+        - decide merge/remap/save policy
+        """
+        resources = existing_resources or PointsRuntimeResources()
+
+        # Narrow lifecycle dependencies injected explicitly.
+        store.attach_layer_resolver(resolve_layer_by_id)
+        store.set_label_mode_getter(get_label_mode)
+
+        # Copy/paste patch
+        if not resources.paste_patch_installed:
+            paste_func = make_paste_data(controls, store=store)
+            install_paste_patch(layer, paste_func=paste_func)
+            resources.paste_patch_installed = True
+
+        # Add layer to store
+        if not resources.add_wrapper_installed:
+            add_impl = MethodType(keypoints.KeypointStore.add, store)
+            install_add_wrapper(layer, add_impl=add_impl, schedule_recolor=schedule_recolor)
+            resources.add_wrapper_installed = True
+
+        # layer-specific navigation event
+        if not hasattr(layer.events, "query_next_frame"):
+            layer.events.add(query_next_frame=Event)
+            resources.query_next_frame_event_added = True
+
+        if not resources.query_next_frame_connected:
+            try:
+                layer.events.query_next_frame.connect(store._advance_step)
+                resources.query_next_frame_connected = True
+            except Exception:
+                pass
+
+        if not resources.keybindings_installed:
+            install_points_layer_keybindings(layer, controls, store)
+            resources.keybindings_installed = True
+
+        return resources
+
+    # ------------------------------------------------------------------ #
     # Registry facade                                                    #
     # ------------------------------------------------------------------ #
 
@@ -191,13 +555,13 @@ class LayerLifecycleManager(QObject):
         )
 
         if isinstance(layer, Image):
-            self.owner._setup_image_layer(layer, getattr(event, "index", None), reorder=True)
+            self._setup_image_layer(layer, getattr(event, "index", None), reorder=True)
         elif isinstance(layer, Points):
-            self.owner._setup_points_layer(layer, allow_merge=True)
+            self._setup_points_layer(layer, allow_merge=True)
 
         for layer_ in self.viewer.layers:
             if not isinstance(layer_, Image):
-                self.owner._remap_frame_indices(layer_)
+                self._remap_frame_indices(layer_)
 
         self.owner._refresh_video_panel_context()
         self.owner._refresh_layer_status_panel()
@@ -215,12 +579,8 @@ class LayerLifecycleManager(QObject):
             type(layer).__name__,
         )
 
-        self.owner._handle_removed_layer(layer)
+        self._handle_removed_layer(layer)
         self.layer_remove_processed.emit(layer)
-
-    # ------------------------------------------------------------------ #
-    # internals                                                          #
-    # ------------------------------------------------------------------ #
 
     def _adopt_layer(self, layer: Any, index: int) -> None:
         logger.debug(
@@ -231,13 +591,13 @@ class LayerLifecycleManager(QObject):
         )
 
         if isinstance(layer, Image):
-            self.owner._setup_image_layer(layer, index, reorder=True)
+            self._setup_image_layer(layer, index, reorder=True)
         elif isinstance(layer, Points):
             if not self.registry.is_managed(layer):
-                self.owner._setup_points_layer(layer, allow_merge=False)
+                self._setup_points_layer(layer, allow_merge=False)
 
         if not isinstance(layer, Image):
-            self.owner._remap_frame_indices(layer)
+            self._remap_frame_indices(layer)
 
     def _resolve_inserted_layer(self, event: Any) -> Any | None:
         # Best case: event carries the inserted value directly

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -28,6 +28,7 @@ from ...core.remap import remap_layer_data_by_paths
 from ...napari_compat import install_add_wrapper, install_paste_patch
 from ...napari_compat.points_layer import make_paste_data
 from ...ui.cropping import resolve_project_path_from_image_layer
+from ...utils.debug import log_timing
 from .registry import (
     ClearedRegistryEntry,
     ManagedPointsRuntime,
@@ -518,7 +519,12 @@ class LayerLifecycleManager(QObject):
     def _remove_layer_if_present(self, layer: Layer) -> None:
         try:
             if layer in self.viewer.layers:
-                self.viewer.layers.remove(layer)
+                with log_timing(
+                    logger,
+                    f"viewer.layers.remove layer={getattr(layer, 'name', layer)!r}",
+                    threshold_ms=0.01,
+                ):
+                    self.viewer.layers.remove(layer)
         except Exception:
             logger.debug("Failed to remove layer=%r", getattr(layer, "name", layer), exc_info=True)
 
@@ -566,15 +572,18 @@ class LayerLifecycleManager(QObject):
         self._post_remove_refresh_timer.start(0)
 
     def _flush_post_remove_refresh(self) -> None:
-        try:
-            self.owner._refresh_video_panel_context()
-        except Exception:
-            logger.debug("Failed to refresh video panel context after removal", exc_info=True)
+        with log_timing(logger, "_flush_post_remove_refresh total", threshold_ms=0.01):
+            try:
+                with log_timing(logger, "_refresh_video_panel_context", threshold_ms=0.01):
+                    self.owner._refresh_video_panel_context()
+            except Exception:
+                logger.debug("Failed to refresh video panel context after removal", exc_info=True)
 
-        try:
-            self.owner._refresh_layer_status_panel()
-        except Exception:
-            logger.debug("Failed to refresh layer status panel after removal", exc_info=True)
+            try:
+                with log_timing(logger, "_refresh_layer_status_panel", threshold_ms=0.01):
+                    self.owner._refresh_layer_status_panel()
+            except Exception:
+                logger.debug("Failed to refresh layer status panel after removal", exc_info=True)
 
     def _handle_removed_layer(self, layer: Any) -> None:
         """Lifecycle-owned remove handling.
@@ -583,34 +592,55 @@ class LayerLifecycleManager(QObject):
         ------------------
         UI/menu cleanup still delegates to a widget-owned UI hook.
         """
-        n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
+        with log_timing(
+            logger,
+            f"_handle_removed_layer total layer={getattr(layer, 'name', layer)!r}",
+            threshold_ms=0.01,
+        ):
+            n_points_layer = sum(isinstance(l, Points) for l in self.viewer.layers)
 
-        if isinstance(layer, Points):
-            self.unregister_managed_layer(layer)
-            self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
+            if isinstance(layer, Points):
+                with log_timing(
+                    logger,
+                    f"unregister_managed_layer layer={getattr(layer, 'name', layer)!r}",
+                    threshold_ms=0.01,
+                ):
+                    self.unregister_managed_layer(layer)
 
-        elif isinstance(layer, Image):
-            if self._active_dlc_image_layer_id == id(layer):
-                self._active_dlc_image_layer_id = None
-                self._image_meta = ImageMetadata()
-                self._project_path = None
+                with log_timing(
+                    logger,
+                    f"_on_points_layer_removed_ui layer={getattr(layer, 'name', layer)!r}",
+                    threshold_ms=0.01,
+                ):
+                    self.owner._on_points_layer_removed_ui(layer, remaining_points_layers=n_points_layer)
 
-                paths = layer.metadata.get("paths")
-                if paths is None:
-                    self.owner.video_widget.setVisible(False)
-            else:
-                logger.debug(
-                    "Removed non-session or inactive image layer=%r; keeping current DLC session context.",
-                    getattr(layer, "name", layer),
-                )
+            elif isinstance(layer, Image):
+                if self._active_dlc_image_layer_id == id(layer):
+                    self._active_dlc_image_layer_id = None
+                    self._image_meta = ImageMetadata()
+                    self._project_path = None
 
-        elif isinstance(layer, Tracks):
-            was_trails = self.owner._trails_controller.on_tracks_layer_removed(layer)
-            if was_trails:
-                with QSignalBlocker(self.owner._trail_cb):
-                    self.owner._trail_cb.setChecked(False)
+                    paths = layer.metadata.get("paths")
+                    if paths is None:
+                        self.owner.video_widget.setVisible(False)
+                else:
+                    logger.debug(
+                        "Removed non-session or inactive image layer=%r; keeping current DLC session context.",
+                        getattr(layer, "name", layer),
+                    )
 
-        self._schedule_post_remove_refresh()
+            elif isinstance(layer, Tracks):
+                with log_timing(
+                    logger,
+                    f"tracks removal hook layer={getattr(layer, 'name', layer)!r}",
+                    threshold_ms=0.01,
+                ):
+                    was_trails = self.owner._trails_controller.on_tracks_layer_removed(layer)
+                if was_trails:
+                    with QSignalBlocker(self.owner._trail_cb):
+                        self.owner._trail_cb.setChecked(False)
+
+            self._schedule_post_remove_refresh()
 
     def _remap_frame_indices(self, layer: Any) -> None:
         """Lifecycle-owned remap of non-Image layer time/frame indices."""
@@ -852,8 +882,13 @@ class LayerLifecycleManager(QObject):
             type(layer).__name__,
         )
 
-        self._handle_removed_layer(layer)
-        self.layer_remove_processed.emit(layer)
+        with log_timing(
+            logger,
+            f"on_remove total layer={getattr(layer, 'name', layer)!r}",
+            threshold_ms=0.01,
+        ):
+            self._handle_removed_layer(layer)
+            self.layer_remove_processed.emit(layer)
 
     def _maybe_accept_and_setup_image_layer(self, layer: Image, index: int | None) -> bool:
         if not self.is_dlc_session_image_layer(layer):

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -206,8 +206,12 @@ class LayerLifecycleManager(QObject):
     def active_dlc_image_layer(self) -> Image | None:
         if self._active_dlc_image_layer_id is None:
             return None
-        layer = self.resolve_live_layer(self._active_dlc_image_layer_id)
-        return layer if isinstance(layer, Image) else None
+
+        for layer in self.viewer.layers:
+            if id(layer) == self._active_dlc_image_layer_id and isinstance(layer, Image):
+                return layer
+
+        return None
 
     def can_accept_dlc_session_image(self, layer: Image) -> tuple[bool, str | None]:
         active = self.active_dlc_image_layer()
@@ -494,8 +498,14 @@ class LayerLifecycleManager(QObject):
             return
 
         # Transitional: merge policy still lives in the widget for now.
-        if allow_merge and self.owner._maybe_merge_config_points_layer(layer):
-            return
+        if allow_merge:
+            consumed = self.owner._maybe_merge_config_points_layer(layer)
+            if consumed:
+                logger.debug(
+                    "Consumed temporary config placeholder layer=%r during merge path",
+                    getattr(layer, "name", layer),
+                )
+                return
 
         store = self._wire_points_layer(layer)
         if store is None:

--- a/src/napari_deeplabcut/core/layer_lifecycle/merge.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/merge.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/core/layer_lifecycle/merge.py
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/napari_deeplabcut/core/layer_lifecycle/merge.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/merge.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+
+
+class MergeDisposition(str, Enum):
+    KEEP_BOTH = "keep_both"
+    HIDE_EXISTING = "hide_existing"
+    HIDE_NEW = "hide_new"
+    CANCEL = "cancel"
+
+
+@dataclass(frozen=True, slots=True)
+class MergeDecisionRequest:
+    new_layer: Any
+    existing_layers: tuple[Any, ...]
+    added_keypoints: tuple[str, ...]
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class MergeDecisionResult:
+    disposition: MergeDisposition
+
+
+class MergeDecisionProvider(Protocol):
+    def resolve_merge(self, request: MergeDecisionRequest) -> MergeDecisionResult: ...

--- a/src/napari_deeplabcut/core/layer_lifecycle/registry.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/registry.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import logging
 import weakref
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any, Generic, TypeVar
 
+logger = logging.getLogger("napari-deeplabcut.lifecycle.registry")
 StoreT = TypeVar("StoreT")
 
 

--- a/src/napari_deeplabcut/core/layer_lifecycle/registry.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/registry.py
@@ -5,7 +5,12 @@ import logging
 import weakref
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Any, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from napari.layers import Points
+
+    from ..keypoints import KeypointStore
 
 logger = logging.getLogger("napari-deeplabcut.lifecycle.registry")
 StoreT = TypeVar("StoreT")
@@ -50,6 +55,14 @@ class PointsRuntimeResources:
     paste_patch_installed: bool = False
     keybindings_installed: bool = False
     extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PointsLayerSetupRequest:
+    layer: Points
+    store: KeypointStore
+    existing_resources: PointsRuntimeResources | None = None
+    runtime_resources: PointsRuntimeResources | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/napari_deeplabcut/core/layer_lifecycle/registry.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/registry.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/core/layer_lifecycle/registry.py
 from __future__ import annotations
 
 import logging
@@ -33,6 +34,22 @@ class ManagedPointsRuntime(Generic[StoreT]):
     layer_id: int
     store: StoreT
     resources: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class PointsRuntimeResources:
+    """Non-Qt runtime attachments installed on a managed Points layer.
+
+    It gives the lifecycle manager one place to record what it attached and later clean up or audit.
+    Intended to fit in ManagedPointsRuntime.resources.
+    """
+
+    query_next_frame_event_added: bool = False
+    query_next_frame_connected: bool = False
+    add_wrapper_installed: bool = False
+    paste_patch_installed: bool = False
+    keybindings_installed: bool = False
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/napari_deeplabcut/core/layer_lifecycle/registry.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/registry.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import weakref
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any, Generic, TypeVar
+
+StoreT = TypeVar("StoreT")
+
+
+@dataclass(slots=True)
+class ManagedPointsRuntime(Generic[StoreT]):
+    """Runtime attachment for a managed Points layer.
+
+    This wraps:
+    - the layer
+    - its store
+    - a generic resources dict for future cleanup hooks / attachments
+    """
+
+    layer: Any
+    store: StoreT
+    resources: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class _RegistryEntry(Generic[StoreT]):
+    layer_id: int
+    layer_ref: weakref.ReferenceType[Any] | None
+    strong_layer: Any | None
+    runtime: ManagedPointsRuntime[StoreT]
+
+    def resolve_layer(self) -> Any | None:
+        if self.layer_ref is not None:
+            return self.layer_ref()
+        return self.strong_layer
+
+
+class RuntimeRegistry(Generic[StoreT]):
+    """Single owner of managed Points-layer runtime attachments.
+
+    Invariants
+    ----------
+    - At most one runtime bundle per live layer object.
+    - Registration is explicit.
+    - Querying is by object identity.
+    """
+
+    def __init__(self) -> None:
+        self._entries_by_id: dict[int, _RegistryEntry[StoreT]] = {}
+
+    def __len__(self) -> int:
+        self.purge_dead()
+        return len(self._entries_by_id)
+
+    def is_managed(self, layer: Any) -> bool:
+        self.purge_dead()
+        return id(layer) in self._entries_by_id
+
+    def register(self, layer: Any, runtime: ManagedPointsRuntime[StoreT]) -> None:
+        self.purge_dead()
+        layer_id = id(layer)
+        if layer_id in self._entries_by_id:
+            raise ValueError(f"Layer already registered: id={layer_id}")
+
+        try:
+            layer_ref: weakref.ReferenceType[Any] | None = weakref.ref(layer)
+            strong_layer = None
+        except TypeError:
+            layer_ref = None
+            strong_layer = layer
+
+        self._entries_by_id[layer_id] = _RegistryEntry(
+            layer_id=layer_id,
+            layer_ref=layer_ref,
+            strong_layer=strong_layer,
+            runtime=runtime,
+        )
+
+    def unregister(self, layer: Any) -> ManagedPointsRuntime[StoreT] | None:
+        self.purge_dead()
+        entry = self._entries_by_id.pop(id(layer), None)
+        return None if entry is None else entry.runtime
+
+    def get(self, layer: Any) -> ManagedPointsRuntime[StoreT] | None:
+        self.purge_dead()
+        entry = self._entries_by_id.get(id(layer))
+        return None if entry is None else entry.runtime
+
+    def require(self, layer: Any) -> ManagedPointsRuntime[StoreT]:
+        runtime = self.get(layer)
+        if runtime is None:
+            raise KeyError(f"Layer is not managed: id={id(layer)}")
+        return runtime
+
+    def items(self) -> Iterator[tuple[Any, ManagedPointsRuntime[StoreT]]]:
+        self.purge_dead()
+        for entry in list(self._entries_by_id.values()):
+            layer = entry.resolve_layer()
+            if layer is not None:
+                yield layer, entry.runtime
+
+    def layers(self) -> Iterator[Any]:
+        for layer, _runtime in self.items():
+            yield layer
+
+    def runtimes(self) -> Iterator[ManagedPointsRuntime[StoreT]]:
+        self.purge_dead()
+        for entry in self._entries_by_id.values():
+            yield entry.runtime
+
+    def layer_ids(self) -> tuple[int, ...]:
+        self.purge_dead()
+        return tuple(self._entries_by_id.keys())
+
+    def purge_dead(self) -> None:
+        dead_ids: list[int] = []
+        for layer_id, entry in self._entries_by_id.items():
+            if entry.resolve_layer() is None:
+                dead_ids.append(layer_id)
+
+        for layer_id in dead_ids:
+            self._entries_by_id.pop(layer_id, None)
+
+    def clear(self) -> None:
+        self._entries_by_id.clear()
+
+    def assert_consistent(self) -> None:
+        self.purge_dead()
+        seen_ids: set[int] = set()
+
+        for layer, runtime in self.items():
+            assert runtime.layer is layer, "Runtime bundle layer reference is inconsistent"
+            layer_id = id(layer)
+            assert layer_id not in seen_ids, "Duplicate managed layer identity detected"
+            seen_ids.add(layer_id)

--- a/src/napari_deeplabcut/core/layer_lifecycle/registry.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/registry.py
@@ -14,15 +14,47 @@ StoreT = TypeVar("StoreT")
 class ManagedPointsRuntime(Generic[StoreT]):
     """Runtime attachment for a managed Points layer.
 
-    This wraps:
-    - the layer
-    - its store
-    - a generic resources dict for future cleanup hooks / attachments
+    Important:
+    ----------
+    This runtime should not strongly store the layer object itself.
+
+    It stores:
+    - the stable layer identity used by the registry (`layer_id`)
+    - the store (KeypointStore) associated with this layer
+    - generic resources for future cleanup hooks / attachments
+
+    Layer liveness / resolution is owned by the registry.
+    Everything downstream should use it to resolve whether the layer is still live.
+    This is meant to let napari own true layer lifecycles without interference,
+    while still enabling robust cleanup of plugin-managed
+    runtime attachments when layers are removed.
     """
 
-    layer: Any
+    layer_id: int
     store: StoreT
     resources: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ClearedRegistryEntry(Generic[StoreT]):
+    """A registry entry that was removed because its layer was no longer live."""
+
+    layer_id: int
+    runtime: ManagedPointsRuntime[StoreT]
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryAuditIssue:
+    code: str
+    message: str
+    layer_id: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryAuditReport:
+    live_count: int
+    dead_count: int
+    issues: tuple[RegistryAuditIssue, ...]
 
 
 @dataclass(slots=True)
@@ -39,36 +71,58 @@ class _RegistryEntry(Generic[StoreT]):
 
 
 class RuntimeRegistry(Generic[StoreT]):
-    """Single owner of managed Points-layer runtime attachments.
+    """Single owner of managed runtime attachments.
 
     Invariants
     ----------
-    - At most one runtime bundle per live layer object.
+    - At most one runtime bundle per registered layer identity.
     - Registration is explicit.
-    - Querying is by object identity.
+    - Layer liveness is resolved here.
+    - Runtime attachments do not need to strongly own the layer object.
     """
 
     def __init__(self) -> None:
         self._entries_by_id: dict[int, _RegistryEntry[StoreT]] = {}
 
+    # ------------------------------------------------------------------ #
+    # core identity / registration                                       #
+    # ------------------------------------------------------------------ #
+
     def __len__(self) -> int:
-        self.purge_dead()
-        return len(self._entries_by_id)
+        """Number of currently live entries."""
+        return sum(1 for _layer, _runtime in self.iter_live_items())
+
+    def layer_ids(self) -> tuple[int, ...]:
+        """All currently registered entry ids, including stale/dead ones."""
+        return tuple(self._entries_by_id.keys())
 
     def is_managed(self, layer: Any) -> bool:
-        self.purge_dead()
-        return id(layer) in self._entries_by_id
+        """Whether this exact live layer object is currently registered and live."""
+        entry = self._entries_by_id.get(id(layer))
+        if entry is None:
+            return False
+        resolved = entry.resolve_layer()
+        return resolved is layer
+
+    def contains_layer_id(self, layer_id: int) -> bool:
+        """Whether a registry entry exists for this id (live or stale)."""
+        return layer_id in self._entries_by_id
 
     def register(self, layer: Any, runtime: ManagedPointsRuntime[StoreT]) -> None:
-        self.purge_dead()
         layer_id = id(layer)
         if layer_id in self._entries_by_id:
             raise ValueError(f"Layer already registered: id={layer_id}")
+
+        if runtime.layer_id != layer_id:
+            raise ValueError(f"Runtime layer_id mismatch: runtime.layer_id={runtime.layer_id}, actual={layer_id}")
 
         try:
             layer_ref: weakref.ReferenceType[Any] | None = weakref.ref(layer)
             strong_layer = None
         except TypeError:
+            logger.error("Could not cleanly register layer as a weakref; storing strong reference instead: %r", layer)
+            # Fallback for objects that do not support weakref.
+            # This means the registry *will* strongly hold such layers.
             layer_ref = None
             strong_layer = layer
 
@@ -79,60 +133,163 @@ class RuntimeRegistry(Generic[StoreT]):
             runtime=runtime,
         )
 
-    def unregister(self, layer: Any) -> ManagedPointsRuntime[StoreT] | None:
-        self.purge_dead()
-        entry = self._entries_by_id.pop(id(layer), None)
+    def unregister(self, layer_or_id: Any) -> ManagedPointsRuntime[StoreT] | None:
+        entry = self._entries_by_id.pop(self._coerce_layer_id(layer_or_id), None)
         return None if entry is None else entry.runtime
 
-    def get(self, layer: Any) -> ManagedPointsRuntime[StoreT] | None:
-        self.purge_dead()
-        entry = self._entries_by_id.get(id(layer))
-        return None if entry is None else entry.runtime
+    # ------------------------------------------------------------------ #
+    # centralized live resolution                                        #
+    # ------------------------------------------------------------------ #
 
-    def require(self, layer: Any) -> ManagedPointsRuntime[StoreT]:
-        runtime = self.get(layer)
+    def resolve_live_layer(self, layer_or_id: Any) -> Any | None:
+        """Resolve a currently live layer object from a layer or layer id."""
+        entry = self._entries_by_id.get(self._coerce_layer_id(layer_or_id))
+        if entry is None:
+            return None
+        return entry.resolve_layer()
+
+    def get_live_runtime(self, layer_or_id: Any) -> ManagedPointsRuntime[StoreT] | None:
+        """Return runtime only if the corresponding layer is currently live."""
+        entry = self._entries_by_id.get(self._coerce_layer_id(layer_or_id))
+        if entry is None:
+            return None
+        if entry.resolve_layer() is None:
+            return None
+        return entry.runtime
+
+    def require_live_runtime(self, layer_or_id: Any) -> ManagedPointsRuntime[StoreT]:
+        runtime = self.get_live_runtime(layer_or_id)
         if runtime is None:
-            raise KeyError(f"Layer is not managed: id={id(layer)}")
+            raise KeyError(f"Managed live runtime not found: {layer_or_id!r}")
         return runtime
 
-    def items(self) -> Iterator[tuple[Any, ManagedPointsRuntime[StoreT]]]:
-        self.purge_dead()
+    def get_store(self, layer_or_id: Any) -> StoreT | None:
+        runtime = self.get_live_runtime(layer_or_id)
+        return None if runtime is None else runtime.store
+
+    def require_store(self, layer_or_id: Any) -> StoreT:
+        runtime = self.require_live_runtime(layer_or_id)
+        return runtime.store
+
+    # ------------------------------------------------------------------ #
+    # live iteration                                                     #
+    # ------------------------------------------------------------------ #
+
+    def iter_live_items(self) -> Iterator[tuple[Any, ManagedPointsRuntime[StoreT]]]:
+        """Yield only currently live (layer, runtime) pairs."""
         for entry in list(self._entries_by_id.values()):
             layer = entry.resolve_layer()
             if layer is not None:
                 yield layer, entry.runtime
 
-    def layers(self) -> Iterator[Any]:
-        for layer, _runtime in self.items():
+    def iter_live_layers(self) -> Iterator[Any]:
+        for layer, _runtime in self.iter_live_items():
             yield layer
 
-    def runtimes(self) -> Iterator[ManagedPointsRuntime[StoreT]]:
-        self.purge_dead()
-        for entry in self._entries_by_id.values():
-            yield entry.runtime
+    def iter_live_runtimes(self) -> Iterator[ManagedPointsRuntime[StoreT]]:
+        for _layer, runtime in self.iter_live_items():
+            yield runtime
 
-    def layer_ids(self) -> tuple[int, ...]:
-        self.purge_dead()
-        return tuple(self._entries_by_id.keys())
+    # ------------------------------------------------------------------ #
+    # dead-entry handling / reporting                                    #
+    # ------------------------------------------------------------------ #
 
-    def purge_dead(self) -> None:
-        dead_ids: list[int] = []
+    def dead_layer_ids(self) -> tuple[int, ...]:
+        """Return ids whose registered layer object is no longer live."""
+        dead: list[int] = []
         for layer_id, entry in self._entries_by_id.items():
             if entry.resolve_layer() is None:
-                dead_ids.append(layer_id)
+                dead.append(layer_id)
+        return tuple(dead)
 
-        for layer_id in dead_ids:
-            self._entries_by_id.pop(layer_id, None)
+    def clear_dead_entries(self, *, log: bool = True) -> tuple[ClearedRegistryEntry[StoreT], ...]:
+        """Remove dead entries and return what was reaped.
+
+        This is intentionally observable so lifecycle cleanup bugs are not silently hidden.
+        """
+        reaped: list[ClearedRegistryEntry[StoreT]] = []
+
+        for layer_id in list(self.dead_layer_ids()):
+            entry = self._entries_by_id.pop(layer_id, None)
+            if entry is None:
+                continue
+
+            item = ClearedRegistryEntry(layer_id=layer_id, runtime=entry.runtime)
+            reaped.append(item)
+
+            if log:
+                logger.warning(
+                    "Cleared dead managed layer entry without explicit unregister: layer_id=%s",
+                    layer_id,
+                )
+
+        return tuple(reaped)
+
+    # ------------------------------------------------------------------ #
+    # diagnostics / auditing                                             #
+    # ------------------------------------------------------------------ #
+
+    def audit(self) -> RegistryAuditReport:
+        issues: list[RegistryAuditIssue] = []
+        live_count = 0
+        dead_count = 0
+        seen_ids: set[int] = set()
+
+        for layer_id, entry in self._entries_by_id.items():
+            if layer_id in seen_ids:
+                issues.append(
+                    RegistryAuditIssue(
+                        code="duplicate-layer-id",
+                        message="Duplicate registry layer id detected",
+                        layer_id=layer_id,
+                    )
+                )
+            seen_ids.add(layer_id)
+
+            resolved = entry.resolve_layer()
+            if resolved is None:
+                dead_count += 1
+                issues.append(
+                    RegistryAuditIssue(
+                        code="dead-entry",
+                        message="Managed entry has no live layer",
+                        layer_id=layer_id,
+                    )
+                )
+                continue
+
+            live_count += 1
+
+            if entry.runtime.layer_id != layer_id:
+                issues.append(
+                    RegistryAuditIssue(
+                        code="runtime-layer-id-mismatch",
+                        message=(
+                            f"Runtime layer_id ({entry.runtime.layer_id}) does not match registry entry id ({layer_id})"
+                        ),
+                        layer_id=layer_id,
+                    )
+                )
+
+        return RegistryAuditReport(
+            live_count=live_count,
+            dead_count=dead_count,
+            issues=tuple(issues),
+        )
+
+    def assert_consistent(self) -> None:
+        report = self.audit()
+        assert not report.issues, f"Registry consistency issues: {report.issues!r}"
+
+    # ------------------------------------------------------------------ #
+    # misc                                                               #
+    # ------------------------------------------------------------------ #
 
     def clear(self) -> None:
         self._entries_by_id.clear()
 
-    def assert_consistent(self) -> None:
-        self.purge_dead()
-        seen_ids: set[int] = set()
-
-        for layer, runtime in self.items():
-            assert runtime.layer is layer, "Runtime bundle layer reference is inconsistent"
-            layer_id = id(layer)
-            assert layer_id not in seen_ids, "Duplicate managed layer identity detected"
-            seen_ids.add(layer_id)
+    @staticmethod
+    def _coerce_layer_id(layer_or_id: Any) -> int:
+        if isinstance(layer_or_id, int):
+            return layer_or_id
+        return id(layer_or_id)

--- a/src/napari_deeplabcut/core/layer_lifecycle/spawn.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/spawn.py
@@ -1,0 +1,61 @@
+# src/napari_deeplabcut/core/layer_lifecycle/spawn.py
+from __future__ import annotations
+
+import threading
+import weakref
+
+from qtpy.QtCore import QObject
+
+from .manager import LayerLifecycleManager
+
+_MANAGER_REGISTRY: weakref.WeakKeyDictionary[object, LayerLifecycleManager] = weakref.WeakKeyDictionary()
+_MANAGER_LOCK = threading.RLock()
+_VIEWER_ATTR = "_ndlc_layer_manager"
+
+
+def _viewer_qparent(viewer) -> QObject | None:
+    try:
+        window = getattr(viewer, "window", None)
+        qt_window = getattr(window, "_qt_window", None)
+        return qt_window if isinstance(qt_window, QObject) else None
+    except Exception:
+        return None
+
+
+def get_layer_manager(viewer) -> LayerLifecycleManager | None:
+    with _MANAGER_LOCK:
+        mgr = _MANAGER_REGISTRY.get(viewer)
+        if mgr is not None:
+            return mgr
+
+        try:
+            mgr = getattr(viewer, _VIEWER_ATTR, None)
+        except Exception:
+            mgr = None
+
+        if mgr is not None and getattr(mgr, "viewer", None) is viewer:
+            _MANAGER_REGISTRY[viewer] = mgr
+            return mgr
+
+        return None
+
+
+def get_or_create_layer_manager(viewer) -> LayerLifecycleManager:
+    with _MANAGER_LOCK:
+        mgr = get_layer_manager(viewer)
+        if mgr is not None:
+            return mgr
+
+        mgr = LayerLifecycleManager(
+            viewer=viewer,
+            parent=_viewer_qparent(viewer),
+        )
+        mgr.attach()
+
+        _MANAGER_REGISTRY[viewer] = mgr
+        try:
+            setattr(viewer, _VIEWER_ATTR, mgr)
+        except Exception:
+            pass
+
+        return mgr

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -13,6 +13,7 @@ from qtpy.QtCore import QTimer
 
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel
 from napari_deeplabcut.core.keypoints import build_color_cycles
+from napari_deeplabcut.utils.deprecations import deprecated
 
 T = TypeVar("T")
 
@@ -554,6 +555,7 @@ def infer_folder_display_name(
     return "—"
 
 
+@deprecated(reason="Use LayerLifecycleManager.active_dlc_image_layer instead")
 def find_relevant_image_layer(viewer) -> Image | None:
     active = viewer.layers.selection.active
     if isinstance(active, Image):

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -269,12 +269,16 @@ def set_uniform_point_size(layer: Points, size: int) -> None:
     layer.size = float(size)
 
 
-def infer_frame_count(layer: Points, *, preferred_paths: list[str] | None = None) -> int:
+def infer_frame_count(
+    layer: Points, *, preferred_paths: list[str] | None = None, fallback_n_frames: int | None = None
+) -> int:
     md = getattr(layer, "metadata", {}) or {}
 
     paths = preferred_paths or md.get("paths") or []
     if paths:
         return len(paths)
+    if fallback_n_frames is not None:
+        return fallback_n_frames
 
     data = np.asarray(getattr(layer, "data", []))
     if data.size == 0:
@@ -418,7 +422,9 @@ def _iter_labeled_slots(layer: Points):
         yield (frame, id_text, label)
 
 
-def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = None) -> LabelProgress:
+def compute_label_progress(
+    layer: Points, *, fallback_paths: list[str] | None = None, fallback_n_frames: int | None = None
+) -> LabelProgress:
     """
     Compute progress for the active napari layer.
 
@@ -429,7 +435,7 @@ def compute_label_progress(layer: Points, *, fallback_paths: list[str] | None = 
       currently represented in napari:
         observed_ids × observed_labels
     """
-    frame_count = infer_frame_count(layer, preferred_paths=fallback_paths)
+    frame_count = infer_frame_count(layer, preferred_paths=fallback_paths, fallback_n_frames=fallback_n_frames)
     bodypart_count = infer_bodypart_count(layer)
     individual_count = infer_individual_count(layer)
 

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -555,7 +555,7 @@ def infer_folder_display_name(
     return "—"
 
 
-@deprecated(reason="Use LayerLifecycleManager.active_dlc_image_layer instead")
+@deprecated(details="Use LayerLifecycleManager.active_dlc_image_layer instead")
 def find_relevant_image_layer(viewer) -> Image | None:
     active = viewer.layers.selection.active
     if isinstance(active, Image):

--- a/src/napari_deeplabcut/core/metadata.py
+++ b/src/napari_deeplabcut/core/metadata.py
@@ -421,7 +421,7 @@ def attach_source_and_io_to_layer_kwargs(
     file_path: Path,
     *,
     kind: AnnotationKind | None = None,
-    dataset_key: str = "keypoints",
+    dataset_key: str = "df_with_missing",
 ) -> None:
     """
     Attach authoritative source info + IO provenance to napari layer metadata dict.
@@ -542,7 +542,7 @@ def _infer_kind_from_source_name(p: Path) -> AnnotationKind | None:
 def _build_io_from_source_h5(
     src: str,
     *,
-    dataset_key: str = "keypoints",
+    dataset_key: str = "df_with_missing",
 ) -> dict[str, Any] | None:
     """Legacy migration: build io provenance dict from source_h5 string."""
     if not isinstance(src, str) or not src:
@@ -596,7 +596,7 @@ def _prepare_points_payload(
     # legacy migration: io from source_h5
     if migrate_legacy and not raw.get("io"):
         src = raw.get("source_h5")
-        io_dict = _build_io_from_source_h5(src, dataset_key="keypoints")
+        io_dict = _build_io_from_source_h5(src, dataset_key="df_with_missing")
         if io_dict:
             raw["io"] = io_dict
 
@@ -717,7 +717,7 @@ def write_points_meta(
 
     # legacy migration (optional): if caller writes anything, keep io stable
     if migrate_legacy and not merged.get("io") and merged.get("source_h5"):
-        io_dict = _build_io_from_source_h5(str(merged.get("source_h5")), dataset_key="keypoints")
+        io_dict = _build_io_from_source_h5(str(merged.get("source_h5")), dataset_key="df_with_missing")
         if io_dict:
             merged["io"] = io_dict
 

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -667,7 +667,6 @@ def infer_dlc_project_from_image_layer(
     )
 
 
-# FIXME @C-Achard 2026-04-22 Add unit tests for below funcs
 def infer_dlc_project_from_labeled_folder(
     folder: str | Path,
     *,

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -739,7 +739,7 @@ def session_key_from_project_context(ctx: DLCProjectContext | None) -> str | Non
 
     Priority:
     - project_root
-    - config_path parent/project_root
+    - config_path parent (project_root)
     - dataset_folder
     - root_anchor
 

--- a/src/napari_deeplabcut/core/project_paths.py
+++ b/src/napari_deeplabcut/core/project_paths.py
@@ -665,3 +665,94 @@ def infer_dlc_project_from_image_layer(
         prefer_project_root=prefer_project_root,
         max_levels=max_levels,
     )
+
+
+# FIXME @C-Achard 2026-04-22 Add unit tests for below funcs
+def infer_dlc_project_from_labeled_folder(
+    folder: str | Path,
+    *,
+    prefer_project_root: bool = True,
+    max_levels: int = 5,
+) -> DLCProjectContext:
+    """
+    Infer DLC project context from a labeled-data/<dataset> folder.
+
+    This is the common case for folder-parser workflows:
+    - the dataset folder itself is a valid root anchor
+    - config.yaml may or may not exist above it
+    - if config exists, we may elevate project_root/config_path
+    """
+    dataset_folder = normalize_anchor_candidate(folder)
+    if dataset_folder is None:
+        raise ValueError(f"Could not normalize labeled folder: {folder!r}")
+
+    return infer_dlc_project(
+        anchor_candidates=[dataset_folder],
+        dataset_candidates=[dataset_folder],
+        explicit_root=dataset_folder,
+        prefer_project_root=prefer_project_root,
+        max_levels=max_levels,
+    )
+
+
+def infer_dlc_project_from_video_path(
+    video_path: str | Path,
+    *,
+    max_levels: int = 5,
+) -> DLCProjectContext | None:
+    """
+    Infer DLC project context for a directly opened video.
+
+    Important:
+    ----------
+    A directly opened video should count as a DLC session video only if it can
+    be confidently associated with a DLC project context (typically via a nearby
+    config.yaml).
+    TODO @C-Achard 2026-04-22: Ensure that adding a config.yaml later properly
+    updates the inferred context and associated session image layers.
+
+    Returns
+    -------
+    DLCProjectContext | None
+        Returns None if no recognizable DLC project context can be inferred.
+    """
+    ctx = infer_dlc_project_from_opened(
+        video_path,
+        explicit_root=None,
+        prefer_project_root=True,
+        max_levels=max_levels,
+    )
+
+    # For directly opened videos, require a recognizable project context.
+    if ctx.project_root is None and ctx.config_path is None:
+        return None
+
+    return ctx
+
+
+# -----------------------------------------------------------------------------
+# Lifecycle/session helpers
+# -----------------------------------------------------------------------------
+def session_key_from_project_context(ctx: DLCProjectContext | None) -> str | None:
+    """
+    Build a stable session key from the strongest available project context hint.
+
+    Priority:
+    - project_root
+    - config_path parent/project_root
+    - dataset_folder
+    - root_anchor
+
+    This is intended for lifecycle/session identity, not for IO routing.
+    """
+    if ctx is None:
+        return None
+
+    key = ctx.project_root or ctx.dataset_folder or ctx.root_anchor
+    if key is None:
+        return None
+
+    try:
+        return str(key.expanduser().resolve())
+    except Exception:
+        return str(key)

--- a/src/napari_deeplabcut/core/provenance.py
+++ b/src/napari_deeplabcut/core/provenance.py
@@ -51,7 +51,7 @@ def build_gt_save_target(
     anchor: str,
     scorer: str,
     *,
-    dataset_key: str = "keypoints",
+    dataset_key: str = "df_with_missing",
 ) -> IOProvenance:
     """
     Build a GT save_target pointing to CollectedData_<scorer>.h5 under a folder anchor.
@@ -72,7 +72,7 @@ def apply_gt_save_target(
     *,
     anchor: str,
     scorer: str,
-    dataset_key: str = "keypoints",
+    dataset_key: str = "df_with_missing",
 ) -> PointsMetadata:
     """
     Return an updated PointsMetadata with a GT promotion save_target attached.

--- a/src/napari_deeplabcut/misc.py
+++ b/src/napari_deeplabcut/misc.py
@@ -14,6 +14,8 @@ from napari_deeplabcut.core.project_paths import canonicalize_path
 from napari_deeplabcut.utils.deprecations import DeprecationMode, deprecated
 
 logger = logging.getLogger(__name__)
+# DEPRECATED: If another refactor occurs, please consider finalizing the deprecation of this file
+# and moving any remaining functions to more specific locations.
 
 
 class HeaderLike(Protocol):
@@ -41,6 +43,7 @@ def is_latest_version():
     return __version__ == latest_version, latest_version
 
 
+@deprecated(details="Should be moved out of misc.py, likely to io.py where it is currently only used.")
 def encode_categories(categories: Sequence, return_unique: bool = False, is_path: bool = True, do_sort: bool = True):
     """
     Convert a list of categories (typically filenames) into integer indices
@@ -78,6 +81,7 @@ def unsorted_unique(array: Sequence) -> np.ndarray:
     return np.asarray(array)[np.sort(inds)]
 
 
+# TODO move to keypoints.py
 class CycleEnumMeta(EnumMeta):
     def __new__(metacls, cls, bases, classdict, **kwargs):
         enum_ = super().__new__(metacls, cls, bases, classdict, **kwargs)
@@ -96,6 +100,7 @@ class CycleEnumMeta(EnumMeta):
         return super().__getitem__(item)
 
 
+# TODO move to keypoints.py
 class CycleEnum(Enum, metaclass=CycleEnumMeta):
     def _generate_next_value_(name, start, count, last_values):
         return name.lower()

--- a/src/napari_deeplabcut/ui/base_widget/__init__.py
+++ b/src/napari_deeplabcut/ui/base_widget/__init__.py
@@ -1,0 +1,3 @@
+from .singleton_widget import ViewerSingletonWidget
+
+__all__ = ["ViewerSingletonWidget"]

--- a/src/napari_deeplabcut/ui/base_widget/singleton_widget.py
+++ b/src/napari_deeplabcut/ui/base_widget/singleton_widget.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import weakref
+from typing import ClassVar
+
+from qtpy.QtWidgets import QWidget
+
+
+class ViewerSingletonWidget(QWidget):
+    """Base QWidget enforcing at most one live instance per viewer per subclass."""
+
+    _instances_by_cls: ClassVar[
+        dict[type, weakref.WeakKeyDictionary[object, weakref.ReferenceType[ViewerSingletonWidget]]]
+    ] = {}
+
+    # ------------------------------------------------------------------ #
+    # Viewer extraction / normalization                                  #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _extract_viewer_from_call(args, kwargs):
+        if args:
+            return args[0]
+        if "napari_viewer" in kwargs:
+            return kwargs["napari_viewer"]
+        if "viewer" in kwargs:
+            return kwargs["viewer"]
+        return None
+
+    @staticmethod
+    def canonical_viewer(viewer):
+        current = viewer
+        seen = set()
+
+        while True:
+            wrapped = getattr(current, "__wrapped__", None)
+            if wrapped is None:
+                wrapped = getattr(current, "_obj", None)
+
+            if wrapped is None or wrapped is current or id(wrapped) in seen:
+                return current
+
+            seen.add(id(current))
+            current = wrapped
+
+    # ------------------------------------------------------------------ #
+    # Registry helpers                                                   #
+    # ------------------------------------------------------------------ #
+
+    @classmethod
+    def _instance_registry(cls):
+        reg = ViewerSingletonWidget._instances_by_cls.get(cls)
+        if reg is None:
+            reg = weakref.WeakKeyDictionary()
+            ViewerSingletonWidget._instances_by_cls[cls] = reg
+        return reg
+
+    @staticmethod
+    def _is_qt_alive(widget) -> bool:
+        try:
+            widget.objectName()  # any QObject call is enough
+        except RuntimeError:
+            return False
+        except Exception:
+            return True
+        return True
+
+    @classmethod
+    def get_existing(cls, viewer):
+        canonical = cls.canonical_viewer(viewer)
+        ref = cls._instance_registry().get(canonical)
+        widget = ref() if ref is not None else None
+        if widget is None:
+            return None
+        if not cls._is_qt_alive(widget):
+            cls._instance_registry().pop(canonical, None)
+            return None
+        return widget
+
+    @classmethod
+    def get_or_create(cls, viewer, *args, **kwargs):
+        existing = cls.get_existing(viewer)
+        if existing is not None:
+            return existing
+        return cls(viewer, *args, **kwargs)
+
+    @classmethod
+    def is_docked(cls, viewer, widget) -> bool:
+        try:
+            for obj in viewer.window.dock_widgets.values():
+                if obj is widget:
+                    return True
+                try:
+                    if obj.widget() is widget:
+                        return True
+                except Exception:
+                    pass
+        except Exception:
+            pass
+        return False
+
+    # ------------------------------------------------------------------ #
+    # Singleton construction                                             #
+    # ------------------------------------------------------------------ #
+
+    def __new__(cls, *args, **kwargs):
+        viewer = cls._extract_viewer_from_call(args, kwargs)
+        if viewer is None:
+            raise TypeError(
+                f"{cls.__name__} requires a viewer argument (positional, napari_viewer=..., or viewer=...)."
+            )
+
+        canonical = cls.canonical_viewer(viewer)
+        existing = cls.get_existing(canonical)
+        if existing is not None:
+            return existing
+
+        obj = super().__new__(cls)
+        cls._instance_registry()[canonical] = weakref.ref(obj)
+        return obj
+
+    def _singleton_prepare_init(self, *args, **kwargs) -> bool:
+        """Pre-Qt-init guard. Safe to call before QWidget.__init__()."""
+        if getattr(self, "_viewer_singleton_initialized", False):
+            return False
+
+        viewer = self._extract_viewer_from_call(args, kwargs)
+        if viewer is None:
+            raise TypeError(f"{self.__class__.__name__} requires a viewer argument during initialization.")
+
+        self._viewer_singleton_initialized = True
+        self._viewer_singleton_key = self.canonical_viewer(viewer)
+        return True
+
+    def _singleton_finalize_init(self) -> None:
+        """Post-Qt-init finalization. Call after QWidget.__init__()."""
+        # only connect once, and only after QObject exists
+        if getattr(self, "_viewer_singleton_finalize_done", False):
+            return
+        self._viewer_singleton_finalize_done = True
+        self.destroyed.connect(self._on_singleton_destroyed)
+
+    def _on_singleton_destroyed(self, *args) -> None:
+        key = getattr(self, "_viewer_singleton_key", None)
+        if key is None:
+            return
+
+        reg = self.__class__._instance_registry()
+        ref = reg.get(key)
+        if ref is not None and ref() is self:
+            reg.pop(key, None)

--- a/src/napari_deeplabcut/ui/debug_window.py
+++ b/src/napari_deeplabcut/ui/debug_window.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QAction, QFontDatabase, QKeySequence
+from qtpy.QtGui import QAction, QFontDatabase, QKeySequence, QTextCursor
 from qtpy.QtWidgets import (
     QApplication,
     QDialog,
@@ -128,7 +128,7 @@ class DebugTextWindow(QDialog):
             text = f"[debug-window] failed to build debug text\n\n{exc!r}"
 
         self._text_edit.setPlainText(text or "<no debug text available>")
-        self._text_edit.moveCursor(self._text_edit.textCursor().Start)
+        self._text_edit.moveCursor(QTextCursor.MoveOperation.Start)
         self._status_label.setText("")
 
     def copy_to_clipboard(self) -> None:

--- a/src/napari_deeplabcut/ui/debug_window.py
+++ b/src/napari_deeplabcut/ui/debug_window.py
@@ -1,0 +1,140 @@
+# src/napari_deeplabcut/ui/debug_window.py
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QAction, QFontDatabase, QKeySequence
+from qtpy.QtWidgets import (
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from napari_deeplabcut.utils.debug import InMemoryDebugRecorder, build_debug_report
+
+
+def make_log_text_provider(
+    *,
+    recorder: InMemoryDebugRecorder | None,
+    limit: int = 300,
+) -> Callable[[], str]:
+    def _provider() -> str:
+        if recorder is None:
+            return "<debug recorder unavailable>"
+        return recorder.render_text(limit=limit)
+
+    return _provider
+
+
+def make_issue_report_provider(
+    *,
+    viewer,
+    recorder: InMemoryDebugRecorder | None,
+    log_limit: int = 300,
+) -> Callable[[], str]:
+    def _provider() -> str:
+        return build_debug_report(viewer=viewer, recorder=recorder, log_limit=log_limit)
+
+    return _provider
+
+
+class DebugTextWindow(QDialog):
+    """
+    Minimal, shape-agnostic debug text viewer.
+
+    This widget only knows how to:
+    - fetch text from a callable
+    - display it read-only
+    - copy it to clipboard
+    - refresh it on demand
+
+    It intentionally knows nothing about:
+    - log recorder internals
+    - napari viewer internals
+    - environment/report formatting
+    """
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        text_provider: Callable[[], str],
+        parent: QWidget | None = None,
+        initial_hint: str = "Read-only diagnostic output",
+    ) -> None:
+        super().__init__(parent=parent)
+        self.setWindowTitle(title)
+        self.setModal(False)
+        self.resize(900, 650)
+
+        self._text_provider = text_provider
+
+        self._build_ui(initial_hint=initial_hint)
+        self.refresh_text()
+
+    def _build_ui(self, *, initial_hint: str) -> None:
+        layout = QVBoxLayout(self)
+
+        self._hint_label = QLabel(initial_hint, self)
+        self._hint_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        layout.addWidget(self._hint_label)
+
+        self._text_edit = QPlainTextEdit(self)
+        self._text_edit.setReadOnly(True)
+        self._text_edit.setLineWrapMode(QPlainTextEdit.NoWrap)
+
+        # Use a fixed-width system font for logs / reports
+        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        self._text_edit.setFont(font)
+
+        layout.addWidget(self._text_edit, stretch=1)
+
+        button_row = QHBoxLayout()
+
+        self._status_label = QLabel("", self)
+        self._status_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        button_row.addWidget(self._status_label, stretch=1)
+
+        self._refresh_btn = QPushButton("Refresh", self)
+        self._refresh_btn.clicked.connect(self.refresh_text)
+        button_row.addWidget(self._refresh_btn)
+
+        self._copy_btn = QPushButton("Copy to clipboard", self)
+        self._copy_btn.clicked.connect(self.copy_to_clipboard)
+        button_row.addWidget(self._copy_btn)
+
+        self._close_btn = QPushButton("Close", self)
+        self._close_btn.clicked.connect(self.close)
+        button_row.addWidget(self._close_btn)
+
+        layout.addLayout(button_row)
+
+        # Optional keyboard shortcut
+        copy_action = QAction(self)
+        copy_action.setShortcut(QKeySequence.Copy)
+        copy_action.triggered.connect(self.copy_to_clipboard)
+        self.addAction(copy_action)
+
+    def refresh_text(self) -> None:
+        try:
+            text = self._text_provider()
+        except Exception as exc:
+            text = f"[debug-window] failed to build debug text\n\n{exc!r}"
+
+        self._text_edit.setPlainText(text or "<no debug text available>")
+        self._text_edit.moveCursor(self._text_edit.textCursor().Start)
+        self._status_label.setText("")
+
+    def copy_to_clipboard(self) -> None:
+        try:
+            text = self._text_edit.toPlainText()
+            QApplication.clipboard().setText(text)
+            self._status_label.setText("Copied to clipboard")
+        except Exception:
+            self._status_label.setText("Could not copy to clipboard")

--- a/src/napari_deeplabcut/ui/dialogs.py
+++ b/src/napari_deeplabcut/ui/dialogs.py
@@ -1,3 +1,8 @@
+"""Common dialogs used in napari-deeplabcut.
+
+NOTE: could be split into dialogs/tutorial.py, dialogs/shortcuts.py, dialogs/config_prompt.py, etc.
+"""
+
 # src/napari_deeplabcut/ui/dialogs.py
 from __future__ import annotations
 

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -152,7 +152,7 @@ class LayerStatusPanel(QGroupBox):
         text = folder_name or "—"
         self._folder_value.setText(text)
 
-        tooltip = (full_path or "No open project folder").strip()
+        tooltip = (f"Project: {full_path}" if full_path else "No open project folder").strip()
         self._folder_value.setToolTip(tooltip)
 
     def _show_progress_context_menu(self, pos) -> None:

--- a/src/napari_deeplabcut/ui/layer_stats.py
+++ b/src/napari_deeplabcut/ui/layer_stats.py
@@ -148,8 +148,12 @@ class LayerStatusPanel(QGroupBox):
         self._size_slider.setToolTip(tooltip)
         self._size_value.setToolTip(tooltip)
 
-    def set_folder_name(self, folder_name: str) -> None:
-        self._folder_value.setText(folder_name or "—")
+    def set_folder_name(self, folder_name: str, *, full_path: str | None = None) -> None:
+        text = folder_name or "—"
+        self._folder_value.setText(text)
+
+        tooltip = (full_path or "No open project folder").strip()
+        self._folder_value.setToolTip(tooltip)
 
     def _show_progress_context_menu(self, pos) -> None:
         if not self._progress_details_text:

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -23,12 +23,12 @@ from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayout, QWidget
 
 import napari_deeplabcut.core.io as io
-from napari_deeplabcut.config.models import DLCHeaderModel
 from napari_deeplabcut.config.settings import (
     DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP,
     DEFAULT_SINGLE_ANIMAL_CMAP,
 )
 from napari_deeplabcut.core.keypoints import build_color_cycles
+from napari_deeplabcut.core.layer_lifecycle import LayerLifecycleManager
 from napari_deeplabcut.core.layers import (
     get_first_image_layer,
     get_first_video_image_layer,
@@ -184,44 +184,6 @@ class TrajectoryMatplotlibCanvas(QWidget):
         Smallest comfortable size before the widget becomes cramped.
         """
         return QSize(280, 340)
-
-    def _get_header_model_from_metadata(self, md: dict) -> DLCHeaderModel | None:
-        """Return DLCHeaderModel from metadata['header'] when possible.
-        TODO: Check codebase for duplicate logic and centralize if needed.
-        """
-        if not isinstance(md, dict):
-            return None
-
-        hdr = md.get("header", None)
-        if hdr is None:
-            return None
-
-        if isinstance(hdr, DLCHeaderModel):
-            return hdr
-
-        if isinstance(hdr, dict):
-            try:
-                return DLCHeaderModel.model_validate(hdr)
-            except Exception:
-                return None
-
-        try:
-            return DLCHeaderModel(columns=hdr)
-        except Exception:
-            return None
-
-    def _is_multianimal_layer(self, layer: Points) -> bool:
-        """TODO: Check codebase for duplicate logic and centralize if needed."""
-        md = getattr(layer, "metadata", None) or {}
-        header = self._get_header_model_from_metadata(md)
-        if header is None:
-            return False
-
-        try:
-            inds = getattr(header, "individuals", None)
-            return bool(inds and len(inds) > 0 and str(inds[0]) != "")
-        except Exception:
-            return False
 
     def _get_config_colormap(self, layer: Points) -> str:
         """Return the colormap for the given layer based on its metadata.
@@ -661,7 +623,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         - single-animal falls back to the bodypart cycle for both
         """
         md = getattr(layer, "metadata", None) or {}
-        header = self._get_header_model_from_metadata(md)
+        header = LayerLifecycleManager.get_header_model_from_metadata(md)
         if header is None:
             return {}
 
@@ -673,7 +635,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
             logger.debug("Trajectory plot: failed to build bodypart color cycles", exc_info=True)
             bodypart_cycles = {}
 
-        if self._is_multianimal_layer(layer):
+        if LayerLifecycleManager.is_multianimal(layer):
             try:
                 individual_cycles = build_color_cycles(header, DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP) or {}
             except Exception:
@@ -705,7 +667,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         individual_key = self._normalized_individual_name(individual)
         bodypart_key = str(bodypart)
 
-        if mode == "individual" and self._is_multianimal_layer(points_layer):
+        if mode == "individual" and LayerLifecycleManager.is_multianimal(points_layer):
             if individual_key and individual_key in id_cycle:
                 return id_cycle[individual_key]
             if bodypart_key in label_cycle:

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -5,15 +5,18 @@ import logging
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
+from html import escape
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from napari.layers import Image, Points
 from napari.utils.history import get_save_history
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 
 from ...core.conflicts import compute_overwrite_report_for_points_save
 from ...core.errors import MissingProvenanceError
+from ...core.io import is_video
 from ...core.layers import is_machine_layer
 from ...core.metadata import (
     MergePolicy,
@@ -179,6 +182,14 @@ class PointsLayerSaveWorkflow:
             base_metadata = overridden_metadata if overridden_metadata is not None else dict(layer.metadata or {})
             save_metadata = self._enrich_points_metadata_for_save(layer, base_metadata)
 
+            if self._is_unsupported_direct_video_label_save(layer, save_metadata):
+                self.logger.debug(
+                    "Save aborted due to unsupported direct video label save case. Layer=%r",
+                    getattr(layer, "name", layer),
+                )
+                self._warn_unsupported_direct_video_label_save(layer, save_metadata)
+                return SaveOutcome(saved=False)
+
             attributes = {
                 "name": layer.name,
                 "metadata": save_metadata,
@@ -334,6 +345,80 @@ class PointsLayerSaveWorkflow:
                 md.setdefault("root", str(candidate))
 
         return md
+
+    def _is_video_context_layer(self, layer: Image | None) -> bool:
+        if layer is None:
+            return False
+
+        md = getattr(layer, "metadata", {}) or {}
+        dlc_md = md.get("dlc") or {}
+        if dlc_md.get("session_role") == "video":
+            return True
+
+        try:
+            src = getattr(getattr(layer, "source", None), "path", None)
+        except Exception:
+            src = None
+
+        for candidate in (src, getattr(layer, "name", None)):
+            if candidate and is_video(str(candidate)):
+                return True
+
+        return False
+
+    def _is_unsupported_direct_video_label_save(self, layer: Points, metadata: dict) -> bool:
+        """
+        Unsupported case:
+        - points layer has no extracted-frame row keys (`paths`)
+        - current save context is a video session
+
+        This corresponds to labeling directly on a loaded video after adding
+        a config.yaml / placeholder config, which bypasses DLC frame extraction.
+        """
+        paths = metadata.get("paths") or []
+        if paths:
+            return False
+
+        image_layer = self._best_image_context_layer()
+        return self._is_video_context_layer(image_layer)
+
+    def _warn_unsupported_direct_video_label_save(self, layer: Points, metadata: dict) -> None:
+        image_layer = self._best_image_context_layer()
+        image_name = getattr(image_layer, "name", None) if image_layer is not None else "current video"
+        config_path = self.resolve_config_path_for_layer(layer)
+
+        image_html = escape(image_name or "not found")
+        config_html = escape(str(config_path) if config_path is not None else "not found")
+
+        msg = QMessageBox(self.parent)
+        msg.setIcon(QMessageBox.Warning)
+        msg.setWindowTitle("Cannot save labels from video directly")
+        msg.setTextFormat(Qt.RichText)
+        msg.setText(
+            "<p>"
+            "The currently loaded image layer looks like it is a video, and the keypoints layer "
+            "has no paths to individual image files."
+            "</p>"
+            "<p>"
+            "Saving labels created directly on a loaded video by adding <code>config.yaml</code> "
+            "is <b>not supported</b>."
+            "</p>"
+            "<p>"
+            "This bypasses DeepLabCut's frame extraction workflow, and the plugin cannot write a valid "
+            "<code>CollectedData_&lt;scorer&gt;.h5</code> file from video frame indices alone."
+            "</p>"
+            f"<p><b>Video context:</b> {image_html}<br>"
+            f"<b>Config:</b> {config_html}</p>"
+            "<p><b>What to do instead:</b></p>"
+            "<ul>"
+            "<li>First, use <b>Video panel &gt; 'Extract current frame'</b> (or use DeepLabCut) for this video</li>"
+            "<li>Load the resulting <code>labeled-data</code> folder / extracted images</li>"
+            "<li>If needed, drag and drop the <code>config.yaml</code> to create a placeholder points layer</li>"
+            "<li>Start annotating and save those extracted frames</li>"
+            "</ul>"
+        )
+        msg.setStandardButtons(QMessageBox.Ok)
+        msg.exec()
 
     def _format_missing_provenance_save_message(self, layer: Points, metadata: dict) -> str:
         config_path = self.resolve_config_path_for_layer(layer)

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -254,9 +254,13 @@ class PointsLayerSaveWorkflow:
         hist = get_save_history()
         dlg.setHistory(hist)
 
+        if hist and hist[0]:
+            dir_hint = hist[0]
+        else:
+            dir_hint = str(Path.home())
         filename, _ = dlg.getSaveFileName(
             caption=f"Save {'selected' if selected else 'all'} layers",
-            dir=hist[0],  # home dir by default
+            dir=dir_hint,  # home dir by default
         )
 
         if not filename:
@@ -462,7 +466,7 @@ class PointsLayerSaveWorkflow:
 
         from ...config.models import PointsMetadata  # local import to avoid unnecessary module load in import path
 
-        if not safe_folder_anchor_from_points_layer(layer) and not is_machine_layer(layer := layer):
+        if not safe_folder_anchor_from_points_layer(layer):
             # Preserve old fast path for non-machine layers
             return True
 

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -85,14 +85,31 @@ def _prompt_for_scorer(parent_widget, *, anchor: str, suggested: str) -> str | N
     return scorer
 
 
+def _replace_layer_metadata_in_place(layer: Points, metadata: dict) -> None:
+    """Replace layer.metadata contents while preserving the mapping object."""
+    current = layer.metadata
+    if current is None:
+        layer.metadata = {}
+        current = layer.metadata
+
+    current.clear()
+    current.update(metadata or {})
+
+
 @contextmanager
 def _temporary_layer_metadata(layer: Points, metadata: dict):
-    old_metadata = dict(layer.metadata or {})
-    layer.metadata = metadata
+    current = layer.metadata
+    if current is None:
+        layer.metadata = {}
+        current = layer.metadata
+
+    old_metadata = dict(current)
     try:
+        _replace_layer_metadata_in_place(layer, metadata)
         yield
     finally:
-        layer.metadata = old_metadata
+        current.clear()
+        current.update(old_metadata)
 
 
 class PointsLayerSaveWorkflow:
@@ -239,7 +256,7 @@ class PointsLayerSaveWorkflow:
 
         # Persist successful save-time metadata improvements into the live layer.
         if metadata_changed:
-            layer.metadata = dict(save_metadata)
+            _replace_layer_metadata_in_place(layer, save_metadata)
 
         self._persist_folder_ui_state_for_layers([layer])
 

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -184,7 +184,7 @@ class PointsLayerSaveWorkflow:
 
             if self._is_unsupported_direct_video_label_save(layer, save_metadata):
                 self.logger.debug(
-                    "Save aborted due to unsupported direct video label save case. Layer=%r",
+                    "Save aborted due to unsupported direct video + config.yaml label save case. Layer=%r",
                     getattr(layer, "name", layer),
                 )
                 self._warn_unsupported_direct_video_label_save(layer, save_metadata)

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -581,7 +581,7 @@ class PointsLayerSaveWorkflow:
             pts,
             anchor=anchor,
             scorer=scorer,
-            dataset_key="keypoints",
+            dataset_key="df_with_missing",
         )
 
         out = write_points_meta(

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -1,4 +1,4 @@
-# src/napari_deeplabcut/ui/dialogs/save.py
+# src/napari_deeplabcut/ui/ui_dialogs/save.py
 from __future__ import annotations
 
 import logging

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -407,14 +407,14 @@ class PointsLayerSaveWorkflow:
             "This bypasses DeepLabCut's frame extraction workflow, and the plugin cannot write a valid "
             "<code>CollectedData_&lt;scorer&gt;.h5</code> file from video frame indices alone."
             "</p>"
-            f"<p><b>Video context:</b> {image_html}<br>"
+            f"<p><b>Video:</b> {image_html}<br>"
             f"<b>Config:</b> {config_html}</p>"
             "<p><b>What to do instead:</b></p>"
             "<ul>"
             "<li>First, use <b>Video panel &gt; 'Extract current frame'</b> (or use DeepLabCut) for this video</li>"
             "<li>Load the resulting <code>labeled-data</code> folder / extracted images</li>"
             "<li>If needed, drag and drop the <code>config.yaml</code> to create a placeholder points layer</li>"
-            "<li>Start annotating and save those extracted frames</li>"
+            "<li>Start annotating in the created Points layer and save it</li>"
             "</ul>"
         )
         msg.setStandardButtons(QMessageBox.Ok)

--- a/src/napari_deeplabcut/ui/ui_dialogs/save.py
+++ b/src/napari_deeplabcut/ui/ui_dialogs/save.py
@@ -1,0 +1,625 @@
+# src/napari_deeplabcut/ui/dialogs/save.py
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from napari.layers import Image, Points
+from napari.utils.history import get_save_history
+from qtpy.QtWidgets import QFileDialog, QInputDialog, QMessageBox
+
+from ...core.conflicts import compute_overwrite_report_for_points_save
+from ...core.errors import MissingProvenanceError
+from ...core.layers import is_machine_layer
+from ...core.metadata import (
+    MergePolicy,
+    apply_project_paths_override_to_points_meta,
+    migrate_points_layer_metadata,
+    read_points_meta,
+    write_points_meta,
+)
+from ...core.project_paths import (
+    coerce_paths_to_dlc_row_keys,
+    dataset_folder_has_files,
+    find_nearest_config,
+    looks_like_dlc_labeled_folder,
+    normalize_anchor_candidate,
+    resolve_project_root_from_config,
+    target_dataset_folder_for_config,
+)
+from ...core.provenance import (
+    apply_gt_save_target,
+    is_projectless_folder_association_candidate,
+    requires_gt_promotion,
+    suggest_human_placeholder,
+)
+from ...core.sidecar import get_default_scorer, set_default_scorer
+from ...core.trails import safe_folder_anchor_from_points_layer
+from ..dialogs import (
+    ProjectConfigPromptAction,
+    load_scorer_from_config,
+    maybe_confirm_dataset_path_rewrite,
+    maybe_confirm_overwrite,
+    prompt_for_project_config_for_save,
+    warn_existing_dataset_folder_conflict,
+    warn_invalid_config_for_scorer,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ...config.models import ImageMetadata
+    from ...core.layer_lifecycle.manager import LayerLifecycleManager
+    from ...core.trails import TrailsController
+
+
+@dataclass(slots=True)
+class SaveOutcome:
+    saved: bool
+    status_message: str | None = None
+
+
+def _prompt_for_scorer(parent_widget, *, anchor: str, suggested: str) -> str | None:
+    """Prompt user for a scorer name. Returns non-empty string or None if cancelled."""
+    text, ok = QInputDialog.getText(
+        parent_widget,
+        "Choose scorer",
+        "No DLC config.yaml scorer found.\n"
+        "Please enter a scorer name for the CollectedData file.\n\n"
+        "Tip: Use your name or a stable lab identifier.\n"
+        "(We strongly discourage keeping the generic 'human_xxxxxx'.)",
+        text=suggested,
+    )
+    if not ok:
+        return None
+    scorer = (text or "").strip()
+    if not scorer:
+        return None
+    return scorer
+
+
+@contextmanager
+def _temporary_layer_metadata(layer: Points, metadata: dict):
+    old_metadata = dict(layer.metadata or {})
+    layer.metadata = metadata
+    try:
+        yield
+    finally:
+        layer.metadata = old_metadata
+
+
+class PointsLayerSaveWorkflow:
+    """Orchestrate save flows for napari-deeplabcut points layers.
+
+    This class owns:
+    - single-layer save routing
+    - promotion-to-GT checks
+    - project association / metadata override flow
+    - overwrite preflight + confirmation
+    - save-time provenance enrichment
+    - post-save sidecar UI-state persistence
+
+    It intentionally does NOT own widget-specific UI state updates such as:
+    - KeypointControls._is_saved
+    - last-saved timestamp label
+    """
+
+    def __init__(
+        self,
+        *,
+        parent,
+        viewer,
+        layer_manager: LayerLifecycleManager,
+        trails_controller: TrailsController,
+        trail_checkbox_getter: Callable[[], bool],
+        resolve_config_path_for_layer: Callable[[Points | None], Path | None],
+        current_project_path_getter: Callable[[], str | None],
+        current_image_meta_getter: Callable[[], ImageMetadata],
+        logger: logging.Logger,
+    ) -> None:
+        self.parent = parent
+        self.viewer = viewer
+        self.layer_manager = layer_manager
+        self.trails_controller = trails_controller
+        self.trail_checkbox_getter = trail_checkbox_getter
+        self.resolve_config_path_for_layer = resolve_config_path_for_layer
+        self.current_project_path_getter = current_project_path_getter
+        self.current_image_meta_getter = current_image_meta_getter
+        self.logger = logger
+
+    # ------------------------------------------------------------------ #
+    # Public entry point                                                 #
+    # ------------------------------------------------------------------ #
+
+    def save_layers(self, *, selected: bool = False) -> SaveOutcome:
+        selected_layers = list(self.viewer.layers.selection)
+
+        msg = ""
+        if not len(self.viewer.layers):
+            msg = "There are no layers in the viewer to save."
+        elif selected and not len(selected_layers):
+            msg = "Please select a Points layer to save."
+
+        if msg:
+            QMessageBox.warning(self.parent, "Nothing to save", msg, QMessageBox.Ok)
+            return SaveOutcome(saved=False)
+
+        if len(selected_layers) == 1 and isinstance(selected_layers[0], Points):
+            return self._save_single_points_layer(selected_layers[0])
+
+        return self._save_multiple_layers(selected=selected, selected_layers=selected_layers)
+
+    # ------------------------------------------------------------------ #
+    # Single-layer points save                                           #
+    # ------------------------------------------------------------------ #
+
+    def _save_single_points_layer(self, layer: Points) -> SaveOutcome:
+        ok = self._ensure_promotion_save_target(layer)
+        if not ok:
+            return SaveOutcome(saved=False)
+
+        self.logger.debug(
+            "About to save. io.kind=%r save_target=%r",
+            layer.metadata.get("io", {}).get("kind"),
+            layer.metadata.get("save_target"),
+        )
+
+        save_metadata: dict = dict(layer.metadata or {})
+
+        try:
+            overridden_metadata, abort_save = self._maybe_prepare_project_path_override_metadata(layer)
+            if abort_save:
+                self.logger.debug("Save aborted during project-association path handling.")
+                return SaveOutcome(saved=False)
+
+            base_metadata = overridden_metadata if overridden_metadata is not None else dict(layer.metadata or {})
+            save_metadata = self._enrich_points_metadata_for_save(layer, base_metadata)
+
+            attributes = {
+                "name": layer.name,
+                "metadata": save_metadata,
+                "properties": dict(layer.properties or {}),
+            }
+
+            report = compute_overwrite_report_for_points_save(layer.data, attributes)
+
+        except MissingProvenanceError:
+            self.logger.exception(
+                "Missing save provenance for layer %r",
+                getattr(layer, "name", layer),
+            )
+            QMessageBox.warning(
+                self.parent,
+                "Cannot save keypoints",
+                self._format_missing_provenance_save_message(layer, save_metadata),
+                QMessageBox.Ok,
+            )
+            return SaveOutcome(saved=False)
+
+        except Exception as e:
+            self.logger.exception(
+                "Failed to prepare save checks for layer %r",
+                getattr(layer, "name", layer),
+            )
+            QMessageBox.warning(
+                self.parent,
+                "Cannot save keypoints",
+                f"Something went wrong while preparing this layer for saving:\n{e}",
+                QMessageBox.Ok,
+            )
+            return SaveOutcome(saved=False)
+
+        if report is not None:
+            if not maybe_confirm_overwrite(
+                parent=self.parent,
+                report=report,
+            ):
+                self.logger.debug("Save cancelled.")
+                return SaveOutcome(saved=False)
+
+        metadata_changed = save_metadata != dict(layer.metadata or {})
+
+        with _temporary_layer_metadata(layer, save_metadata):
+            self.viewer.layers.save("__dlc__.h5", selected=True, plugin="napari-deeplabcut")
+
+        # Persist successful save-time metadata improvements into the live layer.
+        if metadata_changed:
+            layer.metadata = dict(save_metadata)
+
+        self._persist_folder_ui_state_for_layers([layer])
+
+        return SaveOutcome(saved=True, status_message="Data successfully saved")
+
+    # ------------------------------------------------------------------ #
+    # Multi-layer / generic save                                         #
+    # ------------------------------------------------------------------ #
+
+    def _save_multiple_layers(self, *, selected: bool, selected_layers: list) -> SaveOutcome:
+        dlg = QFileDialog()
+        hist = get_save_history()
+        dlg.setHistory(hist)
+
+        filename, _ = dlg.getSaveFileName(
+            caption=f"Save {'selected' if selected else 'all'} layers",
+            dir=hist[0],  # home dir by default
+        )
+
+        if not filename:
+            return SaveOutcome(saved=False)
+
+        self.viewer.layers.save(filename, selected=selected)
+
+        if selected:
+            candidate_layers = [ly for ly in selected_layers if isinstance(ly, Points)]
+        else:
+            candidate_layers = list(self.layer_manager.managed_points_layers())
+
+        self._persist_folder_ui_state_for_layers(candidate_layers)
+
+        return SaveOutcome(saved=True, status_message="Data successfully saved")
+
+    # ------------------------------------------------------------------ #
+    # Save-time metadata enrichment                                      #
+    # ------------------------------------------------------------------ #
+
+    def _best_image_context_layer(self) -> Image | None:
+        """Return the best available image layer for save-time provenance inference."""
+        active = self.layer_manager.active_dlc_image_layer()
+        if active is not None:
+            return active
+
+        selected = self.viewer.layers.selection.active
+        if isinstance(selected, Image):
+            return selected
+
+        for layer in self.viewer.layers:
+            if isinstance(layer, Image):
+                return layer
+
+        return None
+
+    def _enrich_points_metadata_for_save(self, layer: Points, metadata: dict) -> dict:
+        """Best-effort save-time metadata enrichment for DLC routing.
+
+        Conservative policy:
+        - never overwrite explicit metadata already present
+        - first reuse lifecycle-owned image context
+        - then try nearby config.yaml + image/source hints
+        """
+        md = dict(metadata or {})
+
+        if md.get("root"):
+            return md
+
+        if self.layer_manager.image_root:
+            md.setdefault("root", self.layer_manager.image_root)
+        if self.layer_manager.image_paths:
+            md.setdefault("paths", self.layer_manager.image_paths)
+
+        if md.get("root"):
+            return md
+
+        config_path = self.resolve_config_path_for_layer(layer)
+        if config_path is None:
+            return md
+
+        project_root = resolve_project_root_from_config(config_path)
+        if project_root is None:
+            return md
+
+        md.setdefault("project", str(project_root))
+
+        image_layer = self._best_image_context_layer()
+        if image_layer is None:
+            return md
+
+        try:
+            src = getattr(getattr(image_layer, "source", None), "path", None)
+        except Exception:
+            src = None
+
+        src_anchor = normalize_anchor_candidate(src) if src else None
+        if src_anchor is not None and looks_like_dlc_labeled_folder(src_anchor):
+            md.setdefault("root", str(src_anchor))
+            return md
+
+        image_name = getattr(image_layer, "name", None)
+        if image_name:
+            candidate = project_root / "labeled-data" / str(image_name)
+            if candidate.is_dir():
+                md.setdefault("root", str(candidate))
+
+        return md
+
+    def _format_missing_provenance_save_message(self, layer: Points, metadata: dict) -> str:
+        config_path = self.resolve_config_path_for_layer(layer)
+        image_layer = self._best_image_context_layer()
+
+        layer_name = getattr(layer, "name", "Unnamed layer")
+        project_hint = metadata.get("project") or self.current_project_path_getter() or "not available"
+        root_hint = metadata.get("root") or "not available"
+        n_paths = len(metadata.get("paths") or [])
+
+        image_name = getattr(image_layer, "name", None) if image_layer is not None else None
+
+        return (
+            "Couldn't determine where to save this keypoints layer in a DeepLabCut project.\n\n"
+            f"Layer: {layer_name}\n"
+            f"Project hint: {project_hint}\n"
+            f"Dataset folder (root): {root_hint}\n"
+            f"Paths metadata: {n_paths} item(s)\n"
+            f"Nearby config.yaml: {str(config_path) if config_path is not None else 'not found'}\n"
+            f"Image/video context: {image_name or 'not available'}\n\n"
+            "To save this layer, the plugin needs either:\n"
+            "• a dataset folder (metadata['root']), or\n"
+            "• enough project/image context to infer one automatically.\n\n"
+            "Try one of the following:\n"
+            "• open the image/video from the DLC project first,\n"
+            "• load the project's config.yaml or labeled-data folder, or\n"
+            "• make sure this layer is associated with the correct dataset folder."
+        )
+
+    # ------------------------------------------------------------------ #
+    # Promotion / provenance helpers                                     #
+    # ------------------------------------------------------------------ #
+
+    def _ensure_promotion_save_target(self, layer: Points) -> bool:
+        """Ensure a prediction/machine source layer has a GT save_target set.
+
+        Returns True if save_target is set (or already existed), False if user cancels.
+        """
+        if not getattr(layer, "metadata", None):
+            layer.metadata = {}
+
+        from ...config.models import PointsMetadata  # local import to avoid unnecessary module load in import path
+
+        if not safe_folder_anchor_from_points_layer(layer) and not is_machine_layer(layer := layer):
+            # Preserve old fast path for non-machine layers
+            return True
+
+        if not is_machine_layer(layer):
+            return True
+
+        mig = migrate_points_layer_metadata(layer)
+        if hasattr(mig, "errors"):
+            self.logger.warning(
+                "Failed to migrate points layer metadata for layer=%r: %s",
+                getattr(layer, "name", layer),
+                mig,
+            )
+
+        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
+        if hasattr(res, "errors"):
+            self.logger.warning(
+                "Points metadata validation failed for layer=%r during save target check: %s",
+                getattr(layer, "name", layer),
+                res,
+            )
+            QMessageBox.warning(self.parent, "Cannot save", "Layer metadata is invalid; see logs for details.")
+            return False
+
+        pts: PointsMetadata = res
+
+        if not requires_gt_promotion(pts):
+            return True
+
+        anchor = safe_folder_anchor_from_points_layer(layer)
+        if not anchor:
+            QMessageBox.warning(self.parent, "Cannot save", "Could not determine a folder anchor for saving.")
+            return False
+
+        scorer = None
+
+        cfg_path = None
+        try:
+            cfg_path = find_nearest_config(anchor)
+        except Exception:
+            self.logger.debug("Automatic config discovery failed for anchor=%r", anchor, exc_info=True)
+
+        if cfg_path:
+            try:
+                scorer = load_scorer_from_config(cfg_path)
+            except Exception:
+                self.logger.exception("Failed to load auto-discovered config.yaml: %s", cfg_path)
+                warn_invalid_config_for_scorer(
+                    self.parent,
+                    config_path=cfg_path,
+                    reason="unreadable",
+                    auto_found=True,
+                )
+                return False
+
+            if not scorer:
+                warn_invalid_config_for_scorer(
+                    self.parent,
+                    config_path=cfg_path,
+                    reason="missing_scorer",
+                    auto_found=True,
+                )
+                return False
+
+        else:
+            dialog_result = prompt_for_project_config_for_save(
+                self.parent,
+                initial_dir=self.current_project_path_getter() or anchor,
+                window_title="Locate DLC config for scorer resolution",
+                message=(
+                    "No DeepLabCut config.yaml could be found automatically for this machine-labeled layer.\n\n"
+                    "If this layer belongs to a DLC project, choose its config.yaml so the save uses the "
+                    "project scorer and standard naming.\n\n"
+                    "If no config.yaml exists, you can continue without one."
+                ),
+                choose_button_text="Choose config.yaml",
+                skip_button_text="Continue without config",
+                resolve_scorer=True,
+            )
+
+            if dialog_result.action is ProjectConfigPromptAction.CANCEL:
+                return False
+
+            if dialog_result.action is ProjectConfigPromptAction.ASSOCIATE:
+                scorer = dialog_result.scorer
+
+            else:
+                scorer = get_default_scorer(anchor)
+
+                if not scorer:
+                    suggested = suggest_human_placeholder(anchor)
+                    while True:
+                        s = _prompt_for_scorer(self.parent, anchor=anchor, suggested=suggested)
+                        if s is None:
+                            return False
+                        if s.startswith("human_"):
+                            choice = QMessageBox.question(
+                                self.parent,
+                                "Generic scorer name",
+                                "You entered a generic scorer name starting with 'human_'.\n\n"
+                                "We strongly recommend using a real name or stable identifier.\n"
+                                "Do you want to keep this generic scorer anyway?",
+                                QMessageBox.Yes | QMessageBox.No,
+                            )
+                            if choice == QMessageBox.No:
+                                suggested = s
+                                continue
+                        scorer = s
+                        break
+                    try:
+                        set_default_scorer(anchor, scorer)
+                    except Exception:
+                        self.logger.debug("Failed to persist default scorer to sidecar", exc_info=True)
+
+        updated = apply_gt_save_target(
+            pts,
+            anchor=anchor,
+            scorer=scorer,
+            dataset_key="keypoints",
+        )
+
+        out = write_points_meta(
+            layer,
+            updated,
+            merge_policy=MergePolicy.MERGE,
+            fields={"save_target"},
+            migrate_legacy=True,
+            validate=True,
+        )
+
+        if hasattr(out, "errors"):
+            self.logger.warning("Failed to write save_target for layer=%r: %s", getattr(layer, "name", layer), out)
+            QMessageBox.warning(
+                self.parent,
+                "Cannot save",
+                "Failed to write save target metadata; see logs for details.",
+            )
+            return False
+
+        return True
+
+    def _maybe_prepare_project_path_override_metadata(self, layer: Points) -> tuple[dict | None, bool]:
+        """Optionally prepare save-time metadata by associating a project-less labeled
+        folder with an explicit DLC project chosen via config.yaml.
+        """
+        from ...config.models import PointsMetadata  # local import to avoid unnecessary module load in import path
+
+        res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
+        if hasattr(res, "errors"):
+            return None, False
+
+        pts_meta: PointsMetadata = res
+        paths = pts_meta.paths or []
+        if not paths:
+            return None, False
+
+        if not is_projectless_folder_association_candidate(pts_meta):
+            return None, False
+
+        source_root = pts_meta.root
+        if not source_root:
+            return None, False
+
+        try:
+            source_root_path = Path(source_root).expanduser().resolve(strict=False)
+        except Exception:
+            source_root_path = Path(source_root)
+
+        dataset_name = source_root_path.name
+        if not dataset_name:
+            return None, False
+
+        initial_dir = self.current_project_path_getter() or pts_meta.project or str(source_root_path)
+        dialog_result = prompt_for_project_config_for_save(self.parent, initial_dir=initial_dir)
+
+        if dialog_result.action is ProjectConfigPromptAction.CANCEL:
+            self.logger.debug("User cancelled project association prompt.")
+            return None, True
+
+        if dialog_result.action is ProjectConfigPromptAction.SKIP:
+            self.logger.debug("User chose to continue without project association.")
+            return None, False
+
+        if dialog_result.action is not ProjectConfigPromptAction.ASSOCIATE:
+            self.logger.warning("Unexpected project association dialog result: %r", dialog_result)
+            return None, True
+
+        config_path = dialog_result.config_path
+        if not config_path:
+            self.logger.warning("Project association result was ASSOCIATE but config_path was empty.")
+            return None, True
+
+        project_root = resolve_project_root_from_config(config_path)
+        if project_root is None:
+            QMessageBox.warning(
+                self.parent,
+                "Invalid project configuration",
+                "The selected file is not a valid DeepLabCut config.yaml or project root. "
+                "The save operation has been cancelled.",
+            )
+            return None, True
+
+        target_folder = target_dataset_folder_for_config(config_path, dataset_name=dataset_name)
+        if dataset_folder_has_files(target_folder):
+            warn_existing_dataset_folder_conflict(self.parent, target_folder=target_folder)
+            return None, True
+
+        rewritten_paths, unresolved = coerce_paths_to_dlc_row_keys(
+            paths,
+            source_root=source_root_path,
+            dataset_name=dataset_name,
+        )
+
+        if not maybe_confirm_dataset_path_rewrite(
+            self.parent,
+            project_root=project_root,
+            dataset_name=dataset_name,
+            n_paths=len(paths),
+            n_unresolved=len(unresolved),
+        ):
+            return None, True
+
+        overridden = apply_project_paths_override_to_points_meta(
+            pts_meta,
+            project_root=project_root,
+            rewritten_paths=rewritten_paths,
+        )
+
+        return overridden.model_dump(mode="python", exclude_none=True), False
+
+    # ------------------------------------------------------------------ #
+    # Post-save state persistence                                        #
+    # ------------------------------------------------------------------ #
+
+    def _persist_folder_ui_state_for_layers(self, layers: Iterable[Points]) -> None:
+        try:
+            checked = bool(self.trail_checkbox_getter())
+            for layer in layers:
+                if layer in self.viewer.layers:
+                    self.trails_controller.persist_folder_ui_state_for_points_layer(
+                        layer,
+                        checkbox_checked=checked,
+                    )
+        except Exception:
+            self.logger.debug("Failed to persist folder UI state after save", exc_info=True)

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -17,8 +17,8 @@ from time import perf_counter_ns
 _DEBUG_HANDLER_ATTR = "_napari_dlc_debug_recorder"
 LOG_QUEUE_MAXLEN = 1000
 
-# FIXME disable for release to avoid any overhead, or make configurable via env var/settings
-NAPARI_DLC_LOG_TIMING = True
+# TODO @C-Achard Consider making this configurable via env var/settings
+NAPARI_DLC_LOG_TIMING = False
 
 
 @contextmanager

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -168,7 +168,9 @@ class InMemoryDebugRecorder(logging.Handler):
         lines: list[str] = []
         try:
             records = self.snapshot()[-max(1, int(limit)) :]
-            if not records and self._dropped == 0:
+            if not records:
+                if self._dropped:
+                    return f"[debug-recorder] no captured logs, {self._dropped} internal failures"
                 return ""
 
             base = records[0].created

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -174,8 +174,11 @@ class InMemoryDebugRecorder(logging.Handler):
             base = records[0].created
             for rec in records:
                 ts = datetime.fromtimestamp(rec.created).strftime("%H:%M:%S.%f")[:-3]
-                rel_ms = (rec.created - base) * 1000.0
-                lines.append(f"{ts} (+{rel_ms:8.1f} ms) | {rec.level:<8} | {rec.logger_name} | {rec.message}")
+                if NAPARI_DLC_LOG_TIMING:
+                    rel_ms = (rec.created - base) * 1000.0
+                    lines.append(f"{ts} (+{rel_ms:8.1f} ms) | {rec.level:<8} | {rec.logger_name} | {rec.message}")
+                else:
+                    lines.append(f"{ts} | {rec.level:<8} | {rec.logger_name} | {rec.message}")
                 if rec.exc_text:
                     lines.append(rec.exc_text.rstrip())
 

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -7,13 +7,45 @@ import sys
 import threading
 import traceback
 from collections import deque
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from importlib import metadata
 from pathlib import Path
+from time import perf_counter_ns
 
 _DEBUG_HANDLER_ATTR = "_napari_dlc_debug_recorder"
 LOG_QUEUE_MAXLEN = 1000
+
+# FIXME disable for release to avoid any overhead, or make configurable via env var/settings
+NAPARI_DLC_LOG_TIMING = True
+
+
+@contextmanager
+def log_timing(
+    logger: logging.Logger,
+    label: str,
+    *,
+    level: int = logging.DEBUG,
+    threshold_ms: float | None = None,
+):
+    """Lightweight scoped timer for debug instrumentation.
+
+    Uses perf_counter_ns() for monotonic timing.
+    Logs only if logger is enabled for the requested level.
+    Optionally suppresses tiny timings below threshold_ms.
+    """
+    if not logger.isEnabledFor(level) or not NAPARI_DLC_LOG_TIMING:
+        yield
+        return
+
+    t0 = perf_counter_ns()
+    try:
+        yield
+    finally:
+        dt_ms = (perf_counter_ns() - t0) / 1e6
+        if threshold_ms is None or dt_ms >= threshold_ms:
+            logger.log(level, "%s took %.3f ms", label, dt_ms)
 
 
 def install_debug_recorder(
@@ -136,11 +168,17 @@ class InMemoryDebugRecorder(logging.Handler):
         lines: list[str] = []
         try:
             records = self.snapshot()[-max(1, int(limit)) :]
+            if not records:
+                return ""
+
+            base = records[0].created
             for rec in records:
-                ts = datetime.fromtimestamp(rec.created).strftime("%H:%M:%S")
-                lines.append(f"{ts} | {rec.level:<8} | {rec.logger_name} | {rec.message}")
+                ts = datetime.fromtimestamp(rec.created).strftime("%H:%M:%S.%f")[:-3]
+                rel_ms = (rec.created - base) * 1000.0
+                lines.append(f"{ts} (+{rel_ms:8.1f} ms) | {rec.level:<8} | {rec.logger_name} | {rec.message}")
                 if rec.exc_text:
                     lines.append(rec.exc_text.rstrip())
+
             if self._dropped:
                 lines.append(f"[debug-recorder] dropped internal failures: {self._dropped}")
         except Exception:

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -168,7 +168,7 @@ class InMemoryDebugRecorder(logging.Handler):
         lines: list[str] = []
         try:
             records = self.snapshot()[-max(1, int(limit)) :]
-            if not records:
+            if not records and self._dropped == 0:
                 return ""
 
             base = records[0].created

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import logging
+import platform
+import sys
+import threading
+import traceback
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime
+from importlib import metadata
+from pathlib import Path
+
+_DEBUG_HANDLER_ATTR = "_napari_dlc_debug_recorder"
+LOG_QUEUE_MAXLEN = 1000
+
+
+def install_debug_recorder(
+    *,
+    logger_name: str = "napari-deeplabcut",
+    capacity: int = LOG_QUEUE_MAXLEN,
+) -> InMemoryDebugRecorder:
+    """
+    Attach a single in-memory recorder to the plugin logger namespace.
+    Idempotent: repeated calls return the same recorder.
+    """
+    root_logger = logging.getLogger(logger_name)
+
+    existing = getattr(root_logger, _DEBUG_HANDLER_ATTR, None)
+    if isinstance(existing, InMemoryDebugRecorder):
+        return existing
+
+    recorder = InMemoryDebugRecorder(capacity=capacity, level=logging.DEBUG)
+    recorder.set_name("napari-deeplabcut-debug-recorder")
+
+    # Important:
+    # - attach only to plugin namespace, not global root logger
+    # - set logger level to DEBUG so plugin debug calls are emitted
+    # - keep propagation unchanged
+    root_logger.addHandler(recorder)
+    root_logger.setLevel(logging.DEBUG)
+
+    setattr(root_logger, _DEBUG_HANDLER_ATTR, recorder)
+    return recorder
+
+
+def get_debug_recorder(
+    *,
+    logger_name: str = "napari-deeplabcut",
+) -> InMemoryDebugRecorder | None:
+    logger = logging.getLogger(logger_name)
+    recorder = getattr(logger, _DEBUG_HANDLER_ATTR, None)
+    return recorder if isinstance(recorder, InMemoryDebugRecorder) else None
+
+
+# --------------------------
+#  Debug infrastructure
+# --------------------------
+
+# Recorder
+
+
+@dataclass(frozen=True)
+class RecordedLog:
+    created: float
+    level: str
+    logger_name: str
+    message: str
+    exc_text: str | None = None
+
+
+class InMemoryDebugRecorder(logging.Handler):
+    """
+    Lightweight, fail-open in-memory log recorder.
+
+    Safety properties:
+    - bounded memory via deque(maxlen=...)
+    - no file/network I/O
+    - swallow-all-errors in emit()
+    - does not log from inside itself
+    - stores only small text snapshots
+    """
+
+    def __init__(self, *, capacity: int = LOG_QUEUE_MAXLEN, level: int = logging.DEBUG):
+        super().__init__(level=level)
+        self._records: deque[RecordedLog] = deque(maxlen=max(10, int(capacity)))
+        self._lock = threading.Lock()
+        self._dropped = 0
+
+    @property
+    def dropped_count(self) -> int:
+        return self._dropped
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            # Never call logging from here.
+            # Never inspect plugin objects.
+            msg = self._safe_message(record)
+            exc_text = self._safe_exception_text(record)
+
+            snap = RecordedLog(
+                created=float(getattr(record, "created", 0.0) or 0.0),
+                level=str(getattr(record, "levelname", "UNKNOWN")),
+                logger_name=str(getattr(record, "name", "")),
+                message=msg,
+                exc_text=exc_text,
+            )
+
+            with self._lock:
+                self._records.append(snap)
+
+        except Exception:
+            # Fail open: never let diagnostics interfere with runtime behavior.
+            try:
+                self._dropped += 1
+            except Exception:
+                pass
+
+    def clear(self) -> None:
+        try:
+            with self._lock:
+                self._records.clear()
+                self._dropped = 0
+        except Exception:
+            pass
+
+    def snapshot(self) -> list[RecordedLog]:
+        try:
+            with self._lock:
+                return list(self._records)
+        except Exception:
+            return []
+
+    def render_text(self, *, limit: int = 200) -> str:
+        lines: list[str] = []
+        try:
+            records = self.snapshot()[-max(1, int(limit)) :]
+            for rec in records:
+                ts = datetime.fromtimestamp(rec.created).strftime("%H:%M:%S")
+                lines.append(f"{ts} | {rec.level:<8} | {rec.logger_name} | {rec.message}")
+                if rec.exc_text:
+                    lines.append(rec.exc_text.rstrip())
+            if self._dropped:
+                lines.append(f"[debug-recorder] dropped internal failures: {self._dropped}")
+        except Exception:
+            return "[debug-recorder] failed to render logs"
+        return "\n".join(lines)
+
+    @staticmethod
+    def _safe_message(record: logging.LogRecord) -> str:
+        try:
+            return record.getMessage()
+        except Exception:
+            try:
+                return str(record.msg)
+            except Exception:
+                return "<unrenderable log message>"
+
+    @staticmethod
+    def _safe_exception_text(record: logging.LogRecord) -> str | None:
+        try:
+            if not record.exc_info:
+                return None
+            return "".join(traceback.format_exception(*record.exc_info))
+        except Exception:
+            return "<exception details unavailable>"
+
+
+# Env info
+
+
+def _version(dist_name: str) -> str:
+    try:
+        return metadata.version(dist_name)
+    except Exception:
+        return "not-installed"
+
+
+def _module_path(module_name: str) -> str:
+    try:
+        mod = __import__(module_name)
+        p = getattr(mod, "__file__", None)
+        return str(Path(p).resolve()) if p else "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _safe_tail(pathlike) -> str:
+    """
+    Redact user-specific absolute paths:
+    keep only the last 2 path components when possible.
+    """
+    try:
+        p = Path(str(pathlike))
+        parts = p.parts
+        if len(parts) >= 2:
+            return str(Path(*parts[-2:]))
+        return str(p)
+    except Exception:
+        return str(pathlike)
+
+
+def collect_environment_summary() -> dict[str, str]:
+    return {
+        "python": sys.version.replace("\n", " "),
+        "platform": platform.platform(),
+        "napari-deeplabcut": _version("napari-deeplabcut"),
+        "napari": _version("napari"),
+        "qtpy": _version("QtPy"),
+        "PySide6": _version("PySide6"),
+        "PyQt6": _version("PyQt6"),
+        "shiboken6": _version("shiboken6"),
+        "numpy": _version("numpy"),
+        "pydantic": _version("pydantic"),
+        "plugin_module_path": _module_path("napari_deeplabcut"),
+    }
+
+
+def summarize_layer(layer) -> dict[str, object]:
+    try:
+        md = dict(getattr(layer, "metadata", {}) or {})
+    except Exception:
+        md = {}
+
+    def _len_or_none(x):
+        try:
+            return len(x)
+        except Exception:
+            return None
+
+    summary = {
+        "name": getattr(layer, "name", "<unnamed>"),
+        "type": type(layer).__name__,
+        "visible": bool(getattr(layer, "visible", True)),
+        "metadata_keys": sorted(md.keys()),
+        "project": _safe_tail(md.get("project")) if md.get("project") else None,
+        "root": _safe_tail(md.get("root")) if md.get("root") else None,
+        "paths_count": _len_or_none(md.get("paths")),
+        "has_header": md.get("header") is not None,
+        "has_tables": bool(md.get("tables")),
+        "has_save_target": md.get("save_target") is not None,
+    }
+
+    # Optional lightweight properties summary
+    try:
+        props = getattr(layer, "properties", {}) or {}
+        summary["property_keys"] = sorted(props.keys())
+    except Exception:
+        summary["property_keys"] = []
+
+    # Optional lightweight data shape
+    try:
+        data = getattr(layer, "data", None)
+        summary["data_shape"] = getattr(data, "shape", None)
+    except Exception:
+        summary["data_shape"] = None
+
+    return summary
+
+
+def summarize_viewer(viewer) -> dict[str, object]:
+    try:
+        layers = list(viewer.layers)
+    except Exception:
+        layers = []
+
+    try:
+        active = viewer.layers.selection.active
+        active_name = getattr(active, "name", None) if active is not None else None
+    except Exception:
+        active_name = None
+
+    return {
+        "n_layers": len(layers),
+        "active_layer": active_name,
+        "layers": [summarize_layer(layer) for layer in layers],
+    }
+
+
+def format_debug_report(
+    *,
+    env: dict[str, str],
+    viewer_summary: dict[str, object],
+    logs_text: str,
+) -> str:
+    lines: list[str] = []
+
+    lines.append("## Environment")
+    for k, v in env.items():
+        lines.append(f"- {k}: {v}")
+
+    lines.append("")
+    lines.append("## Viewer")
+    lines.append(f"- n_layers: {viewer_summary.get('n_layers')}")
+    lines.append(f"- active_layer: {viewer_summary.get('active_layer')}")
+
+    lines.append("")
+    lines.append("## Layers")
+    for idx, layer in enumerate(viewer_summary.get("layers", []), start=1):
+        lines.append(f"- [{idx}] name={layer.get('name')!r}, type={layer.get('type')}, visible={layer.get('visible')}")
+        lines.append(f"  - data_shape: {layer.get('data_shape')}")
+        lines.append(f"  - metadata_keys: {layer.get('metadata_keys')}")
+        lines.append(f"  - property_keys: {layer.get('property_keys')}")
+        lines.append(f"  - project: {layer.get('project')}")
+        lines.append(f"  - root: {layer.get('root')}")
+        lines.append(f"  - paths_count: {layer.get('paths_count')}")
+        lines.append(f"  - has_header: {layer.get('has_header')}")
+        lines.append(f"  - has_tables: {layer.get('has_tables')}")
+        lines.append(f"  - has_save_target: {layer.get('has_save_target')}")
+
+    lines.append("")
+    lines.append("## Recent plugin logs")
+    lines.append("```text")
+    lines.append(logs_text or "<no captured logs>")
+    lines.append("```")
+
+    return "\n".join(lines)

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -84,7 +84,7 @@ class InMemoryDebugRecorder(logging.Handler):
 
     def __init__(self, *, capacity: int = LOG_QUEUE_MAXLEN, level: int = logging.DEBUG):
         super().__init__(level=level)
-        self._records: deque[RecordedLog] = deque(maxlen=max(10, int(capacity)))
+        self._records: deque[RecordedLog] = deque(maxlen=max(1, int(capacity)))
         self._lock = threading.Lock()
         self._dropped = 0
 
@@ -195,8 +195,8 @@ def _safe_tail(pathlike) -> str:
         p = Path(str(pathlike))
         parts = p.parts
         if len(parts) >= 2:
-            return str(Path(*parts[-2:]))
-        return str(p)
+            return str(Path(*parts[-2:]).as_posix())
+        return str(p.as_posix())
     except Exception:
         return str(pathlike)
 

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/utils/debug.py
 from __future__ import annotations
 
 import logging
@@ -315,3 +316,21 @@ def format_debug_report(
     lines.append("```")
 
     return "\n".join(lines)
+
+
+def build_debug_report(
+    *,
+    viewer,
+    recorder: InMemoryDebugRecorder | None,
+    log_limit: int = 300,
+) -> str:
+    logs_text = recorder.render_text(limit=log_limit) if recorder is not None else "<debug recorder unavailable>"
+
+    env = collect_environment_summary()
+    viewer_summary = summarize_viewer(viewer)
+
+    return format_debug_report(
+        env=env,
+        viewer_summary=viewer_summary,
+        logs_text=logs_text,
+    )

--- a/src/napari_deeplabcut/widget_factory.py
+++ b/src/napari_deeplabcut/widget_factory.py
@@ -1,0 +1,12 @@
+# src/napari_deeplabcut/_widget_factory.py
+from __future__ import annotations
+
+from ._widgets import KeypointControls
+
+
+def get_existing_keypoint_controls(viewer) -> KeypointControls | None:
+    return KeypointControls.get_existing(viewer)
+
+
+def get_or_create_keypoint_controls(viewer) -> KeypointControls:
+    return KeypointControls(viewer)

--- a/src/napari_deeplabcut/widget_factory.py
+++ b/src/napari_deeplabcut/widget_factory.py
@@ -1,4 +1,4 @@
-# src/napari_deeplabcut/_widget_factory.py
+# src/napari_deeplabcut/widget_factory.py
 from __future__ import annotations
 
 from ._widgets import KeypointControls

--- a/src/napari_deeplabcut/widget_factory.py
+++ b/src/napari_deeplabcut/widget_factory.py
@@ -5,7 +5,12 @@ from ._widgets import KeypointControls
 
 
 def get_existing_keypoint_controls(viewer) -> KeypointControls | None:
-    return KeypointControls.get_existing(viewer)
+    wdg = KeypointControls.get_existing(viewer)
+    if wdg is None:
+        return None
+    if not KeypointControls.is_docked(viewer, wdg):
+        return None
+    return wdg
 
 
 def get_or_create_keypoint_controls(viewer) -> KeypointControls:

--- a/tox.ini
+++ b/tox.ini
@@ -28,5 +28,5 @@ passenv =
     PYTEST_QT_API
     PYVISTA_OFF_SCREEN
 extras =
-    testing
+    dev
 commands = pytest -v --color=yes --cov=napari_deeplabcut --cov-report=xml


### PR DESCRIPTION
Note: this is a work-in-progress PR meant to assist in refactor-related debugging

This pull request introduces a debug window UI, as well as unit tests for the debug logging and reporting utilities. 
It also aims to improve layer wiring via better centralization.

- Refactors the main widget to integrate the debug window and log recorder 
- Improves layer lifecycle management 
- Enhances debug logging throughout key layer-handling methods.
- Adds a separate save workflow
- And various other enhancements

---

### Automated summary

This pull request introduces several improvements and refactorings to the napari-deeplabcut codebase. The most significant changes include enhancing the handling of DeepLabCut (DLC) project context and metadata in I/O functions, expanding and improving the test suite for layer lifecycle management and keypoint storage, and refactoring test code to use a more robust API for accessing layer stores. These changes improve maintainability, correctness, and test coverage.

**Enhancements to DLC project context and layer metadata:**

* Added `_build_dlc_layer_meta` utility and updated `get_video_reader` and `get_folder_parser` to attach explicit DLC lifecycle metadata to layers, improving session and project context handling for both video and image data. [[1]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fR7-R11) [[2]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL20-R56) [[3]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL43-R97) [[4]](diffhunk://#diff-1adb77a2df0b907720bf772ed569e4addb20a0b59fd5594e91d480c64e75a02fL90-R151)

**Layer lifecycle and keypoint store improvements:**

* Added comprehensive tests for the `RuntimeRegistry` and `ManagedPointsRuntime` classes, covering registration, resolution, duplicate handling, iteration, dead entry cleanup, and auditing.
* Expanded tests for `KeypointStore` to cover layer resolver attachment, authoritative resolver behavior, and correct updating of layer references and IDs.

**Test code refactoring and robustness:**

* Refactored e2e and core tests to use the new `get_layer_store` API instead of directly accessing the `_stores` dictionary, improving encapsulation and reliability. [[1]](diffhunk://#diff-8aff50a899022164b6ca9e1cadc4fbed2071a7aec3160abc991f63deafccf125L58-R58) [[2]](diffhunk://#diff-8aff50a899022164b6ca9e1cadc4fbed2071a7aec3160abc991f63deafccf125L137-R137) [[3]](diffhunk://#diff-8aff50a899022164b6ca9e1cadc4fbed2071a7aec3160abc991f63deafccf125L215-R215) [[4]](diffhunk://#diff-8aff50a899022164b6ca9e1cadc4fbed2071a7aec3160abc991f63deafccf125L276-R277) [[5]](diffhunk://#diff-ed4f96f54f09989b6720526cfc1069efc707144ffd316071a393bdd2d5c5342dL49-R49) [[6]](diffhunk://#diff-ed4f96f54f09989b6720526cfc1069efc707144ffd316071a393bdd2d5c5342dL122-R122) [[7]](diffhunk://#diff-ed4f96f54f09989b6720526cfc1069efc707144ffd316071a393bdd2d5c5342dL152-R152) [[8]](diffhunk://#diff-ed4f96f54f09989b6720526cfc1069efc707144ffd316071a393bdd2d5c5342dL190-R190) [[9]](diffhunk://#diff-d8b6bdf943c5c8f86b24bcc143cf30435e2dd1daa7a17f204badfdcbc335bae7L161-R162) [[10]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L92-R92) [[11]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L139-R139) [[12]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L180-R180) [[13]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L233-R233) [[14]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L314-R314) [[15]](diffhunk://#diff-d55a04a860a84898ad0fbafef392b2528e4f5dbfbe4b18d2174d530418b0d4a7L360-R360)

**Keypoint store and test fixes:**

* Updated tests to assert correct `layer_id` values and to use the public `add` method instead of the private `_add` method for adding keypoints. [[1]](diffhunk://#diff-289686990fd306b0ae614f29150a32859efdbad533791e37ff4c95be45f07c0dR15-L15) [[2]](diffhunk://#diff-289686990fd306b0ae614f29150a32859efdbad533791e37ff4c95be45f07c0dL79-R80)

**Test imports and setup:**

* Added missing `pytest` imports to test files to enable test execution.