### PR TITLE
Prevent likelihood columns from being saved in CollectedData

### DIFF
--- a/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
@@ -6,9 +6,14 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from napari_deeplabcut.config.models import AnnotationKind
+from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
-from napari_deeplabcut.core.io import _drop_likelihood_columns, resolve_output_path_from_metadata, write_hdf
+from napari_deeplabcut.core.io import (
+    _drop_likelihood_columns,
+    _drop_likelihood_from_header,
+    resolve_output_path_from_metadata,
+    write_hdf,
+)
 
 
 def test_resolve_output_path_returns_none_for_machine_without_save_target():
@@ -170,3 +175,61 @@ def test_drop_likelihood_cleans_existing_gt_columns_too():
 
     coords = df_out.columns.get_level_values("coords")
     assert list(coords) == ["x", "y"]
+
+
+def test_drop_likelihood_columns_removes_likelihood_from_empty_dataframe():
+    """
+    Regression guard: likelihood coords must be removed even when the dataframe
+    has 0 rows, e.g. an empty machine layer promoted to GT.
+    """
+    cols = pd.MultiIndex.from_product(
+        [["John"], ["bp1"], ["x", "y", "likelihood"]],
+        names=["scorer", "bodyparts", "coords"],
+    )
+    df = pd.DataFrame([], columns=cols, index=pd.Index([], name="image"))
+
+    out = _drop_likelihood_columns(df)
+
+    assert out.empty
+    assert "likelihood" not in out.columns.get_level_values("coords")
+    assert list(out.columns.get_level_values("coords")) == ["x", "y"]
+
+
+def test_drop_likelihood_from_header_preserves_single_animal_3level_shape():
+    header = DLCHeaderModel(
+        columns=[
+            ("John", "bp1", "x"),
+            ("John", "bp1", "y"),
+            ("John", "bp1", "likelihood"),
+        ],
+        names=["scorer", "bodyparts", "coords"],
+    )
+
+    out = _drop_likelihood_from_header(header)
+
+    assert out.names == ["scorer", "bodyparts", "coords"]
+    assert out.columns == [
+        ("John", "bp1", "x"),
+        ("John", "bp1", "y"),
+    ]
+    assert all(len(col) == 3 for col in out.columns)
+
+
+def test_drop_likelihood_from_header_preserves_multi_animal_4level_shape():
+    header = DLCHeaderModel(
+        columns=[
+            ("John", "mouse1", "bp1", "x"),
+            ("John", "mouse1", "bp1", "y"),
+            ("John", "mouse1", "bp1", "likelihood"),
+        ],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
+
+    out = _drop_likelihood_from_header(header)
+
+    assert out.names == ["scorer", "individuals", "bodyparts", "coords"]
+    assert out.columns == [
+        ("John", "mouse1", "bp1", "x"),
+        ("John", "mouse1", "bp1", "y"),
+    ]
+    assert all(len(col) == 4 for col in out.columns)

--- a/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_write_routing.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from napari_deeplabcut.config.models import AnnotationKind
 from napari_deeplabcut.core.errors import AmbiguousSaveError, MissingProvenanceError
-from napari_deeplabcut.core.io import resolve_output_path_from_metadata, write_hdf
+from napari_deeplabcut.core.io import _drop_likelihood_columns, resolve_output_path_from_metadata, write_hdf
 
 
 def test_resolve_output_path_returns_none_for_machine_without_save_target():
@@ -93,3 +94,79 @@ def test_write_hdf_aborts_machine_without_promotion_target(tmp_path: Path):
 
     with pytest.raises(MissingProvenanceError):
         write_hdf("__dlc__.h5", data, attrs)
+
+
+def test_drop_likelihood_before_merge_prevents_machine_likelihood_from_leaking():
+    """
+    Regression test for GT merge-on-save.
+
+    Machine labels may contain a likelihood coord, while GT labels should not.
+    Because DataFrame.combine_first() keeps the union of columns, likelihood
+    would survive the merge unless explicitly removed first.
+    """
+    gt_cols = pd.MultiIndex.from_product(
+        [["John"], ["bp1"], ["x", "y"]],
+        names=["scorer", "bodyparts", "coords"],
+    )
+    machine_cols = pd.MultiIndex.from_product(
+        [["John"], ["bp1"], ["x", "y", "likelihood"]],
+        names=["scorer", "bodyparts", "coords"],
+    )
+
+    # Existing GT file on disk: only x/y
+    df_old = pd.DataFrame(
+        [[1.0, 2.0]],
+        index=["img000.png"],
+        columns=gt_cols,
+    )
+
+    # New machine/promoted labels: x/y + likelihood
+    df_new = pd.DataFrame(
+        [[10.0, 20.0, 0.95]],
+        index=["img000.png"],
+        columns=machine_cols,
+    )
+
+    # Mimic writer behavior: strip likelihood on both sides before merge
+    df_old = _drop_likelihood_columns(df_old)
+    df_new = _drop_likelihood_columns(df_new)
+
+    df_out = df_new.combine_first(df_old)
+
+    assert "likelihood" not in df_out.columns.get_level_values("coords")
+    expected = pd.DataFrame(
+        [[10.0, 20.0]],
+        index=["img000.png"],
+        columns=gt_cols,
+    )
+    pd.testing.assert_frame_equal(df_out, expected)
+
+
+def test_drop_likelihood_cleans_existing_gt_columns_too():
+    """
+    If an existing GT dataframe already contains likelihood columns from a
+    previous bad write, they must still be removed before the merged result
+    is saved again.
+    """
+    cols_with_likelihood = pd.MultiIndex.from_product(
+        [["John"], ["bp1"], ["x", "y", "likelihood"]],
+        names=["scorer", "bodyparts", "coords"],
+    )
+
+    df_old = pd.DataFrame(
+        [[1.0, 2.0, 0.4]],
+        index=["img000.png"],
+        columns=cols_with_likelihood,
+    )
+    df_new = pd.DataFrame(
+        [[10.0, 20.0, 0.95]],
+        index=["img000.png"],
+        columns=cols_with_likelihood,
+    )
+
+    df_old = _drop_likelihood_columns(df_old)
+    df_new = _drop_likelihood_columns(df_new)
+    df_out = df_new.combine_first(df_old)
+
+    coords = df_out.columns.get_level_values("coords")
+    assert list(coords) == ["x", "y"]

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -328,6 +328,36 @@ def form_df(
     return df
 
 
+def _drop_likelihood_columns(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove DLC likelihood columns from a dataframe if present."""
+    if df.empty:
+        return df
+
+    # DLC-style wide dataframe: MultiIndex columns with a coords level
+    if isinstance(df.columns, pd.MultiIndex):
+        col_names = list(df.columns.names)
+        if "coords" in col_names:
+            mask = df.columns.get_level_values("coords").astype(str) != "likelihood"
+            return df.loc[:, mask]
+
+    # Fallback for already-stacked / flat dataframes
+    if "likelihood" in df.columns:
+        return df.drop(columns="likelihood")
+
+    return df
+
+
+def _drop_likelihood_from_header(header: DLCHeaderModel) -> DLCHeaderModel:
+    """Return a header model with likelihood removed from the coords level."""
+    cols = header.as_multiindex()
+
+    if isinstance(cols, pd.MultiIndex) and "coords" in cols.names:
+        mask = cols.get_level_values("coords").astype(str) != "likelihood"
+        cols = cols[mask]
+
+    return DLCHeaderModel(columns=cols)
+
+
 def _resolve_multianimalproject_for_write(
     *,
     out_path: Path,
@@ -419,6 +449,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
     logger.debug("WRITE header bodyparts=%s", ctx.meta.header.bodyparts)
     logger.debug("WRITE props labels unique=%s", list(dict.fromkeys(map(str, attrs.properties.get("label", []))))[:30])
     df_new = form_df_from_validated(ctx)
+    df_new = _drop_likelihood_columns(df_new)
 
     logger.debug("DF_NEW columns nlevels: %s", df_new.columns.nlevels)
     logger.debug("DF_NEW columns names: %s", df_new.columns.names)
@@ -437,6 +468,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
     if target_scorer:
         df_new = set_df_scorer(df_new, target_scorer)
     header_for_write = pts_meta.header.with_scorer(target_scorer) if target_scorer else pts_meta.header
+    header_for_write = _drop_likelihood_from_header(header_for_write)
 
     # Never write back to machine sources without an explicit promotion target
     if not out_path and source_kind == AnnotationKind.MACHINE:
@@ -492,7 +524,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
 
     # Merge-on-save for GT
     if destination_kind == AnnotationKind.GT and out.exists():
-        df_old = _read_hdf_any_key(out)
+        df_old = _drop_likelihood_columns(_read_hdf_any_key(out))
 
         # Harmonize indices and merge
         try:
@@ -526,6 +558,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
         pts_meta=pts_meta,
     )
     df_out = restore_dlc_on_disk_header_shape(df_out, header_for_write, is_ma_project=is_ma_project)
+    df_out = _drop_likelihood_columns(df_out)
 
     logger.debug("FINAL WRITE first columns=%s", list(df_out.columns[:10]))
     logger.debug(

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -330,9 +330,6 @@ def form_df(
 
 def _drop_likelihood_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Remove DLC likelihood columns from a dataframe if present."""
-    if df.empty:
-        return df
-
     # DLC-style wide dataframe: MultiIndex columns with a coords level
     if isinstance(df.columns, pd.MultiIndex):
         col_names = list(df.columns.names)
@@ -348,14 +345,21 @@ def _drop_likelihood_columns(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _drop_likelihood_from_header(header: DLCHeaderModel) -> DLCHeaderModel:
-    """Return a header model with likelihood removed from the coords level."""
-    cols = header.as_multiindex()
+    """
+    Return, "names": names})    Return a header model with likelihood removed from the coords level,
+    while preserving the original header arity (3-level SA vs 4-level MA)
+    and original header.names.
+    """
+    raw_cols = header.columns
+    names = list(getattr(header, "names", []) or [])
 
-    if isinstance(cols, pd.MultiIndex) and "coords" in cols.names:
-        mask = cols.get_level_values("coords").astype(str) != "likelihood"
-        cols = cols[mask]
+    if not raw_cols or "coords" not in names:
+        return header
 
-    return DLCHeaderModel(columns=cols)
+    coords_idx = names.index("coords")
+    filtered_cols = [col for col in raw_cols if len(col) > coords_idx and str(col[coords_idx]) != "likelihood"]
+
+    return header.model_copy(update={"columns": filtered_cols, "names": names})
 
 
 def _resolve_multianimalproject_for_write(


### PR DESCRIPTION
### Motivation

The latest plugin version attempted to preserve additional columns and merge GT/machine labels in a non-destructive way.
However, this is not entirely compatible with downstream DLC code which makes strong assumptions about df shape (see https://github.com/DeepLabCut/DeepLabCut/pull/3323).

The decision is being made here to drop it, for two reasons:

- It is closer to expectations of downstream code
- Machine labels remain on disk, and therefore the information is not truly lost.
  - Semantically, it considers that user-reviewed machine labels are GT, which matches the file structure
  - Keeping the information was not particularly useful downstream

Closes https://github.com/DeepLabCut/DeepLabCut/issues/3319

### Scope

Adds explicit filters to hdf writing, which will prevent machine label merges from adding likelihood columns. 
It will also filter out post-0.3.0.0 likelihood columns, porting them to the new format.
New tests check both of these points.