### PR TITLE
Fix trajectory plot limits: adhere to requested window, also close for boundaries

### DIFF
--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -594,9 +594,10 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
         with mplstyle.context(self.mpl_style_sheet_path):
             half = self._window / 2.0
-
             start = max(state.frame_min, value - half)
+            start = min(start, state.frame_max - self._window)
             end = min(state.frame_max, value + half)
+            end = max(end, state.frame_min + self._window)
 
             if end <= start:
                 end = start + 1.0


### PR DESCRIPTION
The x and y limits were always set to the current value + half the window size, clipping to 0 and total frame length. This resulted in compression of the figure down to half the window size when close to the boundaries (0 or final frame). 

This PR fixes the x and y limits to show the window size, even when close to the 0 or the final frame. 