### PR TITLE
Revert "Relax napari version pin"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = [ "version" ]
 dependencies = [
   "dask-image",
   "matplotlib>=3.3",
-  "napari>=0.6.6",
+  "napari==0.6.6",
   "natsort",
   "numpy>=1.18.5,<2",
   "opencv-python-headless",


### PR DESCRIPTION
Reverts DeepLabCut/napari-deeplabcut#201, which was not ready and had several failing tests due to napari API changes in v0.7.0