### PR TITLE
Plugin refactor [9]: QTimer safety

### DIFF
--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -178,9 +178,14 @@ def immediate_qtimer(monkeypatch):
     from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
 
     monkeypatch.setattr(
-        manager_module.QTimer,
-        "singleShot",
-        staticmethod(lambda _ms, fn: fn()),
+        manager_module.LayerLifecycleManager,
+        "_single_shot_owned",
+        lambda self, _ms, fn: fn(),
+    )
+    monkeypatch.setattr(
+        manager_module.LayerLifecycleManager,
+        "_schedule_once",
+        lambda self, _name, _ms, fn: fn(),
     )
 
 

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -273,11 +273,19 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
 @pytest.fixture(autouse=True)
 def _no_autodock(monkeypatch):
     """
-    Prevent the QTimer.singleShot in KeypointControls.__init__ from auto-calling
-    silently_dock_matplotlib_canvas during tests, which would otherwise race
-    with these scenarios and make assertions flaky.
+    Prevent deferred owned-timer callbacks in KeypointControls from running
+    asynchronously during tests.
     """
-    monkeypatch.setattr(_widgets.QTimer, "singleShot", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        _widgets.KeypointControls,
+        "_single_shot_owned",
+        lambda self, _ms, fn: None,
+    )
+    monkeypatch.setattr(
+        _widgets.KeypointControls,
+        "_schedule_once",
+        lambda self, _name, _ms, fn: None,
+    )
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/ui/test_qt_timers.py
+++ b/src/napari_deeplabcut/_tests/ui/test_qt_timers.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import pytest
+from qtpy.QtCore import QObject, Signal
+
+from napari_deeplabcut.ui.base_widget._qt_timers import OwnedTimersMixin
+
+
+class DummyOwner(QObject, OwnedTimersMixin):
+    """Minimal QObject host for OwnedTimersMixin."""
+
+    ping = Signal()
+
+    def __init__(self):
+        super().__init__()
+        self._init_owned_timers()
+
+
+class FakeSignal:
+    def __init__(self):
+        self.callbacks = []
+
+    def connect(self, callback):
+        self.callbacks.append(callback)
+
+
+class FakeTimer:
+    def __init__(self, parent=None, *, fail_on_start=False, fail_on_stop=False, fail_on_delete=False):
+        self.parent = parent
+        self.fail_on_start = fail_on_start
+        self.fail_on_stop = fail_on_stop
+        self.fail_on_delete = fail_on_delete
+
+        self.single_shot = None
+        self.started_with = []
+        self.stopped = 0
+        self.deleted = 0
+        self.timeout = FakeSignal()
+
+    def setSingleShot(self, value):
+        self.single_shot = value
+
+    def start(self, msec):
+        if self.fail_on_start:
+            raise RuntimeError("timer already deleted")
+        self.started_with.append(msec)
+
+    def stop(self):
+        if self.fail_on_stop:
+            raise RuntimeError("timer already deleted")
+        self.stopped += 1
+
+    def deleteLater(self):
+        if self.fail_on_delete:
+            raise RuntimeError("timer already deleted")
+        self.deleted += 1
+
+
+@pytest.fixture
+def owner():
+    return DummyOwner()
+
+
+@pytest.fixture
+def fake_qtimer_state():
+    """Mutable state used by the autouse QTimer patch."""
+    return {
+        "created": [],
+        "fail_on_start": False,
+        "fail_on_stop": False,
+        "fail_on_delete": False,
+    }
+
+
+@pytest.fixture(autouse=True)
+def patch_qtimer(monkeypatch, fake_qtimer_state):
+    """Patch OwnedTimersMixin's QTimer dependency for all tests in this module."""
+
+    def fake_qtimer(parent=None):
+        timer = FakeTimer(
+            parent=parent,
+            fail_on_start=fake_qtimer_state["fail_on_start"],
+            fail_on_stop=fake_qtimer_state["fail_on_stop"],
+            fail_on_delete=fake_qtimer_state["fail_on_delete"],
+        )
+        fake_qtimer_state["created"].append(timer)
+        return timer
+
+    monkeypatch.setattr(
+        "napari_deeplabcut.ui.base_widget._qt_timers.QTimer",
+        fake_qtimer,
+    )
+
+
+def test_init_owned_timers_is_idempotent(owner):
+    timers_before = owner._timers
+    temp_before = owner._temp_timers
+
+    owner._init_owned_timers()
+
+    assert owner._owned_timers_initialized is True
+    assert owner._timers is timers_before
+    assert owner._temp_timers is temp_before
+    assert owner._timers == {}
+    assert owner._temp_timers == set()
+
+
+def test_schedule_once_reuses_named_timer(owner, fake_qtimer_state):
+    calls = []
+
+    def cb():
+        calls.append("called")
+
+    owner._schedule_once("refresh", 0, cb)
+    owner._schedule_once("refresh", 10, cb)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+
+    timer = created[0]
+    assert timer.parent is owner
+    assert timer.single_shot is True
+    assert timer.started_with == [0, 10]
+    assert owner._timers["refresh"] is timer
+    assert timer.timeout.callbacks == [cb]
+    assert calls == []  # scheduling only; no auto-fire here
+
+
+def test_schedule_once_creates_distinct_timers_for_distinct_names(owner, fake_qtimer_state):
+    owner._schedule_once("refresh", 0, lambda: None)
+    owner._schedule_once("status", 5, lambda: None)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 2
+    assert set(owner._timers) == {"refresh", "status"}
+    assert owner._timers["refresh"] is created[0]
+    assert owner._timers["status"] is created[1]
+
+
+def test_single_shot_owned_tracks_timer_and_removes_it_after_fire(owner, fake_qtimer_state):
+    calls = []
+
+    def cb():
+        calls.append("called")
+
+    owner._single_shot_owned(7, cb)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+    timer = created[0]
+    assert timer.parent is owner
+    assert timer.single_shot is True
+    assert timer.started_with == [7]
+    assert timer in owner._temp_timers
+    assert len(timer.timeout.callbacks) == 1
+
+    # Simulate timeout
+    fire = timer.timeout.callbacks[0]
+    fire()
+
+    assert calls == ["called"]
+    assert timer not in owner._temp_timers
+    assert timer.deleted == 1
+
+
+def test_single_shot_owned_discards_timer_if_start_raises(owner, fake_qtimer_state):
+    fake_qtimer_state["fail_on_start"] = True
+
+    owner._single_shot_owned(0, lambda: None)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+    assert created[0] not in owner._temp_timers
+
+
+def test_schedule_once_swallows_runtime_error_on_start(owner, fake_qtimer_state):
+    fake_qtimer_state["fail_on_start"] = True
+
+    owner._schedule_once("refresh", 0, lambda: None)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+    assert owner._timers["refresh"] is created[0]
+
+
+def test_cancel_scheduled_stops_named_timer(owner, fake_qtimer_state):
+    owner._schedule_once("refresh", 0, lambda: None)
+    owner._cancel_scheduled("refresh")
+    owner._cancel_scheduled("missing")  # no-op
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+    assert created[0].stopped == 1
+
+
+def test_cleanup_owned_timers_stops_and_deletes_all(owner, fake_qtimer_state):
+    owner._schedule_once("refresh", 0, lambda: None)
+    owner._schedule_once("status", 1, lambda: None)
+    owner._single_shot_owned(2, lambda: None)
+    owner._single_shot_owned(3, lambda: None)
+
+    assert len(owner._timers) == 2
+    assert len(owner._temp_timers) == 2
+
+    owner._cleanup_owned_timers()
+
+    assert owner._timers == {}
+    assert owner._temp_timers == set()
+
+    for timer in fake_qtimer_state["created"]:
+        assert timer.stopped == 1
+        assert timer.deleted == 1
+
+
+def test_cleanup_owned_timers_swallows_runtime_error(owner, fake_qtimer_state):
+    fake_qtimer_state["fail_on_stop"] = True
+    fake_qtimer_state["fail_on_delete"] = True
+
+    owner._schedule_once("refresh", 0, lambda: None)
+    owner._single_shot_owned(0, lambda: None)
+
+    # Should not raise
+    owner._cleanup_owned_timers()
+
+    assert owner._timers == {}
+    assert owner._temp_timers == set()

--- a/src/napari_deeplabcut/_tests/ui/test_qt_timers.py
+++ b/src/napari_deeplabcut/_tests/ui/test_qt_timers.py
@@ -23,6 +23,12 @@ class FakeSignal:
     def connect(self, callback):
         self.callbacks.append(callback)
 
+    def disconnect(self, callback=None):
+        if callback is None:
+            self.callbacks.clear()
+        else:
+            self.callbacks = [cb for cb in self.callbacks if cb is not callback]
+
 
 class FakeTimer:
     def __init__(self, parent=None, *, fail_on_start=False, fail_on_stop=False, fail_on_delete=False):
@@ -224,3 +230,27 @@ def test_cleanup_owned_timers_swallows_runtime_error(owner, fake_qtimer_state):
 
     assert owner._timers == {}
     assert owner._temp_timers == set()
+
+
+def test_schedule_once_replaces_callback_when_same_name_is_reused(owner, fake_qtimer_state):
+    calls = []
+
+    def cb1():
+        calls.append("cb1")
+
+    def cb2():
+        calls.append("cb2")
+
+    owner._schedule_once("refresh", 0, cb1)
+    owner._schedule_once("refresh", 10, cb2)
+
+    created = fake_qtimer_state["created"]
+    assert len(created) == 1
+
+    timer = created[0]
+    assert timer.started_with == [0, 10]
+    assert timer.timeout.callbacks == [cb2]
+
+    # Simulate timeout: latest callback should win
+    timer.timeout.callbacks[0]()
+    assert calls == ["cb2"]

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -35,7 +35,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from napari.layers import Image, Points
 from napari.utils.events import Event
-from qtpy.QtCore import QSettings, QSignalBlocker, Qt, QTimer
+from qtpy.QtCore import QSettings, QSignalBlocker, Qt
 from qtpy.QtGui import QAction
 from qtpy.QtWidgets import (
     QButtonGroup,
@@ -141,11 +141,6 @@ class KeypointControls(ViewerSingletonWidget):
         self.layer_manager.points_layers_merged_requested.connect(self._on_points_layers_merged_requested)
         self.layer_manager.points_layer_removed_requested.connect(self._on_points_layer_removed_requested)
         self.layer_manager.tracks_layer_removed_requested.connect(self._on_tracks_layer_removed_requested)
-        ## Timers
-        self._timers = {}
-        self._temp_timers = set()
-        self.destroyed.connect(self._cleanup_timers)
-
         ## Debug ##
         self._debug_recorder = install_debug_recorder()
         self._debug_window = None
@@ -348,65 +343,6 @@ class KeypointControls(ViewerSingletonWidget):
     @cached_property
     def settings(self):
         return QSettings()
-
-    def _cleanup_timers(self, *_args) -> None:
-        # FIXME @C-Achard move to singleton base class for other widgets to reuse, and maybe add logs
-        """Stop/delete all timers owned by this widget.
-
-        This is intentionally defensive: by teardown time, some underlying
-        C++ objects may already be in the process of destruction.
-        """
-        for timer in list(getattr(self, "_timers", {}).values()):
-            try:
-                timer.stop()
-                timer.deleteLater()
-            except RuntimeError:
-                pass
-        self._timers = {}
-
-        for timer in list(getattr(self, "_temp_timers", set())):
-            try:
-                timer.stop()
-                timer.deleteLater()
-            except RuntimeError:
-                pass
-        self._temp_timers.clear()
-
-    def _schedule_once(self, name: str, msec: int, callback) -> None:
-        """Schedule/coalesce a named single-shot callback owned by this widget."""
-        timer = self._timers.get(name)
-        if timer is None:
-            timer = QTimer(self)
-            timer.setSingleShot(True)
-            timer.timeout.connect(callback)
-            self._timers[name] = timer
-        try:
-            timer.start(msec)
-        except RuntimeError:
-            # Widget/timer already in teardown
-            pass
-
-    def _single_shot_owned(self, msec: int, callback) -> None:
-        """Schedule a one-off callback using a child QTimer tracked by this widget."""
-        timer = QTimer(self)
-        timer.setSingleShot(True)
-        self._temp_timers.add(timer)
-
-        def _fire():
-            try:
-                callback()
-            finally:
-                self._temp_timers.discard(timer)
-                try:
-                    timer.deleteLater()
-                except RuntimeError:
-                    pass
-
-        timer.timeout.connect(_fire)
-        try:
-            timer.start(msec)
-        except RuntimeError:
-            self._temp_timers.discard(timer)
 
     def _flush_recolor_pending(self) -> None:
         pending = tuple(self._recolor_pending)

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -10,14 +10,17 @@ NOTE: This file is generally already too long. For future development, please co
 - Lifecycle of UI elements and Qt wiring should ideally:
     - Use parent child widgets/controllers to KeypointControls
     - Use child QTimers instead of fire-and-forget QTimer.singleShot for deferred UI work
+      - DONE via mixin in ViewerSingletonWidget
     - Use normal Qt signal connections for Qt-owned objects
     - Keep explicit cleanup only for non-Qt subscriptions/resources
     (e.g. napari event connections, observer install/uninstall, monkey-patch restoration)
 
 TODO: And general dev notes:
-- The saving workflow is crammed into save_layers_dialog() right now,
+- The saving workflow is crammed into save_layers_dialog() right now
   and should move to a dedicated  e.g. PointsLayerSaveFactory class in a dedicated file.
+  - DONE, fixed by PointsLayerSaveWorkflow
 - Something that owns UI sync state (what to refresh, why, when) could help with the heavy wiring.
+  - STARTED, LayerLifecycleManager is a step in this direction
 - I'd suggest keeping in this file:
     - color/label mode, menu/help actions, widget visibility and user interaction hooks.
 """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -748,7 +748,8 @@ class KeypointControls(ViewerSingletonWidget):
 
     @deprecated(
         details="This workflow looks partially implemented and "
-        "cannot be triggered in any way. Either finish it or remove it."
+        "cannot be triggered as DLC never writes the required 'tables' key. "
+        "Either finish it or remove it."
     )
     def load_superkeypoints_diagram(self):
         points_layer = get_first_points_layer(self.viewer)
@@ -781,7 +782,8 @@ class KeypointControls(ViewerSingletonWidget):
         self._keypoint_mapping_button.clicked.connect(lambda: self._map_keypoints(super_animal))
 
     @deprecated(
-        details="This workflow looks partially implemented and cannot be triggered in any way. "
+        details="This workflow looks partially implemented and cannot be reached in any way, "
+        "since DLC never writes the required 'tables' key."
         "Either finish it or remove it."
     )
     def _map_keypoints(self, super_animal: str):

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -807,6 +807,10 @@ class KeypointControls(ViewerSingletonWidget):
         if {"selection", "active_layer", "layers"} & set(event.reasons):
             traj_canvas.sync_visible_lines_to_points_selection()
 
+    @deprecated(
+        details="This workflow looks partially implemented and "
+        "cannot be triggered in any way. Either finish it or remove it."
+    )
     def load_superkeypoints_diagram(self):
         points_layer = get_first_points_layer(self.viewer)
         if points_layer is None:
@@ -837,6 +841,10 @@ class KeypointControls(ViewerSingletonWidget):
             pass
         self._keypoint_mapping_button.clicked.connect(lambda: self._map_keypoints(super_animal))
 
+    @deprecated(
+        details="This workflow looks partially implemented and cannot be triggered in any way. "
+        "Either finish it or remove it."
+    )
     def _map_keypoints(self, super_animal: str):
         # NOTE: This implementation makes several assumptions that may need review:
         # - Assumes points_layer.metadata contains "project" and "header" keys with the expected structure.

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -409,6 +409,11 @@ def add(store: KeypointStore, coord):
     return store.add(coord)
 
 
+@deprecated(
+    details="This was meant to be used for the SuperAnimalConversionTables workflow, "
+    "but said workflow is currently not reachable. "
+    "Either finish that workflow or remove this function."
+)
 def find_nearest_neighbors(xy_true, xy_pred, k=5):
     n_preds = xy_pred.shape[0]
     tree = cKDTree(xy_pred)

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -9,7 +9,7 @@ import numpy as np
 from napari.layers import Image, Layer, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import update_save_history
-from qtpy.QtCore import QObject, QTimer, Signal
+from qtpy.QtCore import QObject, Signal
 
 from ...config.keybinds import install_points_layer_keybindings
 from ...config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
@@ -28,6 +28,7 @@ from ...core.project_paths import PathMatchPolicy
 from ...core.remap import remap_layer_data_by_paths
 from ...napari_compat import install_add_wrapper, install_paste_patch
 from ...napari_compat.points_layer import make_paste_data
+from ...ui.base_widget._qt_timers import OwnedTimersMixin
 from ...ui.cropping import resolve_project_path_from_image_layer
 from ...utils.debug import log_timing
 from .merge import MergeDecisionProvider, MergeDecisionRequest, MergeDecisionResult, MergeDisposition
@@ -48,7 +49,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("napari-deeplabcut.lifecycle")
 
 
-class LayerLifecycleManager(QObject):
+class LayerLifecycleManager(QObject, OwnedTimersMixin):
     """Lifecycle wrapper around existing widget behavior.
 
     Goals
@@ -97,17 +98,9 @@ class LayerLifecycleManager(QObject):
         self._image_meta = ImageMetadata()
         self._project_path: str | None = None
 
-        # Layers management
-        ## Layer insertion
-        self._initial_adopt_timer = QTimer(self)
-        self._initial_adopt_timer.setSingleShot(True)
-        self._initial_adopt_timer.timeout.connect(self.adopt_existing_layers)
-        ## Layer removal
-        self._post_remove_refresh_timer = QTimer(self)
-        self._post_remove_refresh_timer.setSingleShot(True)
-        self._post_remove_refresh_timer.timeout.connect(self._flush_post_remove_refresh)
-
         self._attached = False
+
+        self._init_owned_timers()
 
     # ------------------------------------------------------------------ #
     # Centralized access API                                             #
@@ -212,7 +205,7 @@ class LayerLifecycleManager(QObject):
 
     def schedule_initial_adoption(self) -> None:
         """Schedule adoption of existing layers after the event loop starts."""
-        self._initial_adopt_timer.start(0)
+        self._schedule_once("initial_adopt", 0, self.adopt_existing_layers)
 
     def _dlc_meta_for_layer(self, layer: Layer) -> dict | None:
         md = layer.metadata or {}
@@ -278,7 +271,7 @@ class LayerLifecycleManager(QObject):
                     exc_info=True,
                 )
 
-        QTimer.singleShot(0, _remove_later)
+        self._single_shot_owned(0, _remove_later)
 
     # ------------------------------------------------------------------ #
     # Layer setup managers                                               #
@@ -512,7 +505,8 @@ class LayerLifecycleManager(QObject):
         )
 
         if reorder and index is not None:
-            QTimer.singleShot(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
+            # QTimer.singleShot(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
+            self._single_shot_owned(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
 
     def _wire_points_layer(self, layer: Points) -> KeypointStore | None:
         """Lifecycle-owned wiring of a managed Points layer.
@@ -640,7 +634,7 @@ class LayerLifecycleManager(QObject):
 
     def _schedule_post_remove_refresh(self) -> None:
         """Coalesce repeated UI refreshes during layer removal bursts."""
-        self._post_remove_refresh_timer.start(0)
+        self._schedule_once("post_remove_refresh", 0, self._flush_post_remove_refresh)
 
     def _flush_post_remove_refresh(self) -> None:
         with log_timing(logger, "_flush_post_remove_refresh total", threshold_ms=0.01):
@@ -862,7 +856,8 @@ class LayerLifecycleManager(QObject):
             )
 
         if disposition is MergeDisposition.HIDE_NEW:
-            QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+            # QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+            self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
             return True
 
         if disposition is MergeDisposition.CANCEL:
@@ -917,7 +912,8 @@ class LayerLifecycleManager(QObject):
         self.points_layers_merged_requested.emit(tuple(affected_layers))
 
         # Remove the temporary placeholder layer explicitly by identity.
-        QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+        # QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
+        self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
 
         # General panel refreshes
         self.refresh_layer_status_requested.emit()

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -505,7 +505,6 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         )
 
         if reorder and index is not None:
-            # QTimer.singleShot(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
             self._single_shot_owned(10, lambda ly=layer: self.move_image_layer_to_bottom_requested.emit(ly))
 
     def _wire_points_layer(self, layer: Points) -> KeypointStore | None:
@@ -856,7 +855,6 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             )
 
         if disposition is MergeDisposition.HIDE_NEW:
-            # QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
             self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
             return True
 
@@ -912,7 +910,6 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         self.points_layers_merged_requested.emit(tuple(affected_layers))
 
         # Remove the temporary placeholder layer explicitly by identity.
-        # QTimer.singleShot(0, lambda ly=layer: self._remove_layer_if_present(ly))
         self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
 
         # General panel refreshes

--- a/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
+++ b/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
@@ -1,0 +1,94 @@
+# src/napari_deeplabcut/ui/base_widget/_qt_timers.py
+from __future__ import annotations
+
+from qtpy.QtCore import QTimer
+
+
+class OwnedTimersMixin:
+    """Reusable QObject-owned timer helpers.
+
+    Requirements
+    ------------
+    - `self` must already be a live QObject when `_init_owned_timers()` is called.
+    - The mixin does not subclass QObject itself; it only assumes QObject behavior.
+    """
+
+    def _init_owned_timers(self) -> None:
+        if getattr(self, "_owned_timers_initialized", False):
+            return
+
+        self._owned_timers_initialized = True
+        self._timers: dict[str, QTimer] = {}
+        self._temp_timers: set[QTimer] = set()
+
+        try:
+            self.destroyed.connect(self._cleanup_owned_timers)
+        except Exception:
+            # Defensive: if destroyed is unavailable during odd proxy/test states,
+            # explicit cleanup can still be called manually.
+            pass
+
+    def _cleanup_owned_timers(self, *_args) -> None:
+        """Stop/delete all timers owned by this QObject."""
+        for timer in list(getattr(self, "_timers", {}).values()):
+            try:
+                timer.stop()
+                timer.deleteLater()
+            except RuntimeError:
+                pass
+        self._timers = {}
+
+        for timer in list(getattr(self, "_temp_timers", set())):
+            try:
+                timer.stop()
+                timer.deleteLater()
+            except RuntimeError:
+                pass
+        self._temp_timers.clear()
+
+    def _schedule_once(self, name: str, msec: int, callback) -> None:
+        """Schedule/coalesce a named single-shot callback owned by this QObject."""
+        timer = self._timers.get(name)
+        if timer is None:
+            timer = QTimer(self)
+            timer.setSingleShot(True)
+            timer.timeout.connect(callback)
+            self._timers[name] = timer
+
+        try:
+            timer.start(msec)
+        except RuntimeError:
+            # QObject/timer already tearing down
+            pass
+
+    def _single_shot_owned(self, msec: int, callback) -> None:
+        """Schedule a one-off callback via a child QTimer tracked by this QObject."""
+        timer = QTimer(self)
+        timer.setSingleShot(True)
+        self._temp_timers.add(timer)
+
+        def _fire():
+            try:
+                callback()
+            finally:
+                self._temp_timers.discard(timer)
+                try:
+                    timer.deleteLater()
+                except RuntimeError:
+                    pass
+
+        timer.timeout.connect(_fire)
+
+        try:
+            timer.start(msec)
+        except RuntimeError:
+            self._temp_timers.discard(timer)
+
+    def _cancel_scheduled(self, name: str) -> None:
+        timer = getattr(self, "_timers", {}).get(name)
+        if timer is None:
+            return
+        try:
+            timer.stop()
+        except RuntimeError:
+            pass

--- a/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
+++ b/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
@@ -44,7 +44,8 @@ class OwnedTimersMixin:
                 timer.deleteLater()
             except RuntimeError:
                 pass
-        self._temp_timers.clear()
+        if hasattr(self, "_temp_timers"):
+            self._temp_timers.clear()
 
     def _schedule_once(self, name: str, msec: int, callback) -> None:
         """Schedule/coalesce a named single-shot callback owned by this QObject."""

--- a/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
+++ b/src/napari_deeplabcut/ui/base_widget/_qt_timers.py
@@ -23,7 +23,7 @@ class OwnedTimersMixin:
 
         try:
             self.destroyed.connect(self._cleanup_owned_timers)
-        except Exception:
+        except (RuntimeError, AttributeError):
             # Defensive: if destroyed is unavailable during odd proxy/test states,
             # explicit cleanup can still be called manually.
             pass
@@ -48,13 +48,27 @@ class OwnedTimersMixin:
             self._temp_timers.clear()
 
     def _schedule_once(self, name: str, msec: int, callback) -> None:
-        """Schedule/coalesce a named single-shot callback owned by this QObject."""
+        """Schedule/coalesce a named single-shot callback owned by this QObject.
+
+        Reusing the same name replaces the previous timeout callback with the new one.
+        """
         timer = self._timers.get(name)
         if timer is None:
             timer = QTimer(self)
             timer.setSingleShot(True)
-            timer.timeout.connect(callback)
             self._timers[name] = timer
+        else:
+            try:
+                timer.timeout.disconnect()
+            except (TypeError, RuntimeError):
+                # No previous connection, or timer already tearing down.
+                pass
+
+        try:
+            timer.timeout.connect(callback)
+        except RuntimeError:
+            # QObject/timer already tearing down
+            return
 
         try:
             timer.start(msec)

--- a/src/napari_deeplabcut/ui/base_widget/singleton_widget.py
+++ b/src/napari_deeplabcut/ui/base_widget/singleton_widget.py
@@ -5,8 +5,10 @@ from typing import ClassVar
 
 from qtpy.QtWidgets import QWidget
 
+from ._qt_timers import OwnedTimersMixin
 
-class ViewerSingletonWidget(QWidget):
+
+class ViewerSingletonWidget(QWidget, OwnedTimersMixin):
     """Base QWidget enforcing at most one live instance per viewer per subclass."""
 
     _instances_by_cls: ClassVar[
@@ -139,6 +141,7 @@ class ViewerSingletonWidget(QWidget):
             return
         self._viewer_singleton_finalize_done = True
         self.destroyed.connect(self._on_singleton_destroyed)
+        self._init_owned_timers()
 
     def _on_singleton_destroyed(self, *args) -> None:
         key = getattr(self, "_viewer_singleton_key", None)


### PR DESCRIPTION
Refactors the management of QTimers throughout the codebase by introducing a reusable `OwnedTimersMixin`. This mixin centralizes timer lifecycle management, reducing duplication and making timer cleanup more robust. 
The mixin is now used in both the main widget and the layer lifecycle manager, and all custom timer logic has been removed from those classes. 
Also updates relevant test fixtures that monkeypatched the timers.
This is meant to address random teardown issues in CI.

Additionally, some deprecated and unreachable code is now explicitly marked as such.

---

### Automated summary

**Timer management refactor:**

* Introduced `OwnedTimersMixin` in `src/napari_deeplabcut/ui/base_widget/_qt_timers.py` to provide reusable methods for scheduling, tracking, and cleaning up QTimers owned by QObjects. This ensures consistent and safe timer cleanup on object destruction.
* Updated `LayerLifecycleManager` (`src/napari_deeplabcut/core/layer_lifecycle/manager.py`) to inherit from `OwnedTimersMixin` and use its scheduling methods instead of direct QTimer usage throughout the class. This includes replacing all manual timer setup and single-shot calls with `_schedule_once` and `_single_shot_owned`. [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L12-R12) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R31) [[3]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L51-R52) [[4]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L100-R104) [[5]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L215-R208) [[6]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L281-R274) [[7]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L515-R509) [[8]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L643-R637) [[9]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L865-R860) [[10]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L920-R916)
* Updated `ViewerSingletonWidget` (`src/napari_deeplabcut/ui/base_widget/singleton_widget.py`) to inherit from `OwnedTimersMixin` and initialize the mixin in `_singleton_finalize_init`. [[1]](diffhunk://#diff-35988b625b9113b98ce292dd7cfc214c6d3abc0efb320d909dc896bfe17209d0R8-R11) [[2]](diffhunk://#diff-35988b625b9113b98ce292dd7cfc214c6d3abc0efb320d909dc896bfe17209d0R144)
* Removed all custom timer management code from `src/napari_deeplabcut/_widgets.py`, as this is now handled by the mixin. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L144-L148) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L352-L410)
* Cleaned up imports by removing unused QTimer imports where appropriate. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L38-R41) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L12-R12)

**Codebase clarity and maintenance:**

* Added or updated developer comments and TODOs in `src/napari_deeplabcut/_widgets.py` to reflect the new timer management and workflow refactors.
* Marked unreachable or unfinished workflows and functions as deprecated, adding clear warnings for future maintainers. [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R749-R752) [[2]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6R783-R786) [[3]](diffhunk://#diff-c720f0ede6d0737e1f60ca7cf31ddf4f8ba3014a8e3b26cfdc2271b2ff25af3bR412-R416)