### PR TITLE
Improve images-annotation remapping logic

### DIFF
--- a/src/napari_deeplabcut/_tests/core/test_remap.py
+++ b/src/napari_deeplabcut/_tests/core/test_remap.py
@@ -4,6 +4,8 @@ import numpy as np
 
 from napari_deeplabcut.core.project_paths import PathMatchPolicy
 from napari_deeplabcut.core.remap import (
+    RemapOutcome,
+    RemapReason,
     build_frame_index_map,
     remap_layer_data_by_paths,
     remap_time_indices,
@@ -19,7 +21,6 @@ def test_build_frame_index_map_depth3_overlap_and_reorder():
         "projA/labeled-data/test/img000.png",
         "projA/labeled-data/test/img001.png",
     ]
-    # reverse order in new paths
     new_paths = [
         "projB/labeled-data/test/img001.png",
         "projB/labeled-data/test/img000.png",
@@ -38,17 +39,18 @@ def test_build_frame_index_map_depth3_overlap_and_reorder():
 def test_build_frame_index_map_falls_back_to_depth2_when_depth3_has_no_overlap():
     """
     Construct paths such that:
-      - last 3 components differ (no overlap at n=3)
-      - last 2 components match (overlap at n=2)
+      - last 3 components differ, so no overlap at depth=3
+      - last 2 components match, so overlap exists at depth=2
     """
     old_paths = [
-        "A/one/img000.png",  # last3 => A/one/img000.png
+        "A/one/img000.png",
         "A/one/img001.png",
     ]
     new_paths = [
-        "B/one/img000.png",  # last3 => B/one/img000.png (no overlap)
+        "B/one/img000.png",
         "B/one/img001.png",
     ]
+
     idx_map, depth = build_frame_index_map(
         old_paths=old_paths,
         new_paths=new_paths,
@@ -61,12 +63,11 @@ def test_build_frame_index_map_falls_back_to_depth2_when_depth3_has_no_overlap()
 
 def test_remap_layer_data_by_paths_array_like_points_time_col0():
     """
-    Array-like data (Points/Tracks) should have its time column remapped.
+    Array-like data, such as Points data, should have its time column remapped.
     """
     old_paths = ["x/y/img0.png", "x/y/img1.png"]
-    new_paths = ["x/y/img1.png", "x/y/img0.png"]  # swap order -> mapping {0:1,1:0}
+    new_paths = ["x/y/img1.png", "x/y/img0.png"]
 
-    # data columns: (time, y, x)
     data = np.array(
         [
             [0.0, 10.0, 20.0],
@@ -83,8 +84,11 @@ def test_remap_layer_data_by_paths_array_like_points_time_col0():
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert res.depth_used in (3, 2, 1)  # depends on how many components are present
-    assert res.changed is True
+    assert res.outcome is RemapOutcome.APPLIED_FULL
+    assert res.reason is RemapReason.REMAPPED
+    assert res.applied is True
+    assert res.paths_updated is True
+    assert res.depth_used in (3, 2, 1)
     assert res.data is not None
     assert np.array_equal(res.data[:, 0].astype(int), np.array([1, 0]))
 
@@ -97,7 +101,6 @@ def test_remap_layer_data_by_paths_array_like_tracks_time_col1():
     old_paths = ["root/seq/img0.png", "root/seq/img1.png"]
     new_paths = ["root/seq/img1.png", "root/seq/img0.png"]
 
-    # tracks-like: (track_id, time, y, x)
     data = np.array(
         [
             [5.0, 0.0, 10.0, 20.0],
@@ -114,10 +117,12 @@ def test_remap_layer_data_by_paths_array_like_tracks_time_col1():
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert res.changed is True
+    assert res.outcome is RemapOutcome.APPLIED_FULL
+    assert res.reason is RemapReason.REMAPPED
+    assert res.applied is True
+    assert res.paths_updated is True
     assert res.data is not None
     assert np.array_equal(res.data[:, 1].astype(int), np.array([1, 0]))
-    # track_id must remain unchanged
     assert np.array_equal(res.data[:, 0].astype(int), np.array([5, 5]))
 
 
@@ -146,12 +151,15 @@ def test_remap_layer_data_by_paths_list_like_shapes():
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert res.changed is True
+    assert res.outcome is RemapOutcome.APPLIED_FULL
+    assert res.reason is RemapReason.REMAPPED
+    assert res.applied is True
+    assert res.paths_updated is True
     assert isinstance(res.data, list)
     assert np.array_equal(np.asarray(res.data[0])[:, 0].astype(int), np.array([1, 0]))
 
 
-def test_no_overlap_returns_no_change_and_no_data():
+def test_no_overlap_returns_skipped_and_no_data():
     old_paths = ["a/b/c/img0.png"]
     new_paths = ["x/y/z/other.png"]
 
@@ -165,15 +173,19 @@ def test_no_overlap_returns_no_change_and_no_data():
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert res.changed is False
+    assert res.outcome is RemapOutcome.SKIPPED
+    assert res.reason is RemapReason.NO_OVERLAP
+    assert res.applied is False
+    assert res.paths_updated is False
     assert res.data is None
     assert res.depth_used is None
     assert "No overlap" in res.message or "skipping" in res.message.lower()
 
 
-def test_already_aligned_paths_skips_remap():
+def test_already_aligned_paths_returns_noop():
     """
-    If canonicalized old_keys == new_keys, remap_layer_data_by_paths should no-op.
+    If canonicalized old_keys == new_keys, remap_layer_data_by_paths should no-op
+    while allowing callers to update/sync path metadata.
     """
     paths = ["labeled-data/test/img0.png", "labeled-data/test/img1.png"]
 
@@ -193,61 +205,147 @@ def test_already_aligned_paths_skips_remap():
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert res.changed is False
+    assert res.outcome is RemapOutcome.NOOP
+    assert res.reason is RemapReason.ALREADY_ALIGNED
+    assert res.applied is False
+    assert res.paths_updated is True
     assert res.data is None
-    assert res.depth_used is not None  # a matching depth exists
+    assert res.depth_used is not None
     assert "already aligned" in res.message.lower() or "no remap needed" in res.message.lower()
 
 
 def test_missing_old_or_new_paths_skips():
     data = np.array([[0.0, 1.0, 2.0]], dtype=float)
 
-    res1 = remap_layer_data_by_paths(data=data, old_paths=[], new_paths=["a/b/c.png"], time_col=0)
-    assert res1.changed is False
+    res1 = remap_layer_data_by_paths(
+        data=data,
+        old_paths=[],
+        new_paths=["a/b/c.png"],
+        time_col=0,
+    )
+    assert res1.outcome is RemapOutcome.SKIPPED
+    assert res1.reason is RemapReason.NO_OLD_PATHS
+    assert res1.applied is False
+    assert res1.paths_updated is False
     assert res1.data is None
 
-    res2 = remap_layer_data_by_paths(data=data, old_paths=["a/b/c.png"], new_paths=[], time_col=0)
-    assert res2.changed is False
+    res2 = remap_layer_data_by_paths(
+        data=data,
+        old_paths=["a/b/c.png"],
+        new_paths=[],
+        time_col=0,
+    )
+    assert res2.outcome is RemapOutcome.SKIPPED
+    assert res2.reason is RemapReason.NO_NEW_PATHS
+    assert res2.applied is False
+    assert res2.paths_updated is False
     assert res2.data is None
 
 
-def test_remap_time_indices_leaves_unmapped_indices_unchanged():
+def test_remap_time_indices_rejects_unmapped_indices_in_strict_mode():
     """
-    If idx_map doesn't contain a value, it should remain unchanged.
+    Strict remap no longer leaves unmapped indices unchanged.
+
+    If idx_map does not contain a used frame index, remap_time_indices rejects
+    rather than mixing remapped and stale indices.
     """
-    idx_map = {0: 10}  # only frame 0 remaps
+    idx_map = {0: 10}
     data = np.array(
         [
             [0.0, 10.0, 20.0],
-            [1.0, 11.0, 21.0],  # frame 1 unmapped -> should stay 1
+            [1.0, 11.0, 21.0],
         ],
         dtype=float,
     )
 
     res = remap_time_indices(data=data, time_col=0, idx_map=idx_map)
 
-    assert res.changed is True
+    assert res.outcome is RemapOutcome.REJECTED
+    assert res.reason is RemapReason.REMAP_FAILED
+    assert res.applied is False
+    assert res.paths_updated is False
+    assert res.data is None
+    assert "Failed to remap time column" in res.message
+
+
+def test_remap_time_indices_allows_partial_array_remap_when_requested():
+    """
+    With allow_partial=True, array-like data should drop rows whose frame index
+    cannot be mapped and report APPLIED_PARTIAL.
+    """
+    idx_map = {0: 10}
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [1.0, 11.0, 21.0],
+            [1.0, 12.0, 22.0],
+        ],
+        dtype=float,
+    )
+
+    res = remap_time_indices(
+        data=data,
+        time_col=0,
+        idx_map=idx_map,
+        allow_partial=True,
+    )
+
+    assert res.outcome is RemapOutcome.APPLIED_PARTIAL
+    assert res.reason is RemapReason.PARTIAL_ROWS_DROPPED
+    assert res.applied is True
+    assert res.paths_updated is True
     assert res.data is not None
-    assert np.array_equal(res.data[:, 0].astype(int), np.array([10, 1]))
+    assert res.dropped_row_count == 2
+    assert res.dropped_frame_indices == (1,)
+    assert np.array_equal(res.data[:, 0].astype(int), np.array([10]))
+    assert np.array_equal(res.data[:, 1:].astype(int), np.array([[10, 20]]))
+
+
+def test_remap_time_indices_partial_rejects_when_no_rows_are_mappable():
+    idx_map = {0: 10}
+    data = np.array(
+        [
+            [1.0, 11.0, 21.0],
+            [2.0, 12.0, 22.0],
+        ],
+        dtype=float,
+    )
+
+    res = remap_time_indices(
+        data=data,
+        time_col=0,
+        idx_map=idx_map,
+        allow_partial=True,
+    )
+
+    assert res.outcome is RemapOutcome.REJECTED
+    assert res.reason is RemapReason.NO_MAPPABLE_ROWS
+    assert res.applied is False
+    assert res.paths_updated is False
+    assert res.data is None
+    assert res.dropped_row_count == 2
+    assert res.dropped_frame_indices == (1, 2)
 
 
 def test_remap_time_indices_gracefully_handles_empty_and_none():
     res_none = remap_time_indices(data=None, time_col=0, idx_map={0: 1})
-    assert res_none.changed is False
+    assert res_none.outcome is RemapOutcome.SKIPPED
+    assert res_none.reason is RemapReason.NO_DATA
+    assert res_none.applied is False
+    assert res_none.paths_updated is False
     assert res_none.data is None
 
     res_empty = remap_time_indices(data=np.array([]), time_col=0, idx_map={0: 1})
-    assert res_empty.changed is False
+    assert res_empty.outcome is RemapOutcome.SKIPPED
+    assert res_empty.reason is RemapReason.NO_DATA
+    assert res_empty.applied is False
+    assert res_empty.paths_updated is False
     assert res_empty.data is None
 
 
-def test_remap_warns_on_duplicate_canonical_keys(caplog):
+def test_remap_rejects_on_duplicate_canonical_keys(caplog):
     caplog.set_level(logging.WARNING, logger="napari_deeplabcut.core.remap")
 
-    # Depth=2 canonical keys will be:
-    # old_keys = ["dup/img0.png", "dup/img0.png", "dup/img1.png"]
-    # new_keys = ["dup/img1.png", "dup/img0.png", "dup/img0.png"]
-    # -> not equal => remap path is taken
     old_paths = [
         "A/dup/img0.png",
         "B/dup/img0.png",
@@ -276,17 +374,31 @@ def test_remap_warns_on_duplicate_canonical_keys(caplog):
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
+    assert res.outcome is RemapOutcome.REJECTED
+    assert res.reason is RemapReason.AMBIGUOUS_MATCH
+    assert res.applied is False
+    assert res.paths_updated is False
+    assert res.data is None
     assert "Remap may be ambiguous/risky" in caplog.text
     assert "Duplicate canonical keys" in caplog.text
     assert any("Duplicate canonical keys" in w for w in res.warnings)
 
 
-def test_remap_warns_on_low_overlap_ratio(caplog):
-    caplog.set_level(logging.WARNING)
+def test_remap_warns_on_low_old_path_coverage_in_strict_mode(caplog):
+    caplog.set_level(logging.WARNING, logger="napari_deeplabcut.core.remap")
 
-    old_paths = ["x/y/img0.png", "x/y/img1.png", "x/y/img2.png", "x/y/img3.png"]
-    # same length, only one overlapping key
-    new_paths = ["x/y/img0.png", "x/y/img9.png", "x/y/img8.png", "x/y/img7.png"]
+    old_paths = [
+        "x/y/img0.png",
+        "x/y/img1.png",
+        "x/y/img2.png",
+        "x/y/img3.png",
+    ]
+    new_paths = [
+        "x/y/img0.png",
+        "x/y/img9.png",
+        "x/y/img8.png",
+        "x/y/img7.png",
+    ]
 
     data = np.array([[0.0, 1.0, 2.0]], dtype=float)
 
@@ -298,6 +410,155 @@ def test_remap_warns_on_low_overlap_ratio(caplog):
         policy=PathMatchPolicy.ORDERED_DEPTHS,
     )
 
-    assert "Low path overlap ratio" in caplog.text
-    assert "Low mapping coverage" in caplog.text
-    assert any("Low path overlap ratio" in w for w in res.warnings)
+    assert res.outcome in {RemapOutcome.NOOP, RemapOutcome.APPLIED_FULL}
+    assert res.paths_updated is True
+    assert "Low old-path coverage" in caplog.text
+    assert any("Low old-path coverage" in w for w in res.warnings)
+
+
+def test_remap_layer_data_by_paths_rejects_unmapped_used_indices_in_strict_mode():
+    """
+    In strict mode, if any actually-used frame index has no path mapping,
+    the high-level remap is rejected.
+    """
+    old_paths = [
+        "old/session/img0.png",
+        "old/session/img1.png",
+        "old/session/img2.png",
+        "old/session/img3.png",
+    ]
+    new_paths = [
+        "new/session/img0.png",
+        "new/session/img1.png",
+    ]
+
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [1.0, 11.0, 21.0],
+            [2.0, 12.0, 22.0],
+            [3.0, 13.0, 23.0],
+        ],
+        dtype=float,
+    )
+
+    res = remap_layer_data_by_paths(
+        data=data,
+        old_paths=old_paths,
+        new_paths=new_paths,
+        time_col=0,
+        policy=PathMatchPolicy.ORDERED_DEPTHS,
+        allow_partial=False,
+    )
+
+    assert res.outcome is RemapOutcome.REJECTED
+    assert res.reason is RemapReason.USED_INDICES_UNMAPPED
+    assert res.applied is False
+    assert res.paths_updated is False
+    assert res.data is None
+    assert res.mapped_count == 2
+    assert any("Used frame indices without mapping" in w for w in res.warnings)
+
+
+def test_remap_layer_data_by_paths_applies_partial_when_allowed():
+    """
+    DLC-style partial remap case.
+
+    Some old frame paths map to the new image stack, others do not. With
+    allow_partial=True, rows on unmappable frames are dropped and the remaining
+    rows are remapped.
+    """
+    old_paths = [
+        "old/session/img0.png",
+        "old/session/img1.png",
+        "old/session/img2.png",
+        "old/session/img3.png",
+    ]
+    new_paths = [
+        "new/session/img1.png",
+        "new/session/img0.png",
+    ]
+
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [1.0, 11.0, 21.0],
+            [2.0, 12.0, 22.0],
+            [3.0, 13.0, 23.0],
+            [3.0, 14.0, 24.0],
+        ],
+        dtype=float,
+    )
+
+    res = remap_layer_data_by_paths(
+        data=data,
+        old_paths=old_paths,
+        new_paths=new_paths,
+        time_col=0,
+        policy=PathMatchPolicy.ORDERED_DEPTHS,
+        allow_partial=True,
+    )
+
+    assert res.outcome is RemapOutcome.APPLIED_PARTIAL
+    assert res.reason is RemapReason.PARTIAL_ROWS_DROPPED
+    assert res.applied is True
+    assert res.paths_updated is True
+    assert res.data is not None
+    assert res.mapped_count == 2
+    assert res.dropped_row_count == 3
+    assert res.dropped_frame_indices == (2, 3)
+    assert np.array_equal(res.data[:, 0].astype(int), np.array([1, 0]))
+    assert np.array_equal(
+        res.data[:, 1:].astype(int),
+        np.array(
+            [
+                [10, 20],
+                [11, 21],
+            ]
+        ),
+    )
+    assert any("Partial remap" in w for w in res.warnings)
+
+
+def test_remap_layer_data_by_paths_partial_suppresses_low_coverage_warning(caplog):
+    """
+    When allow_partial=True and unmapped used frames exist, low old-path coverage
+    is expected and should be debug-only rather than a user-facing warning.
+    """
+    caplog.set_level(logging.DEBUG, logger="napari_deeplabcut.core.remap")
+
+    old_paths = [
+        "old/session/img0.png",
+        "old/session/img1.png",
+        "old/session/img2.png",
+        "old/session/img3.png",
+    ]
+    new_paths = [
+        "new/session/img0.png",
+        "new/session/img1.png",
+    ]
+
+    data = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [1.0, 11.0, 21.0],
+            [2.0, 12.0, 22.0],
+            [3.0, 13.0, 23.0],
+        ],
+        dtype=float,
+    )
+
+    res = remap_layer_data_by_paths(
+        data=data,
+        old_paths=old_paths,
+        new_paths=new_paths,
+        time_col=0,
+        policy=PathMatchPolicy.ORDERED_DEPTHS,
+        allow_partial=True,
+    )
+
+    assert res.outcome is RemapOutcome.APPLIED_PARTIAL
+    assert res.reason is RemapReason.PARTIAL_ROWS_DROPPED
+    assert "Low old-path coverage during partial remap" in caplog.text
+    assert not any("Low old-path coverage" in w for w in res.warnings)
+    assert any("Partial remap" in w for w in res.warnings)

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -9,6 +9,7 @@ import numpy as np
 from napari.layers import Image, Layer, Points, Tracks
 from napari.utils.events import Event
 from napari.utils.history import update_save_history
+from napari.utils.notifications import show_error, show_warning
 from qtpy.QtCore import QObject, Signal
 
 from ...config.keybinds import install_points_layer_keybindings
@@ -82,6 +83,10 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
     adopted_existing_layers = Signal()
     layer_insert_processed = Signal(object)
     layer_remove_processed = Signal(object)
+
+    # Remap signals
+    remap_warning_requested = Signal(str)
+    remap_error_requested = Signal(str)
 
     # Session management
     session_conflict_rejected = Signal(str)  # if a new DLC folder is loaded on top of the current one
@@ -690,6 +695,30 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
             self._schedule_post_remove_refresh()
 
+    def _notify_remap_issue(
+        self,
+        *,
+        layer: Layer,
+        level: str,
+        message: str,
+        details: tuple[str, ...] | list[str] | None = None,
+    ) -> None:
+        """Show a user-facing remap notification."""
+        details = list(details or [])
+        text = f"{getattr(layer, 'name', 'Layer')}: {message}"
+        if details:
+            text += "\n\n" + "\n".join(details)
+
+        # Keep the status bar concise.
+        self.viewer.status = f"{getattr(layer, 'name', 'Layer')}: {message}"
+
+        if level == "error":
+            self.remap_error_requested.emit(text)
+            show_error(text)
+        else:
+            self.remap_warning_requested.emit(text)
+            show_warning(text)
+
     def _remap_frame_indices(self, layer: Any) -> None:
         """Lifecycle-owned remap of non-Image layer time/frame indices."""
         try:
@@ -761,12 +790,77 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 if isinstance(layer, Points):
                     mark_layer_presentation_changed(layer)
 
+            if res.is_ambiguous or (not res.applied and not res.accept_paths_update):
+                logger.warning(
+                    "Remap rejected for %s (depth=%s, mapped=%s): %s",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.message,
+                )
+
+                self._notify_remap_issue(
+                    layer=layer,
+                    level="error",
+                    message=(
+                        "Could not safely align this annotation layer to the current image stack. "
+                        "The layer may refer to a different folder layout, stale paths, or a different frame order."
+                    ),
+                    details=[res.message, *res.warnings],
+                )
+
+                # Hide layers that could not be aligned.
+                # This avoids showing clearly misleading annotations.
+                if isinstance(layer, Points):
+                    self._set_layer_visible(layer, False)
+
+                return
+
+            if res.applied and res.warnings:
+                logger.warning(
+                    "Remap applied with warnings for %s (depth=%s, mapped=%s): %s | warnings=%s",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.message,
+                    res.warnings,
+                )
+
+                self._notify_remap_issue(
+                    layer=layer,
+                    level="warning",
+                    message=(
+                        "Annotations were remapped to the current image stack, but the match was considered risky."
+                    ),
+                    details=[res.message, *res.warnings],
+                )
+
+            # Logging only for safe / benign cases
             if res.depth_used is None:
-                logger.debug("Remap skipped for %s: %s", getattr(layer, "name", str(layer)), res.message)
+                logger.debug(
+                    "Remap skipped for %s: %s",
+                    getattr(layer, "name", str(layer)),
+                    res.message,
+                )
+            elif res.applied:
+                logger.debug(
+                    "Remap applied for %s (depth=%s, mapped=%s): %s",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.message,
+                )
+            elif res.accept_paths_update:
+                logger.debug(
+                    "Remap accepted-noop for %s (depth=%s, mapped=%s): %s",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.message,
+                )
             else:
                 logger.debug(
-                    "Remap %s for %s (depth=%s, mapped=%s): %s",
-                    "applied" if res.changed else "accepted-noop",
+                    "Remap ended without changes for %s (depth=%s, mapped=%s): %s",
                     getattr(layer, "name", str(layer)),
                     res.depth_used,
                     res.mapped_count,

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -878,7 +878,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 self._notify_remap_issue(
                     layer=layer,
                     level="warning",
-                    message=("Annotations were remapped to the current image stack, but the match had diagnostics."),
+                    message=("Annotations were remapped to the current image stack, but the match had issues."),
                     details=[res.message, *res.warnings],
                 )
 

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -834,30 +834,30 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 return
 
             if res.warnings and res.paths_updated:
-                logger.warning(
-                    "Remap completed with warnings for %s "
-                    "(outcome=%s, reason=%s, depth=%s, mapped=%s): %s | warnings=%s",
-                    getattr(layer, "name", str(layer)),
-                    res.outcome.value,
-                    res.reason.value,
-                    res.depth_used,
-                    res.mapped_count,
-                    res.message,
-                    res.warnings,
-                )
-
-            if res.outcome is RemapOutcome.APPLIED_PARTIAL:
-                logger.warning(
-                    "Partial remap applied for %s "
-                    "(depth=%s, mapped=%s, dropped_rows=%s, dropped_frames=%s): %s | warnings=%s",
-                    getattr(layer, "name", str(layer)),
-                    res.depth_used,
-                    res.mapped_count,
-                    res.dropped_row_count,
-                    res.dropped_frame_indices,
-                    res.message,
-                    res.warnings,
-                )
+                if res.outcome is not RemapOutcome.APPLIED_PARTIAL:
+                    logger.warning(
+                        "Remap completed with warnings for %s "
+                        "(outcome=%s, reason=%s, depth=%s, mapped=%s): %s | warnings=%s",
+                        getattr(layer, "name", str(layer)),
+                        res.outcome.value,
+                        res.reason.value,
+                        res.depth_used,
+                        res.mapped_count,
+                        res.message,
+                        res.warnings,
+                    )
+                else:
+                    logger.warning(
+                        "Partial remap applied for %s "
+                        "(depth=%s, mapped=%s, dropped_rows=%s, dropped_frames=%s): %s | warnings=%s",
+                        getattr(layer, "name", str(layer)),
+                        res.depth_used,
+                        res.mapped_count,
+                        res.dropped_row_count,
+                        res.dropped_frame_indices,
+                        res.message,
+                        res.warnings,
+                    )
 
                 self._notify_remap_issue(
                     layer=layer,

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -26,7 +26,7 @@ from ...core.metadata import (
     write_points_meta,
 )
 from ...core.project_paths import PathMatchPolicy
-from ...core.remap import remap_layer_data_by_paths
+from ...core.remap import RemapOutcome, RemapReason, remap_layer_data_by_paths
 from ...napari_compat import install_add_wrapper, install_paste_patch
 from ...napari_compat.points_layer import make_paste_data
 from ...ui.base_widget._qt_timers import OwnedTimersMixin
@@ -773,27 +773,45 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             )
 
             logger.debug(
-                "Remap result layer=%r changed=%s mapped_count=%s depth=%s message=%s warnings=%s",
+                "Remap result layer=%r outcome=%s reason=%s mapped_count=%s depth=%s "
+                "paths_updated=%s applied=%s message=%s warnings=%s",
                 getattr(layer, "name", str(layer)),
-                res.changed,
+                res.outcome.value,
+                res.reason.value,
                 res.mapped_count,
                 res.depth_used,
+                res.paths_updated,
+                res.applied,
                 res.message,
                 res.warnings,
             )
 
+            data_updated = False
+
             if res.applied and res.data is not None:
                 layer.data = res.data
+                data_updated = True
 
-            if res.accept_paths_update:
+            if res.paths_updated:
                 layer.metadata["paths"] = list(new_paths)
-                if isinstance(layer, Points):
-                    mark_layer_presentation_changed(layer)
 
-            if res.is_ambiguous or (not res.applied and not res.accept_paths_update):
+            if isinstance(layer, Points) and (data_updated or res.paths_updated):
+                mark_layer_presentation_changed(layer)
+
+            hard_failure = res.outcome is RemapOutcome.REJECTED
+
+            unaligned_skip = res.outcome is RemapOutcome.SKIPPED and res.reason in {
+                RemapReason.NO_OVERLAP,
+                RemapReason.INVALID_TIME_COLUMN,
+                RemapReason.REMAP_FAILED,
+            }
+
+            if hard_failure or unaligned_skip:
                 logger.warning(
-                    "Remap rejected for %s (depth=%s, mapped=%s): %s",
+                    "Remap could not safely align %s (outcome=%s, reason=%s, depth=%s, mapped=%s): %s",
                     getattr(layer, "name", str(layer)),
+                    res.outcome.value,
+                    res.reason.value,
                     res.depth_used,
                     res.mapped_count,
                     res.message,
@@ -801,7 +819,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
                 self._notify_remap_issue(
                     layer=layer,
-                    level="error",
+                    level="error" if hard_failure else "warning",
                     message=(
                         "Could not safely align this annotation layer to the current image stack. "
                         "The layer may refer to a different folder layout, stale paths, or a different frame order."
@@ -809,37 +827,38 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                     details=[res.message, *res.warnings],
                 )
 
-                # Hide layers that could not be aligned.
-                # This avoids showing clearly misleading annotations.
                 if isinstance(layer, Points):
                     self._set_layer_visible(layer, False)
 
                 return
 
-            if res.applied and res.warnings:
+            if res.warnings and res.paths_updated:
                 logger.warning(
-                    "Remap applied with warnings for %s (depth=%s, mapped=%s): %s | warnings=%s",
+                    "Remap completed with warnings for %s "
+                    "(outcome=%s, reason=%s, depth=%s, mapped=%s): %s | warnings=%s",
                     getattr(layer, "name", str(layer)),
+                    res.outcome.value,
+                    res.reason.value,
                     res.depth_used,
                     res.mapped_count,
                     res.message,
                     res.warnings,
                 )
 
+            if res.applied and res.warnings:
                 self._notify_remap_issue(
                     layer=layer,
                     level="warning",
-                    message=(
-                        "Annotations were remapped to the current image stack, but the match was considered risky."
-                    ),
+                    message=("Annotations were remapped to the current image stack, but the match had diagnostics."),
                     details=[res.message, *res.warnings],
                 )
 
-            # Logging only for safe / benign cases
             if res.depth_used is None:
                 logger.debug(
-                    "Remap skipped for %s: %s",
+                    "Remap skipped for %s (outcome=%s, reason=%s): %s",
                     getattr(layer, "name", str(layer)),
+                    res.outcome.value,
+                    res.reason.value,
                     res.message,
                 )
             elif res.applied:
@@ -850,7 +869,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                     res.mapped_count,
                     res.message,
                 )
-            elif res.accept_paths_update:
+            elif res.paths_updated:
                 logger.debug(
                     "Remap accepted-noop for %s (depth=%s, mapped=%s): %s",
                     getattr(layer, "name", str(layer)),
@@ -860,8 +879,10 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 )
             else:
                 logger.debug(
-                    "Remap ended without changes for %s (depth=%s, mapped=%s): %s",
+                    "Remap ended without changes for %s (outcome=%s, reason=%s, depth=%s, mapped=%s): %s",
                     getattr(layer, "name", str(layer)),
+                    res.outcome.value,
+                    res.reason.value,
                     res.depth_used,
                     res.mapped_count,
                     res.message,

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -770,6 +770,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 new_paths=new_paths,
                 time_col=time_col,
                 policy=PathMatchPolicy.ORDERED_DEPTHS,
+                allow_partial=isinstance(layer, Points),
             )
 
             logger.debug(
@@ -843,6 +844,34 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                     res.mapped_count,
                     res.message,
                     res.warnings,
+                )
+
+            if res.outcome is RemapOutcome.APPLIED_PARTIAL:
+                logger.warning(
+                    "Partial remap applied for %s "
+                    "(depth=%s, mapped=%s, dropped_rows=%s, dropped_frames=%s): %s | warnings=%s",
+                    getattr(layer, "name", str(layer)),
+                    res.depth_used,
+                    res.mapped_count,
+                    res.dropped_row_count,
+                    res.dropped_frame_indices,
+                    res.message,
+                    res.warnings,
+                )
+
+                self._notify_remap_issue(
+                    layer=layer,
+                    level="warning",
+                    message=(
+                        "Partially aligned this annotation layer to the current image stack. "
+                        "Rows referring to frames that could not be matched were ignored."
+                    ),
+                    details=[
+                        res.message,
+                        f"Dropped rows: {res.dropped_row_count}",
+                        f"Dropped frame examples: {list(res.dropped_frame_indices)}",
+                        *res.warnings,
+                    ],
                 )
 
             if res.applied and res.warnings:

--- a/src/napari_deeplabcut/core/remap.py
+++ b/src/napari_deeplabcut/core/remap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any
 
 import numpy as np
@@ -11,12 +12,35 @@ import numpy as np
 from napari_deeplabcut.core.project_paths import PathMatchPolicy, canonicalize_path, find_matching_depth
 
 logger = logging.getLogger(__name__)
+# NOTE: if relevant we could add unmapped annotations as a separate "unmapped" layer
 
-# Heuristic thresholds for "risky remap" warnings.
-# These do NOT change behavior; they only control warning emissions.
-_WARN_OVERLAP_RATIO = 0.80  # Warn if canonicalized path overlap is below this ratio (relative to smaller set size).
-_WARN_MAPPED_RATIO = 0.80  # Warn if mapping coverage of old paths is below this ratio (mapped / old).
+_WARN_OLD_PATH_COVERAGE = 0.80
 _SAMPLE_N = 5  # Number of examples to include in warnings about duplicate keys.
+
+
+class RemapOutcome(str, Enum):
+    SKIPPED = "skipped"
+    NOOP = "noop"
+    APPLIED_FULL = "applied_full"
+    APPLIED_PARTIAL = "applied_partial"
+    REJECTED = "rejected"
+
+
+class RemapReason(str, Enum):
+    NONE = "none"
+    NO_DATA = "no_data"
+    EMPTY_MAPPING = "empty_mapping"
+    NO_OLD_PATHS = "no_old_paths"
+    NO_NEW_PATHS = "no_new_paths"
+    NO_OVERLAP = "no_overlap"
+    ALREADY_ALIGNED = "already_aligned"
+    AMBIGUOUS_MATCH = "ambiguous_match"
+    NO_MAPPABLE_ROWS = "no_mappable_rows"
+    INVALID_TIME_COLUMN = "invalid_time_column"
+    REMAP_FAILED = "remap_failed"
+    REMAPPED = "remapped"
+    PARTIAL_ROWS_DROPPED = "partial_rows_dropped"
+    USED_INDICES_UNMAPPED = "used_indices_unmapped"
 
 
 @dataclass(frozen=True)
@@ -26,14 +50,11 @@ class RemapResult:
 
     Attributes
     ----------
-    changed:
-        True if output data differs from input data.
-    applied:
-        True if the remap is considered safe and should be applied upstream.
-    accept_paths_update:
-        True if upstream may safely replace metadata["paths"] with the new paths.
-    is_ambiguous:
-        True if remap was rejected because matching was ambiguous/risky.
+    outcome:
+        Overall outcome of the remap attempt, e.g. "skipped", "applied
+        partial", "rejected", etc.
+    reason:
+        More specific reason for the outcome.
     depth_used:
         Canonicalization depth used to match paths (e.g. 3, 2, 1), or None.
     mapped_count:
@@ -44,17 +65,30 @@ class RemapResult:
         Remapped data object (same type shape intent as input), or None if not applied.
     warnings:
         Tuple of warning strings describing ambiguity/risk detected during remap decision.
+    dropped_row_count:
+        For partial remaps where some rows had unmapped indices and were dropped, the count of dropped rows.
+    dropped_frame_indices:
+        For partial remaps where some rows had unmapped indices and were dropped,
+        example frame indices that were dropped.
     """
 
-    changed: bool
-    applied: bool
-    accept_paths_update: bool
-    is_ambiguous: bool
+    outcome: RemapOutcome
+    reason: RemapReason
     depth_used: int | None
     mapped_count: int
     message: str
     data: Any | None
     warnings: tuple[str, ...] = ()
+    dropped_row_count: int = 0  # for partial remaps where some rows had unmapped indices and were dropped
+    dropped_frame_indices: tuple[int, ...] = ()  # example frame indices that were dropped due to unmapped indices
+
+    @property
+    def applied(self) -> bool:
+        return self.outcome in {RemapOutcome.APPLIED_FULL, RemapOutcome.APPLIED_PARTIAL}
+
+    @property
+    def paths_updated(self) -> bool:
+        return self.outcome in {RemapOutcome.APPLIED_FULL, RemapOutcome.APPLIED_PARTIAL, RemapOutcome.NOOP}
 
 
 def _remap_array(values: np.ndarray, idx_map: Mapping[int, int]) -> np.ndarray:
@@ -67,7 +101,7 @@ def _remap_array(values: np.ndarray, idx_map: Mapping[int, int]) -> np.ndarray:
         Array-like of integer time/frame indices to remap.
     idx_map:
         Mapping from old integer frame index -> new integer frame index.
-        Indices not present in the mapping are left unchanged.
+        Indices not present in the mapping raise a KeyError.
     """
     values = np.asarray(values)
     if values.size == 0:
@@ -88,6 +122,47 @@ def _remap_array(values: np.ndarray, idx_map: Mapping[int, int]) -> np.ndarray:
         count=len(values_int),
     )
     return mapped
+
+
+def _filter_and_remap_array(
+    arr: np.ndarray,
+    *,
+    time_col: int,
+    idx_map: dict[int, int],
+) -> tuple[np.ndarray | None, int, tuple[int, ...], RemapReason, str]:
+
+    if arr.ndim < 2 or arr.shape[1] <= time_col:
+        return None, 0, (), RemapReason.INVALID_TIME_COLUMN, "Invalid time column."
+
+    t = arr[:, time_col].astype(int, copy=False)
+    keep_mask = np.array([v in idx_map for v in t], dtype=bool)
+    drop_mask = ~keep_mask
+
+    if not np.any(keep_mask):
+        return (
+            None,
+            int(drop_mask.sum()),
+            tuple(sorted(set(t))),
+            RemapReason.NO_MAPPABLE_ROWS,
+            ("No rows could be mapped to the new image stack."),
+        )
+
+    dropped_rows = int(drop_mask.sum())
+    dropped_frames = tuple(sorted(set(t[drop_mask])))
+
+    kept = arr[keep_mask].copy()
+    kept[:, time_col] = np.array([idx_map[int(v)] for v in kept[:, time_col]])
+
+    if dropped_rows > 0:
+        return (
+            kept,
+            dropped_rows,
+            dropped_frames,
+            RemapReason.PARTIAL_ROWS_DROPPED,
+            (f"Dropped {dropped_rows} unmappable row(s)."),
+        )
+
+    return kept, 0, (), RemapReason.REMAPPED, "Remapped all rows."
 
 
 def _find_duplicates(keys: list[str]) -> dict[str, int]:
@@ -161,15 +236,29 @@ def remap_time_indices(
 ) -> RemapResult:
     """
     Remap time indices in a data container (array-like or list-of-arrays).
-
-    This function is intentionally policy-free: it only applies a provided
-    index mapping and reports whether anything changed.
     """
+    mapped_count = len(idx_map)
+
+    def _result(
+        outcome: RemapOutcome,
+        reason: RemapReason,
+        message: str,
+        data_out: Any | None = None,
+    ) -> RemapResult:
+        return RemapResult(
+            outcome=outcome,
+            reason=reason,
+            depth_used=None,
+            mapped_count=mapped_count,
+            message=message,
+            data=data_out,
+        )
+
     if data is None:
-        return RemapResult(False, False, False, False, None, 0, "No data to remap (data is None).", None)
+        return _result(RemapOutcome.SKIPPED, RemapReason.NO_DATA, "No data to remap (data is None).")
 
     if not idx_map:
-        return RemapResult(False, False, False, False, None, 0, "No index mapping available (empty idx_map).", None)
+        return _result(RemapOutcome.SKIPPED, RemapReason.EMPTY_MAPPING, "No index mapping available (empty idx_map).")
 
     # Shapes-like: list of arrays
     if isinstance(data, list):
@@ -178,6 +267,7 @@ def remap_time_indices(
 
         for verts in data:
             arr = np.asarray(verts)
+
             if arr.size == 0:
                 new_data.append(arr)
                 continue
@@ -191,9 +281,12 @@ def remap_time_indices(
 
             try:
                 t2 = _remap_array(t, idx_map)
-            except Exception:
-                new_data.append(arr2)
-                continue
+            except Exception as e:
+                return _result(
+                    RemapOutcome.REJECTED,
+                    RemapReason.REMAP_FAILED,
+                    f"Failed to remap list-like vertices: {e}",
+                )
 
             try:
                 if not np.array_equal(t2, np.asarray(t).astype(int, copy=False)):
@@ -204,25 +297,31 @@ def remap_time_indices(
             arr2[:, time_col] = t2
             new_data.append(arr2)
 
-        return RemapResult(
-            changed=changed,
-            applied=changed,
-            accept_paths_update=changed,
-            is_ambiguous=False,
-            depth_used=None,
-            mapped_count=len(idx_map),
-            message="Remapped list-like vertices." if changed else "List-like vertices unchanged.",
-            data=new_data if changed else None,
+        if changed:
+            return _result(
+                RemapOutcome.APPLIED_FULL,
+                RemapReason.REMAPPED,
+                "Remapped list-like vertices.",
+                new_data,
+            )
+
+        return _result(
+            RemapOutcome.NOOP,
+            RemapReason.ALREADY_ALIGNED,
+            "List-like vertices already aligned; no remap needed.",
         )
 
     # Array-like
     arr = np.asarray(data)
+
     if arr.size == 0:
-        return RemapResult(False, False, False, False, None, len(idx_map), "No data to remap (empty array).", None)
+        return _result(RemapOutcome.SKIPPED, RemapReason.NO_DATA, "No data to remap (empty array).")
 
     if arr.ndim < 2 or arr.shape[1] <= time_col:
-        return RemapResult(
-            False, False, False, False, None, len(idx_map), "Data shape does not contain a time column.", None
+        return _result(
+            RemapOutcome.SKIPPED,
+            RemapReason.INVALID_TIME_COLUMN,
+            "Data shape does not contain a valid time column.",
         )
 
     arr2 = np.array(arr, copy=True)
@@ -230,8 +329,12 @@ def remap_time_indices(
 
     try:
         t2 = _remap_array(t, idx_map)
-    except Exception:
-        return RemapResult(False, False, False, False, None, len(idx_map), "Failed to remap time column.", None)
+    except Exception as e:
+        return _result(
+            RemapOutcome.REJECTED,
+            RemapReason.REMAP_FAILED,
+            f"Failed to remap time column: {e}",
+        )
 
     try:
         unchanged = np.array_equal(t2, np.asarray(t).astype(int, copy=False))
@@ -239,10 +342,19 @@ def remap_time_indices(
         unchanged = False
 
     if unchanged:
-        return RemapResult(False, False, False, False, None, len(idx_map), "Time column unchanged after remap.", None)
+        return _result(
+            RemapOutcome.NOOP,
+            RemapReason.ALREADY_ALIGNED,
+            "Time column already aligned; no remap needed.",
+        )
 
     arr2[:, time_col] = t2
-    return RemapResult(True, True, True, False, None, len(idx_map), "Remapped array-like data.", arr2)
+    return _result(
+        RemapOutcome.APPLIED_FULL,
+        RemapReason.REMAPPED,
+        "Remapped array-like data.",
+        arr2,
+    )
 
 
 def remap_layer_data_by_paths(
@@ -254,46 +366,160 @@ def remap_layer_data_by_paths(
     policy: PathMatchPolicy = PathMatchPolicy.ORDERED_DEPTHS,
 ) -> RemapResult:
     """
-    High-level remap: infer idx_map from old/new paths, assess safety, then
-    remap `data` only when the mapping is acceptable.
+    Remap layer time/frame indices after the image stack path list changes.
 
-    Policy
-    ------
-    - Safe remaps are applied automatically.
-    - Ambiguous basename-only remaps (depth=1 with duplicate canonical keys
-      and/or non-bijective mapping) are rejected.
+    Purpose
+    -------
+    This function reconciles annotation data whose time/frame column refers to
+    indices in `old_paths` with a newly loaded image path list `new_paths`.
+
+    In DeepLabCut-style projects, annotation paths would typically be something like:
+
+        labeled-data/<video-or-session-name>/img070.png
+
+    The primary safety invariant is whether all actually-used
+    annotation frame indices can be mapped uniquely and unambiguously.
+
+    Invariants
+    ----------
+    A remap is applied only if all of the following hold:
+
+    1. A canonicalization depth can be found for matching old/new paths.
+    2. Canonical keys at that depth are not ambiguous:
+       - no duplicate keys in old paths,
+       - no duplicate keys in new paths,
+       - no non-bijective old-index -> new-index mapping.
+    3. Every frame index actually used by `data[:, time_col]` has a mapping.
+    4. The data has a valid time column when data remapping is required.
+
+    Assumptions
+    -----------
+    - The layer's time/frame column stores integer indices into `old_paths`.
+    - `old_paths[i]` describes the image frame originally referenced by time
+      index `i`.
+    - `new_paths[j]` describes the image frame currently loaded at time index
+      `j`.
+    - Canonicalized path equality means "same semantic frame" for the selected
+      matching depth.
+    - Sparse annotations are normal. It is acceptable for many image paths to
+      have no annotation rows.
+
+    Outcomes
+    --------
+    - SKIPPED:
+        Required information is missing, or no path overlap can be found.
+    - NOOP:
+        Paths are already aligned, or a safe mapping exists but no data rewrite
+        is needed.
+    - APPLIED_FULL:
+        All relevant annotation rows were remapped.
+    - APPLIED_PARTIAL:
+        Some rows were dropped during a permissive/partial remap.
+        This high-level function currently prefers rejection over partial remap
+        when used frame indices are unmapped.
+    - REJECTED:
+        A remap was possible in principle, but unsafe due to ambiguity or
+        unmapped used frame indices.
+
+    Diagnostics
+    -----------
+    The function may report warnings for suspicious but non-fatal situations,
+    such as low old-path coverage. These warnings do not determine correctness.
+    The hard safety checks above do.
     """
     old_paths = list(old_paths or [])
     new_paths = list(new_paths or [])
 
+    def _result(
+        outcome: RemapOutcome,
+        reason: RemapReason,
+        message: str,
+        *,
+        depth_used: int | None = None,
+        mapped_count: int = 0,
+        data_out: Any | None = None,
+        warnings: list[str] | tuple[str, ...] = (),
+        dropped_row_count: int = 0,
+        dropped_frame_indices: tuple[int, ...] = (),
+    ) -> RemapResult:
+        return RemapResult(
+            outcome=outcome,
+            reason=reason,
+            depth_used=depth_used,
+            mapped_count=mapped_count,
+            message=message,
+            data=data_out,
+            warnings=tuple(warnings),
+            dropped_row_count=dropped_row_count,
+            dropped_frame_indices=dropped_frame_indices,
+        )
+
+    # --- Initial checks -----------------------------------------------------
+
     if not old_paths:
-        return RemapResult(False, False, False, False, None, 0, "No old paths present; cannot remap.", None)
+        return _result(
+            RemapOutcome.SKIPPED,
+            RemapReason.NO_OLD_PATHS,
+            "No old paths present; cannot remap.",
+        )
+
     if not new_paths:
-        return RemapResult(False, False, False, False, None, 0, "No new paths present; cannot remap.", None)
+        return _result(
+            RemapOutcome.SKIPPED,
+            RemapReason.NO_NEW_PATHS,
+            "No new paths present; cannot remap.",
+        )
 
     depth = find_matching_depth(old_paths, new_paths, policy=policy)
     if depth is None:
-        return RemapResult(
-            False, False, False, False, None, 0, "No overlap between old and new paths; skipping remap.", None
+        return _result(
+            RemapOutcome.SKIPPED,
+            RemapReason.NO_OVERLAP,
+            "No overlap between old and new paths; skipping remap.",
         )
+
+    # --- Canonicalize  -------------------------------------------------
 
     old_keys = [canonicalize_path(p, depth) for p in old_paths]
     new_keys = [canonicalize_path(p, depth) for p in new_paths]
 
-    overlap = set(old_keys) & set(new_keys)
-    overlap_ratio = (len(overlap) / max(1, min(len(old_keys), len(new_keys)))) if overlap else 0.0
+    # Fast path: already aligned => no data rewrite needed, but paths metadata
+    # may be considered safe/updatable by callers.
+    if old_keys == new_keys:
+        return _result(
+            RemapOutcome.NOOP,
+            RemapReason.ALREADY_ALIGNED,
+            "Path keys already aligned; no remap needed.",
+            depth_used=depth,
+            mapped_count=len(old_keys),
+        )
 
-    key_to_new_idx = {k: i for i, k in enumerate(new_keys)}
+    # --- Build idx_map -----------------------------------------------------
+
+    # Keep first occurrence for deterministic behavior.
+    # If duplicates exist, we will reject later anyway.
+    key_to_new_idx: dict[str, int] = {}
+    for i, k in enumerate(new_keys):
+        key_to_new_idx.setdefault(k, i)
+
     idx_map: dict[int, int] = {}
     for old_idx, k in enumerate(old_keys):
         new_idx = key_to_new_idx.get(k)
         if new_idx is not None:
             idx_map[old_idx] = new_idx
 
-    matched = set(idx_map.keys())
+    if not idx_map:
+        return _result(
+            RemapOutcome.SKIPPED,
+            RemapReason.NO_OVERLAP,
+            "No overlap between old and new paths after canonicalization; skipping remap.",
+            depth_used=depth,
+        )
+
+    # --- Coverage / safety checks -----------------------------------------
     used = _used_time_indices(data, time_col)
-    unmapped_used = used - matched
-    mapped_used = used & matched
+    unmapped_used = used.difference(idx_map)
+    mapped_used = used.intersection(idx_map)
 
     logger.debug(
         "Remap used-frame coverage: depth=%s used=%s mapped_used=%s unmapped_used=%s "
@@ -306,8 +532,47 @@ def remap_layer_data_by_paths(
         list(unmapped_used)[:10],
     )
 
-    # Reject remap if any frame index actually used by the layer has no mapping.
-    # Otherwise we risk mixing remapped indices with untouched old indices.
+    warnings: list[str] = []
+
+    dup_old = _find_duplicates(old_keys)
+    dup_new = _find_duplicates(new_keys)
+
+    if dup_old:
+        examples = ", ".join(list(dup_old.keys())[:_SAMPLE_N])
+        warnings.append(f"Duplicate canonical keys in old_paths at depth={depth} (examples: {examples}).")
+
+    if dup_new:
+        examples = ", ".join(list(dup_new.keys())[:_SAMPLE_N])
+        warnings.append(f"Duplicate canonical keys in new_paths at depth={depth} (examples: {examples}).")
+
+    matched_old = set(idx_map)
+    matched_new = set(idx_map.values())
+
+    old_path_coverage = len(matched_old) / max(1, len(old_keys))
+    new_path_coverage = len(matched_new) / max(1, len(new_keys))
+    if old_path_coverage < _WARN_OLD_PATH_COVERAGE:
+        warnings.append(
+            f"Low old-path coverage at depth={depth}: {old_path_coverage:.2f} "
+            f"({len(matched_old)} of {len(old_keys)} old paths map to the new stack). "
+            "This may be still normal for DLC annotations if all used frame indices are mapped."
+        )
+
+    logger.debug(
+        "Remap new-path coverage: %.2f (%s of %s new paths represented by old paths). "
+        "Low values are expected when annotations are sparse.",
+        new_path_coverage,
+        len(matched_new),
+        len(new_keys),
+    )
+
+    non_bijective = len(matched_new) < len(idx_map)
+    if non_bijective:
+        warnings.append("Non-bijective mapping detected (multiple old indices map to the same new index).")
+
+    for w in warnings:
+        logger.warning("Remap may be ambiguous/risky: %s", w)
+
+    # Reject if the layer actually uses frame indices that do not map.
     if unmapped_used:
         msg = "Rejected remap because some labeled frame indices have no mapping in the new image stack."
         logger.warning(
@@ -317,113 +582,59 @@ def remap_layer_data_by_paths(
             len(unmapped_used),
             list(unmapped_used)[:10],
         )
-        return RemapResult(
-            changed=False,
-            applied=False,
-            accept_paths_update=False,
-            is_ambiguous=True,
-            depth_used=depth,
-            mapped_count=len(idx_map),
-            message=msg,
-            data=None,
-            warnings=(
+        warnings = [
+            *warnings,
+            (
                 f"Used frame indices without mapping at depth={depth}: "
-                f"{list(unmapped_used)[:10]}{'...' if len(unmapped_used) > 10 else ''}",
+                f"{list(unmapped_used)[:10]}{'...' if len(unmapped_used) > 10 else ''}"
             ),
-        )
-
-    identity_mappings = sum(1 for old_i, new_i in idx_map.items() if old_i == new_i)
-    logger.debug(
-        "Remap mapping stats: depth=%s old=%s new=%s mapped=%s identity=%s overlap=%s",
-        depth,
-        len(old_keys),
-        len(new_keys),
-        len(idx_map),
-        identity_mappings,
-        len(overlap),
-    )
-    for old_i in sorted(idx_map)[:10]:
-        new_i = idx_map[old_i]
-        logger.debug(
-            "Remap example: old_idx=%s -> new_idx=%s | old_path=%r | new_path=%r",
-            old_i,
-            new_i,
-            old_paths[old_i],
-            new_paths[new_i],
-        )
-
-    if not idx_map:
-        return RemapResult(
-            False, False, False, False, None, 0, "No overlap between old and new paths; skipping remap.", None
-        )
-
-    # If ordering already matches, accept metadata paths update but no data remap needed.
-    if old_keys == new_keys:
-        return RemapResult(
-            changed=False,
-            applied=False,
-            accept_paths_update=True,
-            is_ambiguous=False,
+        ]
+        return _result(
+            RemapOutcome.REJECTED,
+            RemapReason.USED_INDICES_UNMAPPED,
+            msg,
             depth_used=depth,
             mapped_count=len(idx_map),
-            message="Path keys already aligned; no remap needed.",
-            data=None,
+            warnings=warnings,
         )
 
-    warnings: list[str] = []
-
-    dup_old = _find_duplicates(old_keys)
-    dup_new = _find_duplicates(new_keys)
-    if dup_old:
-        examples = ", ".join(list(dup_old.keys())[:_SAMPLE_N])
-        warnings.append(f"Duplicate canonical keys in old_paths at depth={depth} (examples: {examples}).")
-    if dup_new:
-        examples = ", ".join(list(dup_new.keys())[:_SAMPLE_N])
-        warnings.append(f"Duplicate canonical keys in new_paths at depth={depth} (examples: {examples}).")
-
-    mapped_ratio = len(idx_map) / max(1, len(old_keys))
-    if overlap_ratio < _WARN_OVERLAP_RATIO:
-        warnings.append(
-            f"Low path overlap ratio at depth={depth}: {overlap_ratio:.2f} "
-            f"(overlap={len(overlap)}, old={len(old_keys)}, new={len(new_keys)})."
-        )
-    if mapped_ratio < _WARN_MAPPED_RATIO:
-        warnings.append(f"Low mapping coverage: {mapped_ratio:.2f} (mapped={len(idx_map)} of old={len(old_keys)}).")
-
-    non_bijective = len(set(idx_map.values())) < len(idx_map)
-    if non_bijective:
-        warnings.append("Non-bijective mapping detected (multiple old indices map to the same new index).")
-
-    for w in warnings:
-        logger.warning("Remap may be ambiguous/risky: %s", w)
-
-    # Reject ambiguous basename-only remaps.
-    is_ambiguous = bool(dup_old) or bool(dup_new) or non_bijective
-    if is_ambiguous:
+    # Reject ambiguous canonicalization/matching.
+    if dup_old or dup_new or non_bijective:
         msg = f"Rejected ambiguous remap at depth={depth}; keeping original frame indices and paths."
         logger.warning(msg)
-        return RemapResult(
-            changed=False,
-            applied=False,
-            accept_paths_update=False,
-            is_ambiguous=True,
+        return _result(
+            RemapOutcome.REJECTED,
+            RemapReason.AMBIGUOUS_MATCH,
+            msg,
             depth_used=depth,
             mapped_count=len(idx_map),
-            message=msg,
-            data=None,
-            warnings=tuple(warnings),
+            warnings=warnings,
         )
+
+    # Safe mapping exists, but there is no data to rewrite. This is still a
+    # successful metadata/path-alignment case for callers.
+    if data is None:
+        return _result(
+            RemapOutcome.NOOP,
+            RemapReason.NO_DATA,
+            "Safe path mapping found, but there is no data to remap.",
+            depth_used=depth,
+            mapped_count=len(idx_map),
+            warnings=warnings,
+        )
+
+    # --- Apply
 
     res = remap_time_indices(data=data, time_col=time_col, idx_map=idx_map)
 
-    return RemapResult(
-        changed=res.changed,
-        applied=res.changed,
-        accept_paths_update=True,
-        is_ambiguous=False,
+    return _result(
+        res.outcome,
+        res.reason,
+        res.message,
         depth_used=depth,
-        mapped_count=res.mapped_count,
-        message=res.message,
-        data=res.data if res.changed else None,
-        warnings=tuple(warnings),
+        mapped_count=len(idx_map),
+        data_out=res.data,
+        warnings=warnings,
+        dropped_row_count=res.dropped_row_count,
+        dropped_frame_indices=res.dropped_frame_indices,
     )

--- a/src/napari_deeplabcut/core/remap.py
+++ b/src/napari_deeplabcut/core/remap.py
@@ -164,14 +164,6 @@ def _filter_and_remap_array(
                 "were not found in the new image stack."
             ),
         )
-    if not np.any(keep_mask):
-        return (
-            None,
-            int(drop_mask.sum()),
-            tuple(sorted(set(t))),
-            RemapReason.NO_MAPPABLE_ROWS,
-            ("No rows could be mapped to the new image stack."),
-        )
 
     return kept, 0, (), RemapReason.REMAPPED, "Remapped all rows."
 
@@ -460,7 +452,10 @@ def remap_layer_data_by_paths(
        - no duplicate keys in old paths,
        - no duplicate keys in new paths,
        - no non-bijective old-index -> new-index mapping.
-    3. Every frame index actually used by `data[:, time_col]` has a mapping.
+    3. In strict mode, every frame index actually used by `data[:, time_col]`
+    must have a mapping.
+    In partial mode, rows whose frame index has no mapping may be dropped and
+    reported as APPLIED_PARTIAL.
     4. The data has a valid time column when data remapping is required.
 
     Assumptions
@@ -486,8 +481,8 @@ def remap_layer_data_by_paths(
         All relevant annotation rows were remapped.
     - APPLIED_PARTIAL:
         Some rows were dropped during a permissive/partial remap.
-        This high-level function currently prefers rejection over partial remap
-        when used frame indices are unmapped.
+        Currently rejects unmapped used frame indices in strict mode,
+        and drops/reports them in partial mode.
     - REJECTED:
         A remap was possible in principle, but unsafe due to ambiguity or
         unmapped used frame indices.
@@ -622,11 +617,21 @@ def remap_layer_data_by_paths(
     old_path_coverage = len(matched_old) / max(1, len(old_keys))
     new_path_coverage = len(matched_new) / max(1, len(new_keys))
     if old_path_coverage < _WARN_OLD_PATH_COVERAGE:
-        warnings.append(
-            f"Low old-path coverage at depth={depth}: {old_path_coverage:.2f} "
-            f"({len(matched_old)} of {len(old_keys)} old paths map to the new stack). "
-            "This may be still normal for DLC annotations if all used frame indices are mapped."
-        )
+        if allow_partial and unmapped_used:
+            logger.debug(
+                "Low old-path coverage during partial remap at depth=%s: %.2f "
+                "(%s of %s old paths map). This is expected when dropping unmappable rows.",
+                depth,
+                old_path_coverage,
+                len(idx_map),
+                len(old_keys),
+            )
+        else:
+            warnings.append(
+                f"Low old-path coverage at depth={depth}: {old_path_coverage:.2f} "
+                f"({len(idx_map)} of {len(old_keys)} old paths map to the new stack). "
+                "This may still be normal for DLC annotations if all used frame indices are mapped."
+            )
 
     logger.debug(
         "Remap new-path coverage: %.2f (%s of %s new paths represented by old paths). "

--- a/src/napari_deeplabcut/core/remap.py
+++ b/src/napari_deeplabcut/core/remap.py
@@ -159,7 +159,18 @@ def _filter_and_remap_array(
             dropped_rows,
             dropped_frames,
             RemapReason.PARTIAL_ROWS_DROPPED,
-            (f"Dropped {dropped_rows} unmappable row(s)."),
+            (
+                f"Partially remapped data; dropped {dropped_rows} row(s) whose frame indices "
+                "were not found in the new image stack."
+            ),
+        )
+    if not np.any(keep_mask):
+        return (
+            None,
+            int(drop_mask.sum()),
+            tuple(sorted(set(t))),
+            RemapReason.NO_MAPPABLE_ROWS,
+            ("No rows could be mapped to the new image stack."),
         )
 
     return kept, 0, (), RemapReason.REMAPPED, "Remapped all rows."
@@ -233,9 +244,16 @@ def remap_time_indices(
     data: Any,
     time_col: int,
     idx_map: Mapping[int, int],
+    allow_partial: bool = False,
 ) -> RemapResult:
     """
-    Remap time indices in a data container (array-like or list-of-arrays).
+    Remap time indices in a data container.
+
+    If allow_partial is False, all used frame indices must be present in
+    idx_map.
+
+    If allow_partial is True, rows whose frame index is not present in idx_map
+    are dropped and reported as APPLIED_PARTIAL.
     """
     mapped_count = len(idx_map)
 
@@ -244,6 +262,9 @@ def remap_time_indices(
         reason: RemapReason,
         message: str,
         data_out: Any | None = None,
+        *,
+        dropped_row_count: int = 0,
+        dropped_frame_indices: tuple[int, ...] = (),
     ) -> RemapResult:
         return RemapResult(
             outcome=outcome,
@@ -252,108 +273,157 @@ def remap_time_indices(
             mapped_count=mapped_count,
             message=message,
             data=data_out,
+            dropped_row_count=dropped_row_count,
+            dropped_frame_indices=dropped_frame_indices,
         )
 
     if data is None:
-        return _result(RemapOutcome.SKIPPED, RemapReason.NO_DATA, "No data to remap (data is None).")
-
-    if not idx_map:
-        return _result(RemapOutcome.SKIPPED, RemapReason.EMPTY_MAPPING, "No index mapping available (empty idx_map).")
-
-    # Shapes-like: list of arrays
-    if isinstance(data, list):
-        new_data = []
-        changed = False
-
-        for verts in data:
-            arr = np.asarray(verts)
-
-            if arr.size == 0:
-                new_data.append(arr)
-                continue
-
-            if arr.ndim < 2 or arr.shape[1] <= time_col:
-                new_data.append(arr)
-                continue
-
-            arr2 = np.array(arr, copy=True)
-            t = arr2[:, time_col]
-
-            try:
-                t2 = _remap_array(t, idx_map)
-            except Exception as e:
-                return _result(
-                    RemapOutcome.REJECTED,
-                    RemapReason.REMAP_FAILED,
-                    f"Failed to remap list-like vertices: {e}",
-                )
-
-            try:
-                if not np.array_equal(t2, np.asarray(t).astype(int, copy=False)):
-                    changed = True
-            except Exception:
-                changed = True
-
-            arr2[:, time_col] = t2
-            new_data.append(arr2)
-
-        if changed:
-            return _result(
-                RemapOutcome.APPLIED_FULL,
-                RemapReason.REMAPPED,
-                "Remapped list-like vertices.",
-                new_data,
-            )
-
-        return _result(
-            RemapOutcome.NOOP,
-            RemapReason.ALREADY_ALIGNED,
-            "List-like vertices already aligned; no remap needed.",
-        )
-
-    # Array-like
-    arr = np.asarray(data)
-
-    if arr.size == 0:
-        return _result(RemapOutcome.SKIPPED, RemapReason.NO_DATA, "No data to remap (empty array).")
-
-    if arr.ndim < 2 or arr.shape[1] <= time_col:
         return _result(
             RemapOutcome.SKIPPED,
-            RemapReason.INVALID_TIME_COLUMN,
-            "Data shape does not contain a valid time column.",
+            RemapReason.NO_DATA,
+            "No data to remap (data is None).",
         )
 
-    arr2 = np.array(arr, copy=True)
-    t = arr2[:, time_col]
-
-    try:
-        t2 = _remap_array(t, idx_map)
-    except Exception as e:
+    if not idx_map:
         return _result(
-            RemapOutcome.REJECTED,
-            RemapReason.REMAP_FAILED,
-            f"Failed to remap time column: {e}",
+            RemapOutcome.SKIPPED,
+            RemapReason.EMPTY_MAPPING,
+            "No index mapping available (empty idx_map).",
         )
 
-    try:
-        unchanged = np.array_equal(t2, np.asarray(t).astype(int, copy=False))
-    except Exception:
-        unchanged = False
+    # Array-like path. This is the common Points-layer case.
+    if not isinstance(data, list):
+        arr = np.asarray(data)
 
-    if unchanged:
+        if arr.size == 0:
+            return _result(
+                RemapOutcome.SKIPPED,
+                RemapReason.NO_DATA,
+                "No data to remap (empty array).",
+            )
+
+        if arr.ndim < 2 or arr.shape[1] <= time_col:
+            return _result(
+                RemapOutcome.SKIPPED,
+                RemapReason.INVALID_TIME_COLUMN,
+                "Data shape does not contain a valid time column.",
+            )
+
+        if allow_partial:
+            remapped, dropped_rows, dropped_frames, reason, message = _filter_and_remap_array(
+                arr,
+                time_col=time_col,
+                idx_map=dict(idx_map),
+            )
+
+            if remapped is None:
+                outcome = (
+                    RemapOutcome.REJECTED
+                    if reason
+                    in {
+                        RemapReason.NO_MAPPABLE_ROWS,
+                        RemapReason.INVALID_TIME_COLUMN,
+                    }
+                    else RemapOutcome.SKIPPED
+                )
+                return _result(
+                    outcome,
+                    reason,
+                    message,
+                    dropped_row_count=dropped_rows,
+                    dropped_frame_indices=dropped_frames[:_SAMPLE_N],
+                )
+
+            outcome = RemapOutcome.APPLIED_PARTIAL if dropped_rows else RemapOutcome.APPLIED_FULL
+            return _result(
+                outcome,
+                reason,
+                message,
+                remapped,
+                dropped_row_count=dropped_rows,
+                dropped_frame_indices=dropped_frames[:_SAMPLE_N],
+            )
+
+        arr2 = np.array(arr, copy=True)
+        t = arr2[:, time_col]
+
+        try:
+            t2 = _remap_array(t, idx_map)
+        except Exception as e:
+            return _result(
+                RemapOutcome.REJECTED,
+                RemapReason.REMAP_FAILED,
+                f"Failed to remap time column: {e}",
+            )
+
+        try:
+            unchanged = np.array_equal(t2, np.asarray(t).astype(int, copy=False))
+        except Exception:
+            unchanged = False
+
+        if unchanged:
+            return _result(
+                RemapOutcome.NOOP,
+                RemapReason.ALREADY_ALIGNED,
+                "Time column already aligned; no remap needed.",
+            )
+
+        arr2[:, time_col] = t2
         return _result(
-            RemapOutcome.NOOP,
-            RemapReason.ALREADY_ALIGNED,
-            "Time column already aligned; no remap needed.",
+            RemapOutcome.APPLIED_FULL,
+            RemapReason.REMAPPED,
+            "Remapped array-like data.",
+            arr2,
         )
 
-    arr2[:, time_col] = t2
+    # Existing list-like behavior can remain strict for now.
+    new_data = []
+    changed = False
+
+    for verts in data:
+        arr = np.asarray(verts)
+
+        if arr.size == 0:
+            new_data.append(arr)
+            continue
+
+        if arr.ndim < 2 or arr.shape[1] <= time_col:
+            new_data.append(arr)
+            continue
+
+        arr2 = np.array(arr, copy=True)
+        t = arr2[:, time_col]
+
+        try:
+            t2 = _remap_array(t, idx_map)
+        except Exception as e:
+            return _result(
+                RemapOutcome.REJECTED,
+                RemapReason.REMAP_FAILED,
+                f"Failed to remap list-like vertices: {e}",
+            )
+
+        try:
+            if not np.array_equal(t2, np.asarray(t).astype(int, copy=False)):
+                changed = True
+        except Exception:
+            changed = True
+
+        arr2[:, time_col] = t2
+        new_data.append(arr2)
+
+    if changed:
+        return _result(
+            RemapOutcome.APPLIED_FULL,
+            RemapReason.REMAPPED,
+            "Remapped list-like vertices.",
+            new_data,
+        )
+
     return _result(
-        RemapOutcome.APPLIED_FULL,
-        RemapReason.REMAPPED,
-        "Remapped array-like data.",
-        arr2,
+        RemapOutcome.NOOP,
+        RemapReason.ALREADY_ALIGNED,
+        "List-like vertices already aligned; no remap needed.",
     )
 
 
@@ -364,6 +434,7 @@ def remap_layer_data_by_paths(
     new_paths: Iterable[str] | None,
     time_col: int,
     policy: PathMatchPolicy = PathMatchPolicy.ORDERED_DEPTHS,
+    allow_partial: bool = False,
 ) -> RemapResult:
     """
     Remap layer time/frame indices after the image stack path list changes.
@@ -573,7 +644,7 @@ def remap_layer_data_by_paths(
         logger.warning("Remap may be ambiguous/risky: %s", w)
 
     # Reject if the layer actually uses frame indices that do not map.
-    if unmapped_used:
+    if unmapped_used and not allow_partial:
         msg = "Rejected remap because some labeled frame indices have no mapping in the new image stack."
         logger.warning(
             "%s depth=%s unmapped_used_count=%s examples=%s",
@@ -596,6 +667,14 @@ def remap_layer_data_by_paths(
             depth_used=depth,
             mapped_count=len(idx_map),
             warnings=warnings,
+        )
+
+    if unmapped_used and allow_partial:
+        warnings.append(
+            f"Partial remap: {len(unmapped_used)} used frame index/indices have no mapping "
+            f"at depth={depth}; rows on those frames will be dropped. "
+            f"Examples: {sorted(unmapped_used)[:_SAMPLE_N]}"
+            f"{'...' if len(unmapped_used) > _SAMPLE_N else ''}"
         )
 
     # Reject ambiguous canonicalization/matching.
@@ -625,7 +704,7 @@ def remap_layer_data_by_paths(
 
     # --- Apply
 
-    res = remap_time_indices(data=data, time_col=time_col, idx_map=idx_map)
+    res = remap_time_indices(data=data, time_col=time_col, idx_map=idx_map, allow_partial=allow_partial)
 
     return _result(
         res.outcome,

--- a/src/napari_deeplabcut/core/remap.py
+++ b/src/napari_deeplabcut/core/remap.py
@@ -78,8 +78,12 @@ def _remap_array(values: np.ndarray, idx_map: Mapping[int, int]) -> np.ndarray:
     except Exception:
         values_int = values.astype(int)
 
+    missing = [int(v) for v in values_int if int(v) not in idx_map]
+    if missing:
+        raise KeyError(f"Unmapped frame indices encountered during remap: {missing[:10]}")
+
     mapped = np.fromiter(
-        (idx_map.get(int(v), int(v)) for v in values_int),
+        (idx_map[int(v)] for v in values_int),
         dtype=values_int.dtype,
         count=len(values_int),
     )
@@ -92,6 +96,25 @@ def _find_duplicates(keys: list[str]) -> dict[str, int]:
     for k in keys:
         counts[k] = counts.get(k, 0) + 1
     return {k: c for k, c in counts.items() if c > 1}
+
+
+def _used_time_indices(data: Any, time_col: int) -> set[int]:
+    if data is None:
+        return set()
+
+    if isinstance(data, list):
+        used = set()
+        for verts in data:
+            arr = np.asarray(verts)
+            if arr.size == 0 or arr.ndim < 2 or arr.shape[1] <= time_col:
+                continue
+            used.update(int(v) for v in arr[:, time_col])
+        return used
+
+    arr = np.asarray(data)
+    if arr.size == 0 or arr.ndim < 2 or arr.shape[1] <= time_col:
+        return set()
+    return set(int(v) for v in arr[:, time_col])
 
 
 def build_frame_index_map(
@@ -267,6 +290,48 @@ def remap_layer_data_by_paths(
         if new_idx is not None:
             idx_map[old_idx] = new_idx
 
+    matched = set(idx_map.keys())
+    used = _used_time_indices(data, time_col)
+    unmapped_used = used - matched
+    mapped_used = used & matched
+
+    logger.debug(
+        "Remap used-frame coverage: depth=%s used=%s mapped_used=%s unmapped_used=%s "
+        "used_examples=%s unmapped_examples=%s",
+        depth,
+        len(used),
+        len(mapped_used),
+        len(unmapped_used),
+        list(mapped_used)[:10],
+        list(unmapped_used)[:10],
+    )
+
+    # Reject remap if any frame index actually used by the layer has no mapping.
+    # Otherwise we risk mixing remapped indices with untouched old indices.
+    if unmapped_used:
+        msg = "Rejected remap because some labeled frame indices have no mapping in the new image stack."
+        logger.warning(
+            "%s depth=%s unmapped_used_count=%s examples=%s",
+            msg,
+            depth,
+            len(unmapped_used),
+            list(unmapped_used)[:10],
+        )
+        return RemapResult(
+            changed=False,
+            applied=False,
+            accept_paths_update=False,
+            is_ambiguous=True,
+            depth_used=depth,
+            mapped_count=len(idx_map),
+            message=msg,
+            data=None,
+            warnings=(
+                f"Used frame indices without mapping at depth={depth}: "
+                f"{list(unmapped_used)[:10]}{'...' if len(unmapped_used) > 10 else ''}",
+            ),
+        )
+
     identity_mappings = sum(1 for old_i, new_i in idx_map.items() if old_i == new_i)
     logger.debug(
         "Remap mapping stats: depth=%s old=%s new=%s mapped=%s identity=%s overlap=%s",
@@ -277,6 +342,15 @@ def remap_layer_data_by_paths(
         identity_mappings,
         len(overlap),
     )
+    for old_i in sorted(idx_map)[:10]:
+        new_i = idx_map[old_i]
+        logger.debug(
+            "Remap example: old_idx=%s -> new_idx=%s | old_path=%r | new_path=%r",
+            old_i,
+            new_i,
+            old_paths[old_i],
+            new_paths[new_i],
+        )
 
     if not idx_map:
         return RemapResult(
@@ -324,9 +398,9 @@ def remap_layer_data_by_paths(
         logger.warning("Remap may be ambiguous/risky: %s", w)
 
     # Reject ambiguous basename-only remaps.
-    ambiguous_depth1 = depth == 1 and (bool(dup_old) or bool(dup_new) or non_bijective)
-    if ambiguous_depth1:
-        msg = "Rejected ambiguous depth=1 remap; keeping original frame indices and paths."
+    is_ambiguous = bool(dup_old) or bool(dup_new) or non_bijective
+    if is_ambiguous:
+        msg = f"Rejected ambiguous remap at depth={depth}; keeping original frame indices and paths."
         logger.warning(msg)
         return RemapResult(
             changed=False,


### PR DESCRIPTION
### Scope

Refines the remapping logic in `remap_layer_data_by_paths` and related functions, introduces more explicit, structured handling of remapping outcomes and reasons. 
It also adds user-facing notifications for remap issues in the layer lifecycle manager. 
The changes improve both the robustness of remap operations and the clarity of their results, especially in edge and partial remap cases.
The plugin now also accepts H5s with only a subset of valid/matching annotations, and will report which entries were omitted.

## Automated summary

**User notification improvements:**

* Added `_notify_remap_issue` method to `LayerLifecycleManager` to emit signals and show user-facing warnings or errors in the napari UI when remap issues occur, improving transparency and debug. [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R698-R721) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R87-R90)
* Uses `show_error` and `show_warning` for displaying notifications.

**API and code structure updates:**

* Updated imports and usage throughout to use the new `RemapOutcome` and `RemapReason` enums, making remap result handling more explicit and maintainable. [[1]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3R7-R8) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L28-R29)

**Test suite improvements and expanded coverage:**

* Refactored tests to assert on new, explicit result fields (`outcome`, `reason`, `applied`, `paths_updated`) instead of the previous `changed` flag, improving clarity and future-proofing. Added checks for user-facing messages and warnings. [[1]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3L86-R91) [[2]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3L117-L120) [[3]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3L149-R162) [[4]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3L168-R188) [[5]](diffhunk://#diff-9f413885f1e7394b39aee2625ac7019769d0260b26c8a717f510a42c75f17cb3L196-L250)
* Added comprehensive tests for strict and partial remapping modes, including:
  - Rejection when unmapped indices are present in strict mode (`REJECTED`/`REMAP_FAILED`). (F5645e13L232R232)
  - Allowing partial remaps that drop unmappable rows with appropriate outcome/reason (`APPLIED_PARTIAL`/`PARTIAL_ROWS_DROPPED`). (F5645e13L246R246)
  - Rejection when no rows are mappable in partial mode (`REJECTED`/`NO_MAPPABLE_ROWS`). (F5645e13L273R273)
  - Handling of duplicate canonical keys as ambiguous matches (`REJECTED`/`AMBIGUOUS_MATCH`).
  - Handling of low old-path coverage, with warnings or debug messages depending on context.
  - Ensuring graceful handling of empty or `None` data (`SKIPPED`/`NO_DATA`). (F5645e13L273R273)