### PR TITLE
Improve video reader speed

### DIFF
--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -328,6 +328,32 @@ def test_video_read_single_frame(video_path):
     vid.close()
 
 
+def test_video_read_frame_out_of_bounds(video_path):
+    vid = Video(video_path)
+    with pytest.raises(IndexError):
+        vid.read_frame(5)
+    with pytest.raises(IndexError):
+        vid.read_frame(-1)
+    vid.close()
+
+
+def test_video_read_sequential_frames(video_path):
+    vid = Video(video_path)
+    f0 = vid.read_frame(0)
+    f1 = vid.read_frame(1)
+    assert f0.shape == f1.shape == (50, 50, 3)
+    vid.close()
+
+
+def test_video_read_frames_block(video_path):
+    vid = Video(video_path)
+    block = vid.read_frames(1, 4)  # frames 1, 2, 3
+    assert block.shape == (3, 50, 50, 3)
+    assert block.dtype == np.uint8
+    assert block[0].shape == (50, 50, 3)
+    vid.close()
+
+
 def test_video_reader_invalid_path():
     """Invalid path should raise ValueError."""
     with pytest.raises(ValueError):

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -319,7 +319,6 @@ def test_video_init_and_properties(video_path):
 def test_video_read_single_frame(video_path):
     """Check that we can read at least one frame correctly."""
     vid = Video(video_path)
-    # vid.set_to_frame(0)
     frame = vid.read_frame(0)
 
     assert isinstance(frame, np.ndarray)

--- a/src/napari_deeplabcut/_tests/test_reader.py
+++ b/src/napari_deeplabcut/_tests/test_reader.py
@@ -319,8 +319,8 @@ def test_video_init_and_properties(video_path):
 def test_video_read_single_frame(video_path):
     """Check that we can read at least one frame correctly."""
     vid = Video(video_path)
-    vid.set_to_frame(0)
-    frame = vid.read_frame()
+    # vid.set_to_frame(0)
+    frame = vid.read_frame(0)
 
     assert isinstance(frame, np.ndarray)
     assert frame.shape == (50, 50, 3)

--- a/src/napari_deeplabcut/_tests/tracking/test_data.py
+++ b/src/napari_deeplabcut/_tests/tracking/test_data.py
@@ -243,6 +243,75 @@ def test_expand_query_features_over_time_raises_for_visibility_shape_mismatch():
         )
 
 
+def test_expand_query_features_over_time_accepts_single_query_visibility_shape_k_t_regression():
+    seed = pd.DataFrame(
+        {
+            "label": ["nose"],
+            "id": ["animal-a"],
+        }
+    )
+    frame_ids = np.array([10, 11, 12], dtype=int)
+
+    # Regression case:
+    # T=3, K=1
+    # Expected canonical shape is (T, K) == (3, 1),
+    # but some model outputs can arrive as (K, T) == (1, 3).
+    visibility = np.array(
+        [[True, False, True]],
+        dtype=bool,
+    )  # shape (1, T)
+
+    out = expand_query_features_over_time(
+        seed,
+        frame_ids=frame_ids,
+        visibility=visibility,
+        tracker_name="Cotracker 3",
+    )
+
+    assert len(out) == 3
+    assert out["tracking_frame"].tolist() == [10, 11, 12]
+    assert out["tracking_visible"].tolist() == [True, False, True]
+
+
+def test_expand_query_features_over_time_accepts_visibility_shape_k_t_transposed():
+    seed = pd.DataFrame(
+        {
+            "label": ["nose", "tail"],
+            "id": ["animal-a", "animal-a"],
+        }
+    )
+    frame_ids = np.array([0, 1, 2], dtype=int)
+
+    # Shape is (K, T) == (2, 3), not canonical (T, K) == (3, 2).
+    visibility = np.array(
+        [
+            [True, False, True],  # nose over time
+            [False, True, False],  # tail over time
+        ],
+        dtype=bool,
+    )
+
+    out = expand_query_features_over_time(
+        seed,
+        frame_ids=frame_ids,
+        visibility=visibility,
+        tracker_name="Cotracker 3",
+    )
+
+    # Output is frame-major:
+    # frame 0: nose, tail
+    # frame 1: nose, tail
+    # frame 2: nose, tail
+    assert out["tracking_visible"].tolist() == [
+        True,
+        False,
+        False,
+        True,
+        True,
+        False,
+    ]
+
+
 # -----------------------------------------------------------------------------#
 # build_tracking_result_metadata
 # -----------------------------------------------------------------------------#

--- a/src/napari_deeplabcut/_tests/tracking/test_data.py
+++ b/src/napari_deeplabcut/_tests/tracking/test_data.py
@@ -312,6 +312,29 @@ def test_expand_query_features_over_time_accepts_visibility_shape_k_t_transposed
     ]
 
 
+def test_expand_query_features_over_time_accepts_single_frame_single_query_visibility_vector():
+    seed = pd.DataFrame(
+        {
+            "label": ["nose"],
+            "id": ["animal-a"],
+        }
+    )
+    frame_ids = np.array([42], dtype=int)
+
+    visibility = np.array([True], dtype=bool)  # shape (1,)
+
+    out = expand_query_features_over_time(
+        seed,
+        frame_ids=frame_ids,
+        visibility=visibility,
+        tracker_name="Cotracker 3",
+    )
+
+    assert len(out) == 1
+    assert out["tracking_frame"].tolist() == [42]
+    assert out["tracking_visible"].tolist() == [True]
+
+
 # -----------------------------------------------------------------------------#
 # build_tracking_result_metadata
 # -----------------------------------------------------------------------------#

--- a/src/napari_deeplabcut/config/settings.py
+++ b/src/napari_deeplabcut/config/settings.py
@@ -2,6 +2,8 @@ import os
 
 from qtpy.QtCore import QSettings
 
+from .utils import _get_int_env
+
 # Colormap settings
 DEFAULT_SINGLE_ANIMAL_CMAP = "rainbow"
 DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP = "Set3"
@@ -12,6 +14,14 @@ AUTO_OPEN_KEYPOINT_CONTROLS_KEY = "napari_deeplabcut/ui/auto_open_keypoint_contr
 
 # Tracking settings
 TRACKING_SHORTCUTS_ENABLED = os.environ.get("NAPARI_DLC_TRACKING_SHORTCUTS_ENABLED", "1") == "1"
+
+# Reader settings
+VIDEO_READER_MIN_CHUNK_SIZE = _get_int_env(
+    "NAPARI_DLC_VIDEO_READER_MIN_CHUNK_SIZE", 8, minimum=1
+)  # lower if you have very little RAM
+VIDEO_READER_CHUNK_TARGET_MB = _get_int_env(
+    "NAPARI_DLC_VIDEO_READER_CHUNK_TARGET_MB", 256, minimum=1
+)  # lower if you have very little RAM
 
 
 def get_overwrite_confirmation_enabled() -> bool:

--- a/src/napari_deeplabcut/config/utils.py
+++ b/src/napari_deeplabcut/config/utils.py
@@ -1,0 +1,17 @@
+import os
+
+
+def _get_int_env(name: str, default: int, *, minimum: int | None = None) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+
+    if minimum is not None:
+        value = max(value, minimum)
+
+    return value

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -64,6 +64,7 @@ from napari_deeplabcut.core.project_paths import (
     infer_dlc_project_from_points_meta,
 )
 from napari_deeplabcut.core.provenance import resolve_output_path_from_metadata
+from napari_deeplabcut.utils.debug import log_timing
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,11 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_SUFFIXES = {ext.lower() for ext in SUPPORTED_IMAGES}
 DLC_CANONICAL_H5_KEY = "df_with_missing"  # TODO use this key instead of str literal in all places
 FALLBACK_H5_KEYS = ["keypoints"]
+
+# -----------------------------------------------------------------------------
+#  Debug consts
+# -----------------------------------------------------------------------------
+LOG_VIDEO_READER_TIMING = False
 
 # =============================================================================
 # CONFIG (YAML)
@@ -855,19 +861,25 @@ def is_video(filename: str) -> bool:
 
 # Video reader using OpenCV
 class Video:
+    """
+    Better reader for viewer-like access:
+    - preserves decoder state
+    - small forward jumps decode forward instead of seeking
+    """
+
     def __init__(self, video_path):
         if not Path(video_path).is_file():
             raise ValueError(f'Video path "{video_path}" does not point to a file.')
 
-        self.path = video_path
-        self.stream = cv2.VideoCapture(video_path)
+        self.path = str(video_path)
+        self.stream = cv2.VideoCapture(self.path)
         if not self.stream.isOpened():
             raise OSError("Video could not be opened.")
 
         self._n_frames = int(self.stream.get(cv2.CAP_PROP_FRAME_COUNT))
         self._width = int(self.stream.get(cv2.CAP_PROP_FRAME_WIDTH))
         self._height = int(self.stream.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        self._frame = cv2.UMat(self._height, self._width, cv2.CV_8UC3)
+        self._pos = 0  # next frame to read
 
     def __len__(self):
         return self._n_frames
@@ -880,43 +892,108 @@ class Video:
     def height(self):
         return self._height
 
-    def set_to_frame(self, ind):
-        ind = min(ind, len(self) - 1)
-        ind += 1  # Unclear why this is needed at all
-        self.stream.set(cv2.CAP_PROP_POS_FRAMES, ind)
+    def seek(self, ind: int):
+        with log_timing(logger, f"Seeking video to frame {ind}", enable=LOG_VIDEO_READER_TIMING, threshold_ms=1):
+            ind = max(0, min(ind, len(self) - 1))
+            if ind != self._pos:
+                ok = self.stream.set(cv2.CAP_PROP_POS_FRAMES, ind)
+                if not ok:
+                    raise OSError(f"Failed to seek to frame {ind}")
+                self._pos = ind
 
-    def read_frame(self):
-        self.stream.retrieve(self._frame)
-        cv2.cvtColor(self._frame, cv2.COLOR_BGR2RGB, self._frame, 3)
-        return self._frame.get()
+    def read_next(self):
+        ok, frame = self.stream.read()
+        if not ok:
+            raise IndexError("Could not read frame")
+        self._pos += 1
+        return cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+    def grab_next(self):
+        ok = self.stream.grab()
+        if not ok:
+            raise IndexError("Could not grab frame")
+        self._pos += 1
+        return ok
+
+    def read_frame(self, ind: int):
+        with log_timing(logger, f"Reading video frame {ind}", enable=LOG_VIDEO_READER_TIMING, threshold_ms=2):
+            if ind == self._pos:
+                return self.read_next()
+
+            # Small forward jumps: decode forward instead of reseeking
+            if ind > self._pos and (ind - self._pos) <= 8:
+                while self._pos < ind:
+                    self.grab_next()
+                return self.read_next()
+
+            self.seek(ind)
+            return self.read_next()
+
+    def read_frames(self, start: int, stop: int):
+        start = max(0, start)
+        stop = min(stop, len(self))
+        if stop <= start:
+            return np.empty((0, self.height, self.width, 3), dtype=np.uint8)
+
+        self.seek(start)
+        out = np.empty((stop - start, self.height, self.width, 3), dtype=np.uint8)
+
+        for i in range(stop - start):
+            ok, frame = self.stream.read()
+            if not ok:
+                raise IndexError(f"Could not read frame {start + i}")
+            self._pos += 1
+            cv2.cvtColor(frame, cv2.COLOR_BGR2RGB, dst=out[i])
+
+        return out
 
     def close(self):
         self.stream.release()
 
 
-def read_video(filename: str, opencv: bool = True, *, dlc_meta: dict | None = None):
-    if opencv:
-        stream = Video(filename)
-        # NOTE construct output shape tuple in (H, W, C) order to match read_frame() data
-        shape = stream.height, stream.width, 3
+def _choose_chunk_size(height: int, width: int, target_mb: int = 256) -> int:
+    """Here we have to trade off between:
 
-        def _read_frame(ind):
-            stream.set_to_frame(ind)
-            return stream.read_frame()
+    - Larger chunks: better for local frame access (going frame-by-frame),
+    but when changing chunks, feels slower. So dragging fast is more expensive.
+    - Smaller chunks: feels more responsive when dragging fast,
+    but chunks recompute more often, so more latency when dragging slowly or frame-by-frame.
+    """
+    bytes_per_frame = height * width * 3
+    target_bytes = target_mb * 1024 * 1024
+    chunk = target_bytes // bytes_per_frame
+    return int(min(max(chunk, 8), 32))
 
-        lazy_reader = delayed(_read_frame)
-    else:  # pragma: no cover
-        from pims import PyAVReaderIndexed
 
-        try:
-            stream = PyAVReaderIndexed(filename)
-        except ImportError:
-            raise ImportError("`pip install av` to use the PyAV video reader.") from None
+def read_video(filename: str, *, dlc_meta: dict | None = None, chunk_size: int | None = None):
+    probe = Video(filename)
+    n_frames = len(probe)
+    shape = (probe.height, probe.width, 3)
+    if chunk_size is None:
+        chunk_size = _choose_chunk_size(probe.height, probe.width)
+        logger.debug("Auto-chosen chunk size for video %s: %d frames (target ~256MB)", filename, chunk_size)
+    probe.close()
 
-        shape = stream.frame_shape
-        lazy_reader = delayed(stream.get_frame)
+    @delayed
+    def _read_block(start: int, stop: int):
+        with log_timing(logger, f"Reading video block {start}-{stop}", enable=LOG_VIDEO_READER_TIMING, threshold_ms=5):
+            vid = Video(filename)
+            try:
+                return vid.read_frames(start, stop)
+            finally:
+                vid.close()
 
-    movie = da.stack([da.from_delayed(lazy_reader(i), shape=shape, dtype=np.uint8) for i in range(len(stream))])
+    blocks = []
+    for start in range(0, n_frames, chunk_size):
+        stop = min(start + chunk_size, n_frames)
+        block = da.from_delayed(
+            _read_block(start, stop),
+            shape=(stop - start, *shape),
+            dtype=np.uint8,
+        )
+        blocks.append(block)
+
+    movie = da.concatenate(blocks, axis=0)
     elems = list(Path(filename).parts)
     elems[-2] = "labeled-data"
     elems[-1] = Path(elems[-1]).stem  # + Path(filename).suffix

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -15,6 +15,8 @@ is just a translation of already-valid objects to disk. This would also make
 validation more consistent across reads and writes.
 Config I/O is an especially good candidate for this, the logic is a bit spread right now
 (here, config_sync.py, and the sidecar JSON)
+
+Also consider breaking this down into video/csv/config modules.
 """
 # src/napari_deeplabcut/core/io.py
 
@@ -916,6 +918,9 @@ class Video:
         return ok
 
     def read_frame(self, ind: int):
+        if ind < 0 or ind >= len(self):
+            raise IndexError(f"Frame index {ind} out of bounds for video with {len(self)} frames.")
+
         with log_timing(logger, f"Reading video frame {ind}", enable=LOG_VIDEO_READER_TIMING, threshold_ms=2):
             if ind == self._pos:
                 return self.read_next()

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -1000,7 +1000,12 @@ def read_video(filename: str, *, dlc_meta: dict | None = None, chunk_size: int |
 
         if chunk_size is None:
             chunk_size = _choose_chunk_size(height, width)
-            logger.debug("Auto-chosen chunk size for video %s: %d frames (target ~256MB)", filename, chunk_size)
+            logger.debug(
+                "Auto-chosen chunk size for video %s: %d frames (target ~%sMB)",
+                filename,
+                chunk_size,
+                VIDEO_READER_CHUNK_TARGET_MB,
+            )
         elif chunk_size <= 0:
             raise ValueError(f"Chunk size must be a positive integer, got {chunk_size}.")
     finally:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -45,7 +45,11 @@ from pydantic import ValidationError
 
 from napari_deeplabcut import misc
 from napari_deeplabcut.config.models import AnnotationKind, DLCHeaderModel, PointsMetadata
-from napari_deeplabcut.config.settings import DEFAULT_SINGLE_ANIMAL_CMAP
+from napari_deeplabcut.config.settings import (
+    DEFAULT_SINGLE_ANIMAL_CMAP,
+    VIDEO_READER_CHUNK_TARGET_MB,
+    VIDEO_READER_MIN_CHUNK_SIZE,
+)
 from napari_deeplabcut.config.supported_files import SUPPORTED_IMAGES, SUPPORTED_VIDEOS
 from napari_deeplabcut.core import schemas as dlc_schemas
 from napari_deeplabcut.core.dataframes import (
@@ -952,7 +956,13 @@ class Video:
         self.stream.release()
 
 
-def _choose_chunk_size(height: int, width: int, target_mb: int = 256) -> int:
+def _choose_chunk_size(
+    height: int,
+    width: int,
+    target_mb: int = VIDEO_READER_CHUNK_TARGET_MB,
+    min_chunk_size: int = VIDEO_READER_MIN_CHUNK_SIZE,
+    max_chunk_size: int = 32,
+) -> int:
     """Here we have to trade off between:
 
     - Larger chunks: better for local frame access (going frame-by-frame),
@@ -961,11 +971,17 @@ def _choose_chunk_size(height: int, width: int, target_mb: int = 256) -> int:
     but chunks recompute more often, so more latency when dragging slowly or frame-by-frame.
     """
     if height <= 0 or width <= 0:
-        raise ValueError("Invalid video dimensions for chunk size calculation.")
+        raise ValueError(f"Invalid video dimensions for chunk size calculation: height={height}, width={width}.")
+
+    target_mb = max(1, int(target_mb))
+    min_chunk_size = max(1, int(min_chunk_size))
+    max_chunk_size = max(min_chunk_size, int(max_chunk_size))
+
     bytes_per_frame = height * width * 3
     target_bytes = target_mb * 1024 * 1024
     chunk = target_bytes // bytes_per_frame
-    return int(min(max(chunk, 8), 32))
+
+    return int(min(max(chunk, min_chunk_size), max_chunk_size))
 
 
 def read_video(filename: str, *, dlc_meta: dict | None = None, chunk_size: int | None = None):

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -5,7 +5,7 @@ Includes:
 - Config file reading/writing
 - HDF reading with provenance attachment
 - Lazy image reading with Dask support
-- Video reading with OpenCV and optional PyAV fallback
+- Video reading with OpenCV and dask-backed block loader
 - Superkeypoints diagram and JSON loading
 
 NOTE: write_hdf could use some refactoring to split responsibilities more cleanly
@@ -853,7 +853,7 @@ def read_images(
 
 
 # =============================================================================
-# VIDEO (OpenCV; optional PyAV fallback)
+# VIDEO (OpenCV)
 # =============================================================================
 
 
@@ -944,11 +944,7 @@ class Video:
         out = np.empty((stop - start, self.height, self.width, 3), dtype=np.uint8)
 
         for i in range(stop - start):
-            ok, frame = self.stream.read()
-            if not ok:
-                raise IndexError(f"Could not read frame {start + i}")
-            self._pos += 1
-            cv2.cvtColor(frame, cv2.COLOR_BGR2RGB, dst=out[i])
+            out[i] = self.read_next()
 
         return out
 
@@ -964,6 +960,8 @@ def _choose_chunk_size(height: int, width: int, target_mb: int = 256) -> int:
     - Smaller chunks: feels more responsive when dragging fast,
     but chunks recompute more often, so more latency when dragging slowly or frame-by-frame.
     """
+    if height <= 0 or width <= 0:
+        raise ValueError("Invalid video dimensions for chunk size calculation.")
     bytes_per_frame = height * width * 3
     target_bytes = target_mb * 1024 * 1024
     chunk = target_bytes // bytes_per_frame
@@ -972,12 +970,25 @@ def _choose_chunk_size(height: int, width: int, target_mb: int = 256) -> int:
 
 def read_video(filename: str, *, dlc_meta: dict | None = None, chunk_size: int | None = None):
     probe = Video(filename)
-    n_frames = len(probe)
-    shape = (probe.height, probe.width, 3)
-    if chunk_size is None:
-        chunk_size = _choose_chunk_size(probe.height, probe.width)
-        logger.debug("Auto-chosen chunk size for video %s: %d frames (target ~256MB)", filename, chunk_size)
-    probe.close()
+    try:
+        n_frames = len(probe)
+        height = probe.height
+        width = probe.width
+        shape = (height, width, 3)
+
+        if n_frames <= 0:
+            raise OSError(f"Video {filename} contains no frames or could not be read.")
+
+        if height <= 0 or width <= 0:
+            raise OSError(f"Video {filename} has invalid dimensions ({width}x{height}).")
+
+        if chunk_size is None:
+            chunk_size = _choose_chunk_size(height, width)
+            logger.debug("Auto-chosen chunk size for video %s: %d frames (target ~256MB)", filename, chunk_size)
+        elif chunk_size <= 0:
+            raise ValueError(f"Chunk size must be a positive integer, got {chunk_size}.")
+    finally:
+        probe.close()
 
     @delayed
     def _read_block(start: int, stop: int):

--- a/src/napari_deeplabcut/tracking/core/data.py
+++ b/src/napari_deeplabcut/tracking/core/data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -9,6 +10,8 @@ import pandas as pd
 
 TRACKING_LAYER_METADATA_KEY = "ndlc_tracking"
 TRACKING_SCHEMA_VERSION = 1
+
+logger = logging.getLogger(__name__)
 
 
 # ----- Data schemas -----
@@ -138,8 +141,11 @@ def expand_query_features_over_time(
         elif vis.shape == (1, T, K, 1):
             vis = vis[0, ..., 0]
         elif vis.shape == (K, T):
-            # Transposed time/query layout.
-            vis = vis.T
+            if K == T:
+                raise ValueError("Ambiguous visibility shape (K, T) with K == T. Please check model output shapes.")
+            else:
+                # Transposed time/query layout.
+                vis = vis.T
         elif vis.shape == (T,) and K == 1:
             # Single-query vector over time.
             vis = vis[:, None]

--- a/src/napari_deeplabcut/tracking/core/data.py
+++ b/src/napari_deeplabcut/tracking/core/data.py
@@ -127,28 +127,24 @@ def expand_query_features_over_time(
 
     if visibility is not None:
         vis = np.asarray(visibility)
-
-        # Remove known batch dimension
-        if vis.ndim >= 1 and vis.shape[0] == 1:
-            vis = np.squeeze(vis, axis=0)
-
-        # Remove known trailing singleton channel
-        if vis.ndim >= 1 and vis.shape[-1] == 1:
-            vis = np.squeeze(vis, axis=-1)
-
         expected = (T, K)
 
-        if vis.shape == (K, T):
+        if vis.shape == expected:
+            pass
+        elif vis.shape == (T, K, 1):
+            vis = vis[..., 0]
+        elif vis.shape == (1, T, K):
+            vis = vis[0]
+        elif vis.shape == (1, T, K, 1):
+            vis = vis[0, ..., 0]
+        elif vis.shape == (K, T):
+            # Transposed time/query layout.
             vis = vis.T
-
-        elif vis.shape == (T,):
-            if K != 1:
-                raise ValueError(...)
+        elif vis.shape == (T,) and K == 1:
+            # Single-query vector over time.
             vis = vis[:, None]
-
-        elif vis.shape == (K,):
-            if T != 1:
-                raise ValueError(...)
+        elif vis.shape == (K,) and T == 1:
+            # Single-frame vector over queries.
             vis = vis[None, :]
 
         if vis.shape != expected:

--- a/src/napari_deeplabcut/tracking/core/data.py
+++ b/src/napari_deeplabcut/tracking/core/data.py
@@ -127,12 +127,30 @@ def expand_query_features_over_time(
 
     if visibility is not None:
         vis = np.asarray(visibility)
-        if vis.ndim == 3 and vis.shape[-1] == 1:
-            vis = vis[..., 0]
-        elif vis.ndim == 3 and vis.shape[0] == 1:
-            vis = vis.squeeze(0)
+
+        # Remove known batch dimension
+        if vis.ndim >= 1 and vis.shape[0] == 1:
+            vis = np.squeeze(vis, axis=0)
+
+        # Remove known trailing singleton channel
+        if vis.ndim >= 1 and vis.shape[-1] == 1:
+            vis = np.squeeze(vis, axis=-1)
 
         expected = (T, K)
+
+        if vis.shape == (K, T):
+            vis = vis.T
+
+        elif vis.shape == (T,):
+            if K != 1:
+                raise ValueError(...)
+            vis = vis[:, None]
+
+        elif vis.shape == (K,):
+            if T != 1:
+                raise ValueError(...)
+            vis = vis[None, :]
+
         if vis.shape != expected:
             raise ValueError(f"Visibility shape mismatch. Expected {expected}, got {vis.shape}.")
 

--- a/src/napari_deeplabcut/tracking/core/data.py
+++ b/src/napari_deeplabcut/tracking/core/data.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
@@ -10,8 +9,6 @@ import pandas as pd
 
 TRACKING_LAYER_METADATA_KEY = "ndlc_tracking"
 TRACKING_SCHEMA_VERSION = 1
-
-logger = logging.getLogger(__name__)
 
 
 # ----- Data schemas -----
@@ -113,7 +110,7 @@ def expand_query_features_over_time(
     frame_ids
         Actual frame indices corresponding to the model output time axis.
     visibility
-        Optional visibility array of shape (T, K) or (T, K, 1).
+        Optional visibility array of shape, ideally (T, K) or (T, K, 1).
     tracker_name
         Human-readable tracker name, e.g. "Cotracker 3".
     """

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -28,6 +28,7 @@ def log_timing(
     *,
     level: int = logging.DEBUG,
     threshold_ms: float | None = None,
+    enable: bool = NAPARI_DLC_LOG_TIMING,
 ):
     """Lightweight scoped timer for debug instrumentation.
 
@@ -35,7 +36,7 @@ def log_timing(
     Logs only if logger is enabled for the requested level.
     Optionally suppresses tiny timings below threshold_ms.
     """
-    if not logger.isEnabledFor(level) or not NAPARI_DLC_LOG_TIMING:
+    if not logger.isEnabledFor(level) or not enable:
         yield
         return
 

--- a/src/napari_deeplabcut/utils/debug.py
+++ b/src/napari_deeplabcut/utils/debug.py
@@ -28,7 +28,7 @@ def log_timing(
     *,
     level: int = logging.DEBUG,
     threshold_ms: float | None = None,
-    enable: bool = NAPARI_DLC_LOG_TIMING,
+    enable: bool | None = None,
 ):
     """Lightweight scoped timer for debug instrumentation.
 
@@ -36,6 +36,9 @@ def log_timing(
     Logs only if logger is enabled for the requested level.
     Optionally suppresses tiny timings below threshold_ms.
     """
+    if enable is None:
+        enable = NAPARI_DLC_LOG_TIMING
+
     if not logger.isEnabledFor(level) or not enable:
         yield
         return


### PR DESCRIPTION

### Scope

This pull request introduces significant improvements to the video reading logic

- Major refactor of the `Video` class and `read_video` function for faster video frame reads
  - Greatly improves both local frame seeking and fast slider updates
  - Dask chunk size is now memory-aware, and better suited for fast slider drags by default
- Fixes in visibility array shapes in tracking for query shape 1
- New regression tests to ensure correct behavior with transposed and singleton visibility shapes.

### Benchmarking

The changes bring improvements in two separate regards:

- Local seeking is now much faster as we avoid paying the decode cost on every frame read (even if they are within the same GOP)
- The Dask implementation used to create one delayed task per frame, which is suboptimal compared to proper chunking

The benchmark was done with an expensive-to-decode, 1000 frames GOP video `(keyint=1000:min-keyint=1000:scenecut=0:bframes=8:ref=4`, using `testrc2`), for 3 repeats (random: 50 frames, local: 5 windows of 10 frames).

95% CIs are shown (note that trials may not be fully independent due to caching)
<img width="1189" height="490" alt="image" src="https://github.com/user-attachments/assets/9a672ba9-f508-499d-9dc2-ce966518b5f3" />



### Automated summary

**Video reading improvements:**
- Refactored the `Video` class to better preserve decoder state, support efficient forward jumps, and provide new methods (`seek`, `read_next`, `grab_next`, `read_frame`, `read_frames`) for robust and performant frame access. This includes logic to avoid unnecessary seeks and optimize small forward jumps. (`src/napari_deeplabcut/core/io.py` [[1]](diffhunk://#diff-be6c6f73ee5c48122719f58a13394e1529cc5c4c7459e8bb7ff3977bb75c616bR864-R882) [[2]](diffhunk://#diff-be6c6f73ee5c48122719f58a13394e1529cc5c4c7459e8bb7ff3977bb75c616bL883-R996)
- Rewrote the `read_video` function to read video data in blocks (chunks) for improved efficiency, with automatic chunk size selection based on frame size. The new implementation now correctly uses Dask for block-wise reading and includes timing instrumentation for debugging. (`src/napari_deeplabcut/core/io.py` [src/napari_deeplabcut/core/io.pyL883-R996](diffhunk://#diff-be6c6f73ee5c48122719f58a13394e1529cc5c4c7459e8bb7ff3977bb75c616bL883-R996))

**Tracking visibility shape handling fixes:**
- Updated `expand_query_features_over_time` to robustly handle various visibility array shapes, including (K, T), (T,), (K,), and singleton batch/channel dimensions. This ensures compatibility with different model outputs and prevents shape mismatches. (`src/napari_deeplabcut/tracking/core/data.py` [src/napari_deeplabcut/tracking/core/data.pyL130-R153](diffhunk://#diff-026a366b7359b9b649a1e93ac27d32b9968225ec7e3e68766819f18d73f27580L130-R153))

**Testing and regression coverage:**
- Added new regression tests to verify that `expand_query_features_over_time` accepts both singleton and transposed visibility shapes, ensuring correct behavior for edge cases and preventing regressions. (`src/napari_deeplabcut/_tests/tracking/test_data.py` [src/napari_deeplabcut/_tests/tracking/test_data.pyR246-R314](diffhunk://#diff-5b94965e62e5cc5d6adf6a85ddbdd39f11e88ceeecafd52a71b4311c5f61b3f9R246-R314))