### PR TITLE
Plugin refactor: Minor adjustments for hdf reading and DLCHeaderModel

### DIFF
--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -249,11 +249,7 @@ class DLCHeaderModel(BaseModel):
                 else:
                     out.append((tt[0], "", tt[1], tt[2]))
             else:
-                # unknown shape: do best-effort padding/truncation
-                scorer = tt[0] if len(tt) > 0 else ""
-                bodypart = tt[1] if len(tt) > 1 else ""
-                coords = tt[-1] if len(tt) > 0 else ""
-                out.append((scorer, "", bodypart, coords))
+                raise ValueError(f"Unknown header shape: {tt}. HDF file seems to be corrupted.")
 
         return out
 

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -250,7 +250,10 @@ class DLCHeaderModel(BaseModel):
                 else:
                     out.append((tt[0], "", tt[1], tt[2]))
             else:
-                raise ValueError(f"Unknown header shape: {tt}. HDF file seems to be corrupted.")
+                raise ValueError(
+                    f"Unsupported DLC header shape {tt!r} (got {len(tt)} levels; "
+                    f"expected 3 or 4; names={self.names!r})."
+                )
 
         return out
 

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -196,8 +196,9 @@ class DLCHeaderModel(BaseModel):
     # Core shape helpers (pandas-free)
     # ----------------------------
     @property
-    def nlevels(self) -> int:
-        return len(self.columns[0]) if self.columns else 0
+    def is_single_animal(self) -> bool:
+        canon = self._canonical_4()
+        return bool(canon) and all(t[1] == "" for t in canon)
 
     def _level_index(self, name: str) -> int | None:
         if not self.names:

--- a/src/napari_deeplabcut/core/dataframes.py
+++ b/src/napari_deeplabcut/core/dataframes.py
@@ -13,38 +13,6 @@ from napari_deeplabcut.core.schemas import DLCHeaderModel, PointsWriteInputModel
 logger = logging.getLogger(__name__)
 
 
-def _is_logical_single_animal_header(
-    header: DLCHeaderModel | None,
-    *,
-    is_ma_project: bool | None = None,
-) -> bool:
-    """
-    Determine whether the target should be written in canonical single-animal format.
-
-    Priority
-    --------
-    1) Explicit project-mode signal from DLC config (is_ma_project)
-    2) Original header shape
-    3) Blank-individuals fallback
-    """
-    if is_ma_project is not None:
-        return not bool(is_ma_project)
-
-    if header is None:
-        return False
-
-    # Canonical/original SA header
-    if header.nlevels == 3:
-        return True
-
-    # Fallback for normalized 4-level headers that still represent SA
-    if header.nlevels == 4:
-        inds = [str(i) for i in header.individuals if str(i) != ""]
-        return len(inds) == 0
-
-    return False
-
-
 def restore_dlc_on_disk_header_shape(
     df: pd.DataFrame, header: DLCHeaderModel, *, is_ma_project: bool | None = None
 ) -> pd.DataFrame:
@@ -65,7 +33,12 @@ def restore_dlc_on_disk_header_shape(
 
     df_out = df.copy()
 
-    if _is_logical_single_animal_header(header, is_ma_project=is_ma_project):
+    # If is_ma_project is not provided, let the header report the format.
+    if is_ma_project is None:
+        is_ma_project = not header.is_single_animal
+
+    # If the logical target is single-animal, collapse an empty 'individuals' level.
+    if not is_ma_project:
         # If the normalized dataframe has an empty individuals level, collapse it.
         if df_out.columns.nlevels == 4 and "individuals" in (df_out.columns.names or []):
             inds = pd.Index(df_out.columns.get_level_values("individuals")).astype(str)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -461,6 +461,8 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
             out = candidates[0]
         else:
             scorer = target_scorer or pts_meta.header.scorer
+            if scorer is None:
+                raise ValueError("Scorer is required to write DLC keypoints.")
             out = root_path / f"CollectedData_{scorer}.h5"
     else:
         out = Path(out_path)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -64,6 +64,7 @@ logger = logging.getLogger(__name__)
 _GLOB_MAGIC = set("*?[")
 _SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
 DLC_CANONICAL_H5_KEY = "df_with_missing"  # TODO use this key instead of str literal in all places
+FALLBACK_H5_KEYS = ["keypoints"]
 
 
 def _has_glob_magic(name: str) -> bool:
@@ -124,15 +125,14 @@ def _read_hdf_any_key(file: Path) -> pd.DataFrame:
     try:
         return pd.read_hdf(file, key=DLC_CANONICAL_H5_KEY)
     except (KeyError, ValueError):
-        logger.warning(f"Key '{DLC_CANONICAL_H5_KEY}' not found in {file}. Trying to read without specifying a key.")
-    fallback_keys = ["keypoints"]
-    for k in fallback_keys:
+        logger.warning(f"Key '{DLC_CANONICAL_H5_KEY}' not found in {file}. Trying fallback keys.")
+    for k in FALLBACK_H5_KEYS:
         try:
             return pd.read_hdf(file, key=k)
         except (KeyError, ValueError):
             logger.warning(f"Key '{k}' not found in {file}.")
     logger.warning(
-        f"None of the expected keys {fallback_keys + [DLC_CANONICAL_H5_KEY]} were found in {file}. "
+        f"None of the expected keys {FALLBACK_H5_KEYS + [DLC_CANONICAL_H5_KEY]} were found in {file}. "
         "Falling back to default read_hdf which may raise its own error if no valid key is found."
     )
     return pd.read_hdf(file)  # Let pandas guess instead


### PR DESCRIPTION
Few small refactors for the write_hdf and DLCHeaderModel. I think the best way forward is just cherry-pick the ones that you like, @C-Achard . 

**`DLCHeaderModel`**
I really like how you now at least have a way to ensure canonical 4-level columns. However, it seems that the schema still inherits some of the awkward multi-format unclarities from the h5 (being either 3-level or 4-level), which means that any callers still have to inspect the header shape.  
- this PR adds a small `is_single_animal` property that can be used for writers, to know which format h5 needs to be saved. 
- malformed headers are now not longer swallowed silently, fabricating a structure that was originally not there
-> future refactors could maybe make DLCHeaderModel always store the 4-level columns internally and only keep a flag `is_single_animal` that indicates what was the original format, so writers know how to save. This would simplify all conditional logic. 


**`write_hdf()` and `_read_hdf_any_key()`**
- Small correction to the error message which stated 'trying to read without specifying a key.' followed by reading with specific fallback options. 
- fail loudly if no target_scorer and header contains no scorer. Not sure if needed, might be that you made a conscious decision here to always write something to disk, even if the h5 will not work in DeepLabCut.


