### PR TITLE
Fix config segfault from layer removal and overhaul dialog

### DIFF
--- a/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
@@ -8,6 +8,7 @@ from napari.layers import Points
 
 from napari_deeplabcut.config.models import DLCHeaderModel
 from napari_deeplabcut.core.io import _read_hdf_any_key
+from napari_deeplabcut.core.layer_lifecycle.merge import PlaceholderConfigAction
 
 from .utils import (
     _make_project_config_and_frames_no_gt,
@@ -171,6 +172,7 @@ def test_single_animal_gt_then_config_merge_preserves_sa_format(
     gt_store = keypoint_controls.get_layer_store(gt_layer)
     assert gt_store is not None
 
+    keypoint_controls.resolve_placeholder_config_action = lambda **kwargs: PlaceholderConfigAction.APPLY_TO_CURRENT
     # Then open config -> should merge and settle back to one Points layer
     viewer.open(str(config_path), plugin="napari-deeplabcut")
     qtbot.waitUntil(

--- a/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_save_e2e.py
@@ -8,7 +8,7 @@ from napari.layers import Points
 
 from napari_deeplabcut.config.models import DLCHeaderModel
 from napari_deeplabcut.core.io import _read_hdf_any_key
-from napari_deeplabcut.core.layer_lifecycle.merge import PlaceholderConfigAction
+from napari_deeplabcut.core.layer_lifecycle import PlaceholderConfigAction
 
 from .utils import (
     _make_project_config_and_frames_no_gt,

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -66,10 +66,10 @@ from .core.config_sync import (
     save_point_size_to_config,
 )
 from .core.layer_lifecycle import (
+    PlaceholderConfigAction,
     PointsLayerSetupRequest,
     get_or_create_layer_manager,
 )
-from .core.layer_lifecycle.merge import PlaceholderConfigAction
 from .core.layer_versioning import mark_layer_presentation_changed
 from .core.layers import (
     PointsInteractionEvent,
@@ -473,10 +473,10 @@ class KeypointControls(ViewerSingletonWidget):
     def resolve_placeholder_config_action(
         self,
         *,
-        placeholder_layer,
-        managed_layers,
-        added_keypoints,
-        message,
+        placeholder_layer: Points,
+        managed_layers: tuple[Points, ...],
+        added_keypoints: tuple[str, ...],
+        message: str,
     ) -> PlaceholderConfigAction:
         """Ask the user how to handle insertion of a config placeholder layer."""
 

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -66,12 +66,10 @@ from .core.config_sync import (
     save_point_size_to_config,
 )
 from .core.layer_lifecycle import (
-    MergeDecisionRequest,
-    MergeDecisionResult,
-    MergeDisposition,
     PointsLayerSetupRequest,
     get_or_create_layer_manager,
 )
+from .core.layer_lifecycle.merge import PlaceholderConfigAction
 from .core.layer_versioning import mark_layer_presentation_changed
 from .core.layers import (
     PointsInteractionEvent,
@@ -132,7 +130,7 @@ class KeypointControls(ViewerSingletonWidget):
 
         # Layer lifecycle manager
         self.layer_manager = get_or_create_layer_manager(self.viewer)
-        self.layer_manager.set_merge_decision_provider(self)
+        self.layer_manager.set_placeholder_config_decision_provider(self)
         ## Hook up signals for layer lifecycle events as needed, e.g.:
         self.layer_manager.session_conflict_rejected.connect(self._on_session_conflict_detected)
         self.layer_manager.refresh_video_panel_requested.connect(self._refresh_video_panel_context)
@@ -472,23 +470,57 @@ class KeypointControls(ViewerSingletonWidget):
     # ######################## #
     # Layer setup core methods #
     # ######################## #
-    def resolve_merge(self, request: MergeDecisionRequest) -> MergeDecisionResult:
-        if not request.added_keypoints:
-            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+    def resolve_placeholder_config_action(
+        self,
+        *,
+        placeholder_layer,
+        managed_layers,
+        added_keypoints,
+        message,
+    ) -> PlaceholderConfigAction:
+        """Ask the user how to handle insertion of a config placeholder layer."""
 
-        shared = "Do you want to hide the existing keypoints and add the new ones as a separate layer?"
-        text = f"{request.message}\n\n{shared}" if request.message else shared
-        answer = QMessageBox.question(
-            self,
-            "",
-            text,
-            QMessageBox.Yes | QMessageBox.No,
+        # If there are no actually new keypoints, apply silently to current.
+        if not added_keypoints:
+            return PlaceholderConfigAction.APPLY_TO_CURRENT
+
+        title = "New keypoints found in config"
+
+        keypoints_text = ", ".join(added_keypoints)
+        intro = f"The loaded config adds new keypoint{'s' if len(added_keypoints) > 1 else ''}: {keypoints_text}."
+
+        body = (
+            "\n\nChoose how to handle this:\n\n"
+            "• Apply to current\n"
+            "  Update the current keypoints layer with the config,\n"
+            "  keep the current layer visible,\n"
+            "  and remove the temporary placeholder layer.\n\n"
+            "• Keep both\n"
+            "  Keep the current layer unchanged\n"
+            "  and keep the new layer as a separate layer.\n\n"
+            "• Cancel\n"
+            "  Discard the temporary placeholder layer and make no changes.\n"
         )
 
-        if answer == QMessageBox.Yes:
-            return MergeDecisionResult(disposition=MergeDisposition.HIDE_EXISTING)
+        msg = QMessageBox(self)
+        msg.setIcon(QMessageBox.Question)
+        msg.setWindowTitle(title)
+        msg.setText(intro + body)
 
-        return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+        apply_btn = msg.addButton("Apply to current", QMessageBox.AcceptRole)
+        keep_both_btn = msg.addButton("Keep both", QMessageBox.ActionRole)
+        msg.addButton("Cancel", QMessageBox.RejectRole)
+
+        msg.setDefaultButton(apply_btn)
+        msg.exec()
+
+        clicked = msg.clickedButton()
+        if clicked is apply_btn:
+            return PlaceholderConfigAction.APPLY_TO_CURRENT
+        if clicked is keep_both_btn:
+            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
+
+        return PlaceholderConfigAction.CANCEL
 
     def _on_points_layers_merged_requested(self, layers: tuple[Points, ...]) -> None:
         """Refresh widget-owned UI after manager merged placeholder config into managed layers."""
@@ -1214,7 +1246,7 @@ class KeypointControls(ViewerSingletonWidget):
             logger.warning("Layer manager audit on close reported issues:\n%s", report.issues)
 
         if self.layer_manager is not None:
-            self.layer_manager.set_merge_decision_provider(None)
+            self.layer_manager.set_placeholder_config_decision_provider(None)
 
     def on_active_layer_change(self, event) -> None:
         """Updates the GUI when the active layer changes

--- a/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/__init__.py
@@ -1,9 +1,7 @@
 from .manager import LayerLifecycleManager
 from .merge import (
-    MergeDecisionProvider,
-    MergeDecisionRequest,
-    MergeDecisionResult,
-    MergeDisposition,
+    PlaceholderConfigAction,
+    PlaceholderConfigDecisionProvider,
 )
 from .registry import ManagedPointsRuntime, PointsLayerSetupRequest, RuntimeRegistry
 from .spawn import get_layer_manager, get_or_create_layer_manager
@@ -12,11 +10,9 @@ __all__ = [
     "LayerLifecycleManager",
     "ManagedPointsRuntime",
     "RuntimeRegistry",
-    "MergeDecisionProvider",
+    "PlaceholderConfigAction",
     "PointsLayerSetupRequest",
-    "MergeDecisionRequest",
-    "MergeDecisionResult",
-    "MergeDisposition",
+    "PlaceholderConfigDecisionProvider",
     "get_layer_manager",
     "get_or_create_layer_manager",
 ]

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Iterator
+from enum import Enum
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
@@ -32,7 +33,7 @@ from ...tracking.core.data import TRACKING_LAYER_METADATA_KEY, is_tracking_resul
 from ...ui.base_widget._qt_timers import OwnedTimersMixin
 from ...ui.cropping import resolve_project_path_from_image_layer
 from ...utils.debug import log_timing
-from .merge import MergeDecisionProvider, MergeDecisionRequest, MergeDecisionResult, MergeDisposition
+from .merge import PlaceholderConfigAction, PlaceholderConfigDecisionProvider
 from .registry import (
     ClearedRegistryEntry,
     ManagedPointsRuntime,
@@ -48,6 +49,12 @@ if TYPE_CHECKING:
     from ..keypoints import KeypointStore
 
 logger = logging.getLogger(__name__)
+
+
+class PointsInsertResult(str, Enum):
+    ADDED = "added"
+    CONFIG_PLACEHOLDER_MERGED = "config_placeholder_merged"
+    SKIPPED = "skipped"
 
 
 class LayerLifecycleManager(QObject, OwnedTimersMixin):
@@ -66,6 +73,8 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
     - moving all logic out of the widget
     - changing merge/remap policies
     """
+
+    _PLACEHOLDER_LAYER_NAME = "__dlc_config_placeholder__"
 
     # UI signals for widget hooks
     refresh_video_panel_requested = Signal()
@@ -92,7 +101,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
         self.viewer = viewer
         self.registry: RuntimeRegistry[Any] = RuntimeRegistry()
-        self._merge_decision_provider: MergeDecisionProvider | None = None
+        self._placeholder_config_decision_provider: PlaceholderConfigDecisionProvider | None = None
 
         # Lifecycle-owned viewer/image context
         self._active_dlc_image_layer_id: int | None = None
@@ -143,8 +152,11 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
     def audit_registry(self) -> RegistryAuditReport:
         return self.registry.audit()
 
-    def set_merge_decision_provider(self, provider: MergeDecisionProvider | None) -> None:
-        self._merge_decision_provider = provider
+    def set_placeholder_config_decision_provider(
+        self,
+        provider: PlaceholderConfigDecisionProvider | None,
+    ) -> None:
+        self._placeholder_config_decision_provider = provider
 
     # ------------------------------------------------------------------ #
     # lifecycle-owned image/project context                              #
@@ -428,8 +440,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
         return data.size == 0
 
-    @staticmethod
-    def validate_header(layer: Points) -> bool:
+    def validate_header(self, layer: Points) -> bool:
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
         if hasattr(res, "errors") or getattr(res, "header", None) is None:
             # self.viewer.status = (
@@ -669,33 +680,38 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         except Exception:
             logger.debug("Failed to remove layer=%r", getattr(layer, "name", layer), exc_info=True)
 
-    @staticmethod
-    def _set_layer_visible(layer: Layer, visible: bool) -> None:
-        try:
-            layer.visible = visible
-        except Exception:
-            try:
-                layer.shown = visible
-            except Exception:
-                logger.debug("Failed to set visibility for layer=%r", getattr(layer, "name", layer), exc_info=True)
-
-    def _setup_points_layer(self, layer: Points, *, allow_merge: bool = True) -> None:
+    def _setup_points_layer(
+        self,
+        layer: Points,
+        *,
+        allow_merge: bool = True,
+    ) -> PointsInsertResult:
         """Lifecycle-owned setup for an inserted/adopted Points layer."""
         if not self.validate_header(layer):
-            return
+            return PointsInsertResult.SKIPPED
 
         if allow_merge:
-            consumed = self._maybe_merge_config_points_layer(layer)
-            if consumed:
+            action = self._maybe_merge_config_points_layer(layer)
+
+            if action is PlaceholderConfigAction.APPLY_TO_CURRENT:
                 logger.debug(
-                    "Consumed temporary config placeholder layer=%r during merge path",
+                    "Applied config placeholder layer=%r to current managed layer(s)",
                     getattr(layer, "name", layer),
                 )
-                return
+                return PointsInsertResult.CONFIG_PLACEHOLDER_MERGED
+
+            if action is PlaceholderConfigAction.CANCEL:
+                logger.debug(
+                    "Cancelled config placeholder handling for layer=%r",
+                    getattr(layer, "name", layer),
+                )
+                return PointsInsertResult.SKIPPED
+
+            # KEEP_AS_SEPARATE_LAYER means continue normal setup below.
 
         store = self._wire_points_layer(layer)
         if store is None:
-            return
+            return PointsInsertResult.SKIPPED
 
         logger.debug(
             "Setup points layer=%r allow_merge=%s metadata_keys=%s",
@@ -703,6 +719,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             allow_merge,
             sorted((layer.metadata or {}).keys()),
         )
+        return PointsInsertResult.ADDED
 
     def _schedule_post_remove_refresh(self) -> None:
         """Coalesce repeated UI refreshes during layer removal bursts."""
@@ -849,25 +866,27 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         except Exception:
             logger.exception("Failed to remap frame indices for layer %s", getattr(layer, "name", str(layer)))
 
-    def _maybe_merge_config_points_layer(self, layer: Points) -> bool:
-        """Merge a temporary config placeholder layer into existing managed layers.
+    def _maybe_merge_config_points_layer(self, layer: Points) -> PlaceholderConfigAction | None:
+        """Handle insertion of a temporary config placeholder layer.
 
         Returns
         -------
-        bool
-            True if the placeholder layer was consumed by the merge flow
-            (including explicit HIDE_NEW / CANCEL handling), else False.
+        PlaceholderConfigAction | None
+            - APPLY_TO_CURRENT: current managed layer(s) were updated
+            - KEEP_AS_SEPARATE_LAYER: do not merge, continue normal setup for the new layer
+            - CANCEL: discard placeholder and do not update anything
+            - None: not applicable / not a placeholder
         """
         if not self.is_config_placeholder_points_layer(layer):
-            return False
+            return None
 
         managed = list(self.iter_managed_points())
         if not managed:
-            return False
+            return None
 
         md = layer.metadata or {}
         logger.debug(
-            "Maybe merge config placeholder layer=%r project=%r managed_layers=%d",
+            "Maybe handle config placeholder layer=%r project=%r managed_layers=%d",
             getattr(layer, "name", layer),
             md.get("project"),
             len(managed),
@@ -877,74 +896,58 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         new_header = self.get_header_model_from_metadata(new_metadata)
         if new_header is None:
             logger.debug(
-                "Skipping config placeholder merge for layer=%r: missing/invalid header",
+                "Skipping config placeholder handling for layer=%r: missing/invalid header",
                 getattr(layer, "name", layer),
             )
-            return False
+            return None
 
         reference_layer, _reference_store = managed[0]
         reference_header = self.get_header_model_from_metadata(reference_layer.metadata or {})
         if reference_header is None:
             logger.debug(
-                "Skipping config placeholder merge for layer=%r: reference managed layer has no valid header",
+                "Skipping config placeholder handling for layer=%r: reference managed layer has no valid header",
                 getattr(layer, "name", layer),
             )
-            return False
+            return None
 
         current_keypoint_set = set(reference_header.bodyparts)
         new_keypoint_set = set(new_header.bodyparts)
         diff = tuple(sorted(new_keypoint_set.difference(current_keypoint_set)))
 
-        visible_existing_layer = None
-        for managed_layer, _store in managed:
-            if managed_layer is layer:
-                continue
-            try:
-                if getattr(managed_layer, "visible", True):
-                    visible_existing_layer = managed_layer
-                    break
-            except Exception:
-                visible_existing_layer = managed_layer
-                break
+        message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found from config." if diff else ""
 
-        message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found." if diff else ""
-
-        decision = self._resolve_merge_decision(
-            new_layer=layer,
-            existing_layers=tuple(ly for ly, _ in managed if ly is not layer),
+        action = self._resolve_placeholder_config_action(
+            placeholder_layer=layer,
+            managed_layers=tuple(ly for ly, _ in managed if ly is not layer),
             added_keypoints=diff,
             message=message,
         )
 
-        disposition = decision.disposition
-
-        # Optional visibility policy before merge
-        if disposition is MergeDisposition.HIDE_EXISTING and visible_existing_layer is not None:
-            self._set_layer_visible(visible_existing_layer, False)
+        if action is PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER:
             logger.debug(
-                "Config placeholder merge layer=%r hid_existing_layer=%r",
-                getattr(layer, "name", layer),
-                getattr(visible_existing_layer, "name", visible_existing_layer),
-            )
-
-        if disposition is MergeDisposition.HIDE_NEW:
-            self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
-            return True
-
-        if disposition is MergeDisposition.CANCEL:
-            # Conservative behavior: stop lifecycle setup and leave the placeholder
-            # layer untouched/unmanaged for now.
-            logger.debug(
-                "Config placeholder merge cancelled for layer=%r",
+                "Keeping config placeholder layer=%r as separate layer",
                 getattr(layer, "name", layer),
             )
-            return True
+            return action
 
+        if action is PlaceholderConfigAction.CANCEL:
+            logger.debug(
+                "Cancelling placeholder config insertion for layer=%r",
+                getattr(layer, "name", layer),
+            )
+            self._single_shot_owned(
+                300,
+                lambda ly=layer: self._remove_layer_if_present(ly),
+            )
+            return action
+
+        # APPLY_TO_CURRENT
         if diff:
             self.viewer.status = message
 
-        # Merge header into all managed layers.
         affected_layers: list[Points] = []
+
+        # Merge header into all managed layers.
         for managed_layer, store in managed:
             pts = read_points_meta(
                 managed_layer,
@@ -963,7 +966,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             store.layer = managed_layer
             affected_layers.append(managed_layer)
 
-        # Apply updated presentation metadata to existing managed layers.
+        # Apply presentation metadata to existing managed layers.
         for managed_layer, store in managed:
             managed_layer.metadata["config_colormap"] = new_metadata.get(
                 "config_colormap",
@@ -979,44 +982,43 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             mark_layer_presentation_changed(managed_layer)
             store.layer = managed_layer
 
-        # Ask UI consumers to refresh menus/colors based on updated managed layers.
-        self.points_layers_merged_requested.emit(tuple(affected_layers))
+        def _finalize_placeholder_apply(ly=layer, affected=tuple(affected_layers)):
+            self._remove_layer_if_present(ly)
+            self.points_layers_merged_requested.emit(affected)
+            self.refresh_layer_status_requested.emit()
 
-        # Remove the temporary placeholder layer explicitly by identity.
-        self._single_shot_owned(0, lambda ly=layer: self._remove_layer_if_present(ly))
+        self._single_shot_owned(300, _finalize_placeholder_apply)
+        return action
 
-        # General panel refreshes
-        self.refresh_layer_status_requested.emit()
-
-        return True
-
-    def _resolve_merge_decision(
+    def _resolve_placeholder_config_action(
         self,
         *,
-        new_layer: Any,
-        existing_layers: tuple[Any, ...],
+        placeholder_layer: Any,
+        managed_layers: tuple[Any, ...],
         added_keypoints: tuple[str, ...],
         message: str,
-    ) -> MergeDecisionResult:
-        provider = self._merge_decision_provider
+    ) -> PlaceholderConfigAction:
+        provider = self._placeholder_config_decision_provider
         if provider is None:
-            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
-
-        req = MergeDecisionRequest(
-            new_layer=new_layer,
-            existing_layers=existing_layers,
-            added_keypoints=added_keypoints,
-            message=message,
-        )
+            if not added_keypoints:
+                return PlaceholderConfigAction.APPLY_TO_CURRENT
+            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
 
         try:
-            result = provider.resolve_merge(req)
+            result = provider.resolve_placeholder_config_action(
+                placeholder_layer=placeholder_layer,
+                managed_layers=managed_layers,
+                added_keypoints=added_keypoints,
+                message=message,
+            )
         except Exception:
-            logger.debug("Merge decision provider failed; defaulting to KEEP_BOTH", exc_info=True)
-            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
-
-        if result is None:
-            return MergeDecisionResult(disposition=MergeDisposition.KEEP_BOTH)
+            logger.debug(
+                "Placeholder config decision provider failed; defaulting to KEEP_AS_SEPARATE_LAYER",
+                exc_info=True,
+            )
+            if not added_keypoints:
+                return PlaceholderConfigAction.APPLY_TO_CURRENT
+            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
 
         return result
 
@@ -1308,15 +1310,23 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         )
 
         should_remap = False
+        emit_insert_processed = True
 
         if isinstance(layer, Image):
             should_remap = self._maybe_accept_and_setup_image_layer(
                 layer,
                 getattr(event, "index", None),
             )
+
         elif isinstance(layer, Points):
-            self._setup_points_layer(layer, allow_merge=True)
-            should_remap = True
+            outcome = self._setup_points_layer(layer, allow_merge=True)
+            should_remap = outcome is PointsInsertResult.ADDED
+            emit_insert_processed = outcome is PointsInsertResult.ADDED
+
+            if outcome is PointsInsertResult.CONFIG_PLACEHOLDER_MERGED:
+                self.refresh_video_panel_requested.emit()
+                self.refresh_layer_status_requested.emit()
+                return
 
         if should_remap:
             for layer_ in self.viewer.layers:
@@ -1325,7 +1335,9 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
         self.refresh_video_panel_requested.emit()
         self.refresh_layer_status_requested.emit()
-        self.layer_insert_processed.emit(layer)
+
+        if emit_insert_processed:
+            self.layer_insert_processed.emit(layer)
 
     def on_remove(self, event: Any) -> None:
         layer = getattr(event, "value", None)

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -910,16 +910,28 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             )
             return None
 
-        current_keypoint_set = set(reference_header.bodyparts)
-        new_keypoint_set = set(new_header.bodyparts)
-        diff = tuple(sorted(new_keypoint_set.difference(current_keypoint_set)))
+        # current_keypoint_set = set(reference_header.bodyparts)
+        # new_keypoint_set = set(new_header.bodyparts)
+        # diff = tuple(sorted(new_keypoint_set.difference(current_keypoint_set)))
+        headers_equal = reference_header.model_dump() == new_header.model_dump()
+        current_kpt_set = set(reference_header.bodyparts)
+        new_kpt_set = set(new_header.bodyparts)
+        diff = tuple(sorted(new_kpt_set.difference(current_kpt_set)))
 
-        message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found from config." if diff else ""
+        # message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found from config." if diff else ""
+
+        if diff:
+            message = f"New keypoint{'s' if len(diff) > 1 else ''} {', '.join(diff)} found from config."
+        elif not headers_equal:
+            message = "Config keypoints differ from the current layer layout."
+        else:
+            message = ""
 
         action = self._resolve_placeholder_config_action(
             placeholder_layer=layer,
             managed_layers=tuple(ly for ly, _ in managed if ly is not layer),
             added_keypoints=diff,
+            headers_match=headers_equal,
             message=message,
         )
 
@@ -996,15 +1008,14 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         placeholder_layer: Any,
         managed_layers: tuple[Any, ...],
         added_keypoints: tuple[str, ...],
+        headers_match: bool,
         message: str,
     ) -> PlaceholderConfigAction:
 
         def _default_action() -> PlaceholderConfigAction:
-            return (
-                PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
-                if added_keypoints
-                else PlaceholderConfigAction.APPLY_TO_CURRENT
-            )
+            if headers_match:
+                return PlaceholderConfigAction.APPLY_TO_CURRENT
+            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
 
         provider = self._placeholder_config_decision_provider
         if provider is None:

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -76,8 +76,6 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
     - changing merge/remap policies
     """
 
-    _PLACEHOLDER_LAYER_NAME = "__dlc_config_placeholder__"
-
     # UI signals for widget hooks
     refresh_video_panel_requested = Signal()
     refresh_layer_status_requested = Signal()

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+LAYER_REMOVAL_DELAY_MS = 300
+
 
 class PointsInsertResult(str, Enum):
     ADDED = "added"
@@ -936,7 +938,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 getattr(layer, "name", layer),
             )
             self._single_shot_owned(
-                300,
+                LAYER_REMOVAL_DELAY_MS,
                 lambda ly=layer: self._remove_layer_if_present(ly),
             )
             return action
@@ -987,7 +989,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             self.points_layers_merged_requested.emit(affected)
             self.refresh_layer_status_requested.emit()
 
-        self._single_shot_owned(300, _finalize_placeholder_apply)
+        self._single_shot_owned(LAYER_REMOVAL_DELAY_MS, _finalize_placeholder_apply)
         return action
 
     def _resolve_placeholder_config_action(
@@ -998,11 +1000,17 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         added_keypoints: tuple[str, ...],
         message: str,
     ) -> PlaceholderConfigAction:
+
+        def _default_action() -> PlaceholderConfigAction:
+            return (
+                PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
+                if added_keypoints
+                else PlaceholderConfigAction.APPLY_TO_CURRENT
+            )
+
         provider = self._placeholder_config_decision_provider
         if provider is None:
-            if not added_keypoints:
-                return PlaceholderConfigAction.APPLY_TO_CURRENT
-            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
+            return _default_action()
 
         try:
             result = provider.resolve_placeholder_config_action(
@@ -1012,13 +1020,23 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
                 message=message,
             )
         except Exception:
+            mode = _default_action()
             logger.debug(
-                "Placeholder config decision provider failed; defaulting to KEEP_AS_SEPARATE_LAYER",
+                "Placeholder config decision provider failed; defaulting to %s",
+                mode,
                 exc_info=True,
             )
-            if not added_keypoints:
-                return PlaceholderConfigAction.APPLY_TO_CURRENT
-            return PlaceholderConfigAction.KEEP_AS_SEPARATE_LAYER
+            return mode
+
+        if not isinstance(result, PlaceholderConfigAction):
+            mode = _default_action()
+            logger.warning(
+                "Placeholder config decision provider returned invalid result %r; "
+                "expected PlaceholderConfigAction. Defaulting to %s",
+                result,
+                mode,
+            )
+            return mode
 
         return result
 

--- a/src/napari_deeplabcut/core/layer_lifecycle/merge.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/merge.py
@@ -1,30 +1,22 @@
 # src/napari_deeplabcut/core/layer_lifecycle/merge.py
 from __future__ import annotations
 
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Protocol
 
 
-class MergeDisposition(str, Enum):
-    KEEP_BOTH = "keep_both"
-    HIDE_EXISTING = "hide_existing"
-    HIDE_NEW = "hide_new"
+class PlaceholderConfigAction(str, Enum):
+    APPLY_TO_CURRENT = "apply_to_current"
+    KEEP_AS_SEPARATE_LAYER = "keep_as_separate_layer"
     CANCEL = "cancel"
 
 
-@dataclass(frozen=True, slots=True)
-class MergeDecisionRequest:
-    new_layer: Any
-    existing_layers: tuple[Any, ...]
-    added_keypoints: tuple[str, ...]
-    message: str
-
-
-@dataclass(frozen=True, slots=True)
-class MergeDecisionResult:
-    disposition: MergeDisposition
-
-
-class MergeDecisionProvider(Protocol):
-    def resolve_merge(self, request: MergeDecisionRequest) -> MergeDecisionResult: ...
+class PlaceholderConfigDecisionProvider(Protocol):
+    def resolve_placeholder_config_action(
+        self,
+        *,
+        placeholder_layer: Any,
+        managed_layers: tuple[Any, ...],
+        added_keypoints: tuple[str, ...],
+        message: str,
+    ) -> PlaceholderConfigAction: ...


### PR DESCRIPTION
### Scope

Refactors and clarifies the logic for handling "config placeholder" keypoint layers in the napari-deeplabcut plugin, replacing the previous generic "merge decision" system with a more focused system. 
The changes improves user prompts, internal naming, and the flow for merging or discarding placeholder layers, ensuring better user experience.

Also fixes a bug that would occur due to premature programmatic layer removal; the delay was increased which prevents event hooks from working on an already-deleted C++ object.

---

## Automated summary

**Refactor of config placeholder layer merge logic:**

- Replaces the generic `MergeDecision*` types and logic with new, dedicated `PlaceholderConfigAction` and `PlaceholderConfigDecisionProvider` types, focusing specifically on the config placeholder layer use case. (`src/napari_deeplabcut/core/layer_lifecycle/merge.py`, `src/napari_deeplabcut/core/layer_lifecycle/__init__.py`, `src/napari_deeplabcut/core/layer_lifecycle/manager.py`, [[1]](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L69-R72) [[2]](diffhunk://#diff-b056a9e5610d9d4dd5c503601275d1f4509bd4121ac992e1921a4bd778bb947cL3-R4) [[3]](diffhunk://#diff-b056a9e5610d9d4dd5c503601275d1f4509bd4121ac992e1921a4bd778bb947cL15-R15) [[4]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L35-R36)

- Refactors the widget UI logic to use the new `resolve_placeholder_config_action` method, providing a clearer and more informative dialog to the user when new keypoints are found in a config file, with explicit options: "Apply to current," "Keep both," or "Cancel." (`src/napari_deeplabcut/_widgets.py`, [src/napari_deeplabcut/_widgets.pyL475-R523](diffhunk://#diff-8829ceca77c22a5bc6d04552ff0d27cb02632b250c2227be4c63c810148b68e6L475-R523))

**Layer lifecycle manager updates:**

- Updates the `LayerLifecycleManager` to use the new placeholder config decision provider, and refactors internal methods to return explicit action enums instead of booleans, improving clarity and future extensibility. (`src/napari_deeplabcut/core/layer_lifecycle/manager.py`, [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R54-R59) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L672-R722) [[3]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L852-R889) [[4]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L880-R950)

- Refines the logic for handling placeholder layers: now, depending on user choice, the system can apply config changes to existing layers, keep the placeholder as a new layer, or cancel and remove the placeholder. (`src/napari_deeplabcut/core/layer_lifecycle/manager.py`, [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L672-R722) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L852-R889) [[3]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L880-R950)

**Test and import updates:**

- Updates tests and imports throughout the codebase to use the new placeholder config action types and methods, ensuring consistency and correctness. (`src/napari_deeplabcut/_tests/e2e/test_save_e2e.py`, [[1]](diffhunk://#diff-218bcad6da7b214e205458700f9af75944fbb67f849c3511f87f1149c0b1c2b6R11) [[2]](diffhunk://#diff-218bcad6da7b214e205458700f9af75944fbb67f849c3511f87f1149c0b1c2b6R175)

These changes collectively make the config placeholder layer handling more robust, explicit, and user-friendly.