### PR TITLE
Update `ClickableLabel` in color scheme reference: don't use colored text

### DIFF
--- a/src/napari_deeplabcut/ui/labels_and_dropdown.py
+++ b/src/napari_deeplabcut/ui/labels_and_dropdown.py
@@ -170,19 +170,19 @@ class ClickableLabel(QLabel):
 
     def __init__(self, text: str = "", color: str = "turquoise", parent=None):
         super().__init__(text, parent)
-        self._default_style = self.styleSheet()
-        self.color = color
+        self._idle_style = "font-weight: normal;"
+        self._hover_style = "font-weight: bold;"
 
     def mousePressEvent(self, event):  # type: ignore[override]
         self.clicked.emit(self.text())
 
     def enterEvent(self, event):  # type: ignore[override]
         self.setCursor(QCursor(Qt.PointingHandCursor))
-        self.setStyleSheet(f"color: {self.color}")
+        self.setStyleSheet(self._hover_style)
 
     def leaveEvent(self, event):  # type: ignore[override]
         self.unsetCursor()
-        self.setStyleSheet(self._default_style)
+        self.setStyleSheet(self._idle_style)
 
 
 class LabelPair(QWidget):
@@ -225,8 +225,6 @@ class LabelPair(QWidget):
     def color(self, color: str) -> None:
         self._color = color
         self.color_label.setStyleSheet(f"background-color: {color};")
-        self.part_label.color = color
-        self.part_label.setStyleSheet(f"color: {color};")
 
     @property
     def part_name(self) -> str:

--- a/src/napari_deeplabcut/ui/labels_and_dropdown.py
+++ b/src/napari_deeplabcut/ui/labels_and_dropdown.py
@@ -170,19 +170,42 @@ class ClickableLabel(QLabel):
 
     def __init__(self, text: str = "", color: str = "turquoise", parent=None):
         super().__init__(text, parent)
-        self._idle_style = "font-weight: normal;"
-        self._hover_style = "font-weight: bold;"
+        self._color = color
+        self._hovered = False
+        self._pre_hover_style = ""
+
+    @property
+    def color(self) -> str:
+        return self._color
+
+    @color.setter
+    def color(self, color: str) -> None:
+        self._color = color
+        if self._hovered:
+            self._apply_hover_style()
+
+    def _apply_hover_style(self) -> None:
+        base = self._pre_hover_style.strip()
+        if base and not base.endswith(";"):
+            base += ";"
+        self.setStyleSheet(f"{base} color: {self._color};")
 
     def mousePressEvent(self, event):  # type: ignore[override]
         self.clicked.emit(self.text())
+        super().mousePressEvent(event)
 
     def enterEvent(self, event):  # type: ignore[override]
+        self._hovered = True
         self.setCursor(QCursor(Qt.PointingHandCursor))
-        self.setStyleSheet(self._hover_style)
+        self._pre_hover_style = self.styleSheet()
+        self._apply_hover_style()
+        super().enterEvent(event)
 
     def leaveEvent(self, event):  # type: ignore[override]
+        self._hovered = False
         self.unsetCursor()
-        self.setStyleSheet(self._idle_style)
+        self.setStyleSheet(self._pre_hover_style)
+        super().leaveEvent(event)
 
 
 class LabelPair(QWidget):
@@ -203,6 +226,16 @@ class LabelPair(QWidget):
         self.color_label.setStyleSheet(f"background-color: {color};")
         self._build()
 
+    @property
+    def color(self) -> str:
+        return self._color
+
+    @color.setter
+    def color(self, color: str) -> None:
+        self._color = color
+        self.color_label.setStyleSheet(f"background-color: {color};")
+        self.part_label.color = color
+
     @staticmethod
     def _format_label(label: QLabel, height: int | None = None, width: int | None = None) -> None:
         label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
@@ -216,15 +249,6 @@ class LabelPair(QWidget):
         layout.addWidget(self.color_label, alignment=Qt.AlignmentFlag.AlignLeft)
         layout.addWidget(self.part_label, alignment=Qt.AlignmentFlag.AlignLeft)
         self.setLayout(layout)
-
-    @property
-    def color(self) -> str:
-        return self._color
-
-    @color.setter
-    def color(self, color: str) -> None:
-        self._color = color
-        self.color_label.setStyleSheet(f"background-color: {color};")
 
     @property
     def part_name(self) -> str:

--- a/src/napari_deeplabcut/ui/labels_and_dropdown.py
+++ b/src/napari_deeplabcut/ui/labels_and_dropdown.py
@@ -225,6 +225,8 @@ class LabelPair(QWidget):
     def color(self, color: str) -> None:
         self._color = color
         self.color_label.setStyleSheet(f"background-color: {color};")
+        self.part_label.color = color
+        self.part_label.setStyleSheet(f"color: {color};")
 
     @property
     def part_name(self) -> str:


### PR DESCRIPTION
**Issue:** 
- The legend boxes in the color scheme reference are properly updated when changing colormap, but **not** the legend text. This causes misalignment between the text and boxes. 
- This causes even more complex behavior when adding extra bodyparts (e.g. the new bodypart becomes white, until hovering which updates it to another wrong color).
- I am assuming that the intention is to always return to uncolored text after unhovering the bodypart (which is probably more readable), but this is also not working. While it is easy to update the textcolor to match the box color (see  c20d15cc6aea3706fc4ca338cac9ca7fefd41eb3), it turns out that clearing the color with `self.setStyleSheet("")` (i.e. the default stylesheet) did not function as intended. 


**Fix:**
Instead of what I think was the intended behavior: color the legend text when hovering and return to default when leaving, I now changed it to making the text bold font when hovering and returning to normal font when leaving. It is an easy maybe not so fancy fix, but at least it is a bit more robust (on my system). 


Screenshot of the issue:
<img width="897" height="818" alt="Screenshot 2026-05-13 093224" src="https://github.com/user-attachments/assets/3c223dab-f160-4566-9651-c31d47a689cb" />

