### PR TITLE
Add centralized layer display settings, make machine labels visually distinct

### DIFF
--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_display_settings.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_display_settings.py
@@ -1,0 +1,101 @@
+# src/napari_deeplabcut/_tests/core/layer_manager/test_display_settings.py
+from __future__ import annotations
+
+import numpy as np
+from napari.layers import Points
+
+from napari_deeplabcut.core.layer_lifecycle.display_settings import (
+    MACHINE_LABELS_POINTS_DISPLAY,
+    POINTS_DISPLAY_SETTINGS_BY_ROLE,
+    TRACKING_RESULT_POINTS_DISPLAY,
+    PointsDisplaySettings,
+    PointsDisplaySource,
+    apply_points_display_role,
+)
+
+
+def make_points_layer(name: str = "pts") -> Points:
+    """Non-empty layer so per-point symbol arrays can be inspected."""
+    layer = Points(np.array([[0, 1, 2]], dtype=float))
+    layer.name = name
+    return layer
+
+
+def _symbol_token(value) -> str:
+    """Best-effort normalize napari Symbol/string values across versions."""
+    try:
+        value = value.value
+    except Exception:
+        pass
+
+    text = str(value).strip().lower()
+
+    # Defensive for enum repr-like strings, e.g. "Symbol.CROSS"
+    if "." in text:
+        text = text.rsplit(".", 1)[-1]
+
+    return text
+
+
+def _layer_symbol_tokens(layer: Points) -> tuple[str, ...]:
+    """Return normalized symbol tokens currently stored on a Points layer."""
+    symbols = np.asarray(layer.symbol, dtype=object).ravel()
+    return tuple(_symbol_token(symbol) for symbol in symbols)
+
+
+def _assert_configured_display_settings_applied(
+    layer: Points,
+    settings: PointsDisplaySettings,
+) -> None:
+    """Assert only the display fields that are explicitly configured."""
+    if settings.symbol is not None:
+        assert _symbol_token(settings.symbol) in _layer_symbol_tokens(layer)
+
+    if settings.opacity is not None:
+        assert layer.opacity == settings.opacity
+
+    if settings.border_width is not None:
+        assert getattr(layer, "border_width", None) == settings.border_width
+
+    if settings.border_color is not None:
+        # napari may normalize color strings to arrays internally, so avoid
+        # over-specifying exact representation unless your pinned napari version
+        # is stable enough. Keeping this light prevents cross-version brittleness.
+        assert getattr(layer, "border_color", None) is not None
+
+
+def test_display_settings_registry_matches_named_presets():
+    assert POINTS_DISPLAY_SETTINGS_BY_ROLE[PointsDisplaySource.MACHINE_LABELS] is MACHINE_LABELS_POINTS_DISPLAY
+    assert POINTS_DISPLAY_SETTINGS_BY_ROLE[PointsDisplaySource.TRACKING_RESULT] is TRACKING_RESULT_POINTS_DISPLAY
+
+
+def test_apply_machine_label_display_role_uses_configured_presentation(qtbot):
+    layer = make_points_layer("machine")
+
+    apply_points_display_role(layer, PointsDisplaySource.MACHINE_LABELS)
+
+    _assert_configured_display_settings_applied(
+        layer,
+        MACHINE_LABELS_POINTS_DISPLAY,
+    )
+
+
+def test_apply_tracking_display_role_uses_configured_presentation_and_copies_source_size(qtbot):
+    source = make_points_layer("source")
+    target = make_points_layer("tracking")
+
+    source.size = 17
+
+    apply_points_display_role(
+        target,
+        PointsDisplaySource.TRACKING_RESULT,
+        source=source,
+    )
+
+    _assert_configured_display_settings_applied(
+        target,
+        TRACKING_RESULT_POINTS_DISPLAY,
+    )
+
+    if TRACKING_RESULT_POINTS_DISPLAY.copy_size_from_source:
+        assert np.all(np.asarray(target.size) == 17)

--- a/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
+++ b/src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/_tests/core/layer_manager/test_manager.py
 from __future__ import annotations
 
 import gc
@@ -7,7 +8,13 @@ import numpy as np
 import pytest
 from napari.layers import Image, Points
 
+from napari_deeplabcut.config.models import AnnotationKind
 from napari_deeplabcut.core.layer_lifecycle import LayerLifecycleManager
+from napari_deeplabcut.core.layer_lifecycle.display_settings import (
+    MACHINE_LABELS_POINTS_DISPLAY,
+    PointsDisplaySource,
+)
+from napari_deeplabcut.tracking.core.data import build_tracking_result_metadata
 
 
 def mark_as_dlc_session_image(layer, *, role="image"):
@@ -166,6 +173,12 @@ def make_image(name="img"):
 
 def make_points(name="pts"):
     layer = Points(np.zeros((0, 3)))
+    layer.name = name
+    return layer
+
+
+def make_nonempty_points(name="pts"):
+    layer = Points(np.array([[0, 1, 2]], dtype=float))
     layer.name = name
     return layer
 
@@ -436,3 +449,196 @@ def test_manager_resolve_inserted_layer_prefers_value_then_index_then_source(qtb
 
     assert layer is pts
     assert layer.name == expected_name
+
+
+# ----------------------------------------------------------------------------
+# Display settings logic tests
+# ---------------------------------------------------------------------------
+
+
+def make_machine_points(name="machine", *, nonempty: bool = False):
+    layer = make_nonempty_points(name) if nonempty else make_points(name)
+    layer.metadata = {
+        "io": {
+            "kind": AnnotationKind.MACHINE,
+        }
+    }
+    return layer
+
+
+def make_machine_points_serialized_kind(name="machine", *, nonempty: bool = False):
+    layer = make_nonempty_points(name) if nonempty else make_points(name)
+    layer.metadata = {
+        "io": {
+            "kind": "machine",
+        }
+    }
+    return layer
+
+
+def make_tracking_points(name="tracking", *, nonempty: bool = False):
+    layer = make_nonempty_points(name) if nonempty else make_points(name)
+    layer.metadata = build_tracking_result_metadata(
+        {},
+        tracker_name="test-tracker",
+        source_layer_name="source",
+        query_frame=0,
+    )
+    return layer
+
+
+def test_manager_detects_machine_label_layer_from_annotation_kind(qtbot):
+    viewer = DummyViewer()
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    layer = make_machine_points()
+
+    assert LayerLifecycleManager.is_machine_label_layer(layer) is True
+    assert manager.points_display_role(layer) is PointsDisplaySource.MACHINE_LABELS
+
+
+def test_manager_detects_machine_label_layer_from_serialized_kind(qtbot):
+    viewer = DummyViewer()
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    layer = make_machine_points_serialized_kind()
+
+    assert LayerLifecycleManager.is_machine_label_layer(layer) is True
+    assert manager.points_display_role(layer) is PointsDisplaySource.MACHINE_LABELS
+
+
+def test_manager_does_not_treat_regular_points_as_machine_labels(qtbot):
+    viewer = DummyViewer()
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    layer = make_points("regular")
+    layer.metadata = {
+        "io": {
+            "kind": AnnotationKind.GT,
+        }
+    }
+
+    assert LayerLifecycleManager.is_machine_label_layer(layer) is False
+    assert manager.points_display_role(layer) is None
+
+
+def test_manager_tracking_display_role_takes_precedence_over_machine_kind(qtbot):
+    viewer = DummyViewer()
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    layer = make_tracking_points()
+    layer.metadata["io"] = {"kind": AnnotationKind.MACHINE}
+
+    assert LayerLifecycleManager.is_tracking_result_layer(layer) is True
+    assert LayerLifecycleManager.is_machine_label_layer(layer) is False
+    assert manager.points_display_role(layer) is PointsDisplaySource.TRACKING_RESULT
+
+
+def test_setup_points_layer_applies_display_settings(
+    qtbot,
+    fake_store,
+    monkeypatch,
+):
+    pts = make_machine_points("machine")
+    viewer = DummyViewer([pts])
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    monkeypatch.setattr(manager, "validate_header", lambda layer: True)
+
+    applied = []
+
+    def fake_apply(layer, *, source=None):
+        applied.append((layer, source))
+        return layer
+
+    monkeypatch.setattr(manager, "apply_points_display_settings", fake_apply)
+
+    result = manager._setup_points_layer(pts, allow_merge=False)
+
+    assert result is not None
+    assert manager.is_managed(pts) is True
+    assert applied == [(pts, None)]
+
+
+def test_manager_apply_points_display_settings_delegates_machine_role(
+    qtbot,
+    monkeypatch,
+):
+    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
+
+    pts = make_machine_points("machine")
+    viewer = DummyViewer([pts])
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    calls = []
+
+    def fake_apply_points_display_role(layer, role, *, source=None):
+        calls.append((layer, role, source))
+        return layer
+
+    monkeypatch.setattr(
+        manager_module,
+        "apply_points_display_role",
+        fake_apply_points_display_role,
+    )
+
+    out = manager.apply_points_display_settings(pts)
+
+    assert out is pts
+    assert calls == [(pts, PointsDisplaySource.MACHINE_LABELS, None)]
+
+
+def test_manager_apply_points_display_settings_delegates_tracking_role_with_source(
+    qtbot,
+    monkeypatch,
+):
+    from napari_deeplabcut.core.layer_lifecycle import manager as manager_module
+
+    source = make_points("source")
+    tracking = make_tracking_points("tracking")
+
+    viewer = DummyViewer([source, tracking])
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    calls = []
+
+    def fake_apply_points_display_role(layer, role, *, source=None):
+        calls.append((layer, role, source))
+        return layer
+
+    monkeypatch.setattr(
+        manager_module,
+        "apply_points_display_role",
+        fake_apply_points_display_role,
+    )
+
+    out = manager.apply_points_display_settings(tracking, source=source)
+
+    assert out is tracking
+    assert calls == [(tracking, PointsDisplaySource.TRACKING_RESULT, source)]
+
+
+def test_setup_points_layer_styles_machine_labels_using_config(
+    qtbot,
+    fake_store,
+    monkeypatch,
+):
+    pts = make_machine_points("machine", nonempty=True)
+    viewer = DummyViewer([pts])
+    manager = LayerLifecycleManager(viewer=viewer)
+
+    monkeypatch.setattr(manager, "validate_header", lambda layer: True)
+
+    manager._setup_points_layer(pts, allow_merge=False)
+
+    if MACHINE_LABELS_POINTS_DISPLAY.symbol is not None:
+        assert MACHINE_LABELS_POINTS_DISPLAY.symbol in set(pts.symbol)
+
+    if MACHINE_LABELS_POINTS_DISPLAY.opacity is not None:
+        assert pts.opacity == MACHINE_LABELS_POINTS_DISPLAY.opacity
+
+    if MACHINE_LABELS_POINTS_DISPLAY.border_width is not None:
+        assert getattr(pts, "border_width", None) == MACHINE_LABELS_POINTS_DISPLAY.border_width
+
+    if MACHINE_LABELS_POINTS_DISPLAY.border_color is not None:
+        assert getattr(pts, "border_color", None) is not None

--- a/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
@@ -7,9 +7,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-import napari
 from napari.layers import Points
-
 from ..layers import get_uniform_point_size
 
 logger = logging.getLogger(__name__)
@@ -66,21 +64,18 @@ def apply_points_display_role(
     role: PointsDisplaySource,
     *,
     source: Points | None = None,
-    viewer: napari.Viewer | None = None,
 ) -> Points:
     settings = POINTS_DISPLAY_SETTINGS_BY_ROLE.get(role)
     if settings is None:
         return layer
 
-    return apply_points_display_settings(layer, settings, source=source, viewer=viewer)
-
+    return apply_points_display_settings(layer, settings, source=source)
 
 def apply_points_display_settings(
     layer: Points,
     settings: PointsDisplaySettings,
     *,
     source: Points | None = None,
-    viewer: napari.Viewer | None = None,
 ) -> Points:
     """Apply display settings to a Points layer.
 
@@ -114,7 +109,6 @@ def apply_tracking_result_display_settings(
     layer: Points,
     *,
     source: Points | None = None,
-    viewer: napari.Viewer | None = None,
 ) -> Points:
     """Apply the standard visual style for tracking-result Points layers."""
 
@@ -122,7 +116,6 @@ def apply_tracking_result_display_settings(
         layer,
         TRACKING_RESULT_POINTS_DISPLAY,
         source=source,
-        viewer=viewer,
     )
 
 

--- a/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
@@ -1,0 +1,172 @@
+#  src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
+from __future__ import annotations
+
+import logging
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import napari
+from napari.layers import Points
+
+from ..layers import get_uniform_point_size
+
+logger = logging.getLogger(__name__)
+
+
+class PointsDisplaySource(str, Enum):
+    TRACKING_RESULT = "tracking_result"
+    MACHINE_LABELS = "machine_labels"
+
+
+@dataclass(frozen=True, slots=True)
+class PointsDisplaySettings:
+    """Declarative display settings for Points layers.
+
+    All fields are optional so callers can apply only the presentation concerns
+    relevant for a given layer role.
+    """
+
+    symbol: str | None = None
+    opacity: float | None = None
+    border_width: float | None = None
+    border_color: Any | None = None
+
+    # If True, copy face_color and face_color_mode from the source layer.
+    copy_face_colors_from_source: bool = False
+
+    # If True, copy/derive size from the source layer.
+    copy_size_from_source: bool = False
+
+
+TRACKING_RESULT_POINTS_DISPLAY = PointsDisplaySettings(
+    symbol="cross",
+    opacity=0.85,
+    border_width=0.15,
+    border_color="green",
+    copy_face_colors_from_source=True,
+    copy_size_from_source=True,
+)
+
+MACHINE_LABELS_POINTS_DISPLAY = PointsDisplaySettings(
+    symbol="x",
+    opacity=0.85,
+)
+
+
+POINTS_DISPLAY_SETTINGS_BY_ROLE: dict[PointsDisplaySource, PointsDisplaySettings] = {
+    PointsDisplaySource.TRACKING_RESULT: TRACKING_RESULT_POINTS_DISPLAY,
+    PointsDisplaySource.MACHINE_LABELS: MACHINE_LABELS_POINTS_DISPLAY,
+}
+
+
+def apply_points_display_role(
+    layer: Points,
+    role: PointsDisplaySource,
+    *,
+    source: Points | None = None,
+    viewer: napari.Viewer | None = None,
+) -> Points:
+    settings = POINTS_DISPLAY_SETTINGS_BY_ROLE.get(role)
+    if settings is None:
+        return layer
+
+    return apply_points_display_settings(layer, settings, source=source, viewer=viewer)
+
+
+def apply_points_display_settings(
+    layer: Points,
+    settings: PointsDisplaySettings,
+    *,
+    source: Points | None = None,
+    viewer: napari.Viewer | None = None,
+) -> Points:
+    """Apply display settings to a Points layer.
+
+    This helper is deliberately forgiving: display tweaks should not make layer
+    creation fail. If napari changes a presentation attribute or rejects a value,
+    the failure is logged at debug level and the remaining settings are applied.
+    """
+
+    if settings.symbol is not None:
+        _safe_set(layer, "symbol", settings.symbol)
+
+    if settings.opacity is not None:
+        _safe_set(layer, "opacity", settings.opacity)
+
+    if settings.copy_size_from_source and source is not None:
+        _copy_point_size(layer, source)
+
+    if settings.copy_face_colors_from_source and source is not None:
+        _copy_face_colors(layer, source)
+
+    if settings.border_width is not None:
+        _safe_set(layer, "border_width", settings.border_width)
+
+    if settings.border_color is not None:
+        _safe_set(layer, "border_color", settings.border_color)
+
+    return layer
+
+
+def apply_tracking_result_display_settings(
+    layer: Points,
+    *,
+    source: Points | None = None,
+    viewer: napari.Viewer | None = None,
+) -> Points:
+    """Apply the standard visual style for tracking-result Points layers."""
+
+    return apply_points_display_settings(
+        layer,
+        TRACKING_RESULT_POINTS_DISPLAY,
+        source=source,
+        viewer=viewer,
+    )
+
+
+def _safe_set(obj: Any, attr: str, value: Any) -> None:
+    try:
+        setattr(obj, attr, value)
+    except Exception:
+        logger.debug(
+            "Failed to set display attribute %s=%r on layer %r",
+            attr,
+            value,
+            getattr(obj, "name", obj),
+            exc_info=True,
+        )
+
+
+def _copy_point_size(layer: Points, source: Points) -> None:
+    try:
+        layer.size = get_uniform_point_size(source)
+        return
+    except Exception:
+        logger.debug(
+            "Failed to derive uniform point size from source layer %r",
+            getattr(source, "name", source),
+            exc_info=True,
+        )
+
+    try:
+        layer.size = deepcopy(source.size)
+    except Exception:
+        logger.debug(
+            "Failed to copy point size from source layer %r",
+            getattr(source, "name", source),
+            exc_info=True,
+        )
+
+
+def _copy_face_colors(layer: Points, source: Points) -> None:
+    try:
+        layer.face_color = deepcopy(source.face_color)
+        layer.face_color_mode = source.face_color_mode
+    except Exception:
+        logger.debug(
+            "Failed to copy face colors from source layer %r",
+            getattr(source, "name", source),
+            exc_info=True,
+        )

--- a/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/display_settings.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import Any
 
 from napari.layers import Points
+
 from ..layers import get_uniform_point_size
 
 logger = logging.getLogger(__name__)
@@ -70,6 +71,7 @@ def apply_points_display_role(
         return layer
 
     return apply_points_display_settings(layer, settings, source=source)
+
 
 def apply_points_display_settings(
     layer: Points,

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -14,7 +14,7 @@ from napari.utils.history import update_save_history
 from qtpy.QtCore import QObject, Signal
 
 from ...config.keybinds import install_points_layer_keybindings
-from ...config.models import DLCHeaderModel, ImageMetadata, PointsMetadata
+from ...config.models import AnnotationKind, DLCHeaderModel, ImageMetadata, PointsMetadata
 from ...core import keypoints
 from ...core.io import is_video
 from ...core.layer_versioning import mark_layer_presentation_changed
@@ -34,6 +34,7 @@ from ...tracking.core.data import TRACKING_LAYER_METADATA_KEY, is_tracking_resul
 from ...ui.base_widget._qt_timers import OwnedTimersMixin
 from ...ui.cropping import resolve_project_path_from_image_layer
 from ...utils.debug import log_timing
+from .display_settings import PointsDisplaySource, apply_points_display_role
 from .merge import PlaceholderConfigAction, PlaceholderConfigDecisionProvider
 from .registry import (
     ClearedRegistryEntry,
@@ -267,7 +268,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         if data.ndim != 2 or len(data) == 0:
             return False
 
-        if self.is_tracking_result_layer(layer):
+        if LayerLifecycleManager.is_tracking_result_layer(layer):
             return True
 
         return self.is_managed(layer) and self.validate_header(layer)
@@ -298,7 +299,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             return active
 
         for layer, _store in self.iter_managed_points():
-            if self.is_plottable_traj_layer(layer) and not self.is_tracking_result_layer(layer):
+            if self.is_plottable_traj_layer(layer) and not LayerLifecycleManager.is_tracking_result_layer(layer):
                 return layer
 
         for layer in self.iter_tracking_result_layers():
@@ -440,6 +441,69 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             data = np.empty((0, 3))
 
         return data.size == 0
+
+    @staticmethod
+    def is_machine_label_layer(layer: Any) -> bool:
+        """Return True if this Points layer represents loaded machine labels.
+
+        The source of truth is IO provenance:
+            layer.metadata["io"]["kind"] == AnnotationKind.MACHINE
+
+        This is better than detecting from the layer name because users may
+        rename layers.
+        """
+        if layer is None or not isinstance(layer, Points):
+            return False
+
+        if LayerLifecycleManager.is_tracking_result_layer(layer):
+            return False
+
+        md = getattr(layer, "metadata", {}) or {}
+        if not isinstance(md, dict):
+            return False
+
+        io_payload = md.get("io", None)
+        if not isinstance(io_payload, dict):
+            return False
+
+        kind = io_payload.get("kind", None)
+
+        if kind is AnnotationKind.MACHINE:
+            return True
+
+        # Be tolerant if metadata has been serialized/deserialized.
+        try:
+            return AnnotationKind(kind) is AnnotationKind.MACHINE
+        except Exception:
+            pass
+
+        return str(kind).lower() in {
+            "machine",
+            "annotationkind.machine",
+        }
+
+    def points_display_role(self, layer: Any) -> PointsDisplaySource | None:
+        """Resolve the semantic display role for a Points layer, if any."""
+        if LayerLifecycleManager.is_tracking_result_layer(layer):
+            return PointsDisplaySource.TRACKING_RESULT
+
+        if LayerLifecycleManager.is_machine_label_layer(layer):
+            return PointsDisplaySource.MACHINE_LABELS
+
+        return None
+
+    def apply_points_display_settings(
+        self,
+        layer: Points,
+        *,
+        source: Points | None = None,
+    ) -> Points:
+        """Apply centralized role-based display settings for known Points layers."""
+        role = self.points_display_role(layer)
+        if role is None:
+            return layer
+
+        return apply_points_display_role(layer, role, source=source)
 
     def validate_header(self, layer: Points) -> bool:
         res = read_points_meta(layer, migrate_legacy=True, drop_controls=True, drop_header=False)
@@ -714,6 +778,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         if store is None:
             return PointsInsertResult.SKIPPED
 
+        self.apply_points_display_settings(layer)
         logger.debug(
             "Setup points layer=%r allow_merge=%s metadata_keys=%s",
             getattr(layer, "name", layer),
@@ -1126,7 +1191,8 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         payload = md.get(TRACKING_LAYER_METADATA_KEY, None)
         return payload if isinstance(payload, dict) else None
 
-    def is_tracking_result_layer(self, layer: Any) -> bool:
+    @staticmethod
+    def is_tracking_result_layer(layer: Any) -> bool:
         """
         Authoritative viewer/session-facing predicate for tracking-result layers.
 
@@ -1178,7 +1244,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
 
         # Tracking-result targets are allowed, but they are never "managed DLC"
         # for the managed-only pass.
-        if self.is_tracking_result_layer(layer):
+        if LayerLifecycleManager.is_tracking_result_layer(layer):
             return not require_managed
 
         if not self.validate_header(layer):
@@ -1192,7 +1258,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
     def iter_tracking_result_layers(self) -> Iterator[Points]:
         """Iterate live tracking-result Points layers in current viewer order."""
         for layer in self.viewer.layers:
-            if isinstance(layer, Points) and self.is_tracking_result_layer(layer):
+            if isinstance(layer, Points) and LayerLifecycleManager.is_tracking_result_layer(layer):
                 yield layer
 
     def iter_mergeable_dlc_points_layers(

--- a/src/napari_deeplabcut/tracking/_widgets.py
+++ b/src/napari_deeplabcut/tracking/_widgets.py
@@ -1,5 +1,4 @@
 import logging
-from copy import deepcopy
 from functools import partial
 
 import napari
@@ -38,7 +37,6 @@ from napari_deeplabcut.config.settings import TRACKING_SHORTCUTS_ENABLED
 from napari_deeplabcut.core.keypoints import KeypointStore
 from napari_deeplabcut.core.layer_lifecycle import get_or_create_layer_manager
 from napari_deeplabcut.core.layer_versioning import mark_layer_presentation_changed
-from napari_deeplabcut.core.layers import get_uniform_point_size
 from napari_deeplabcut.ui.base_widget.singleton_widget import ViewerSingletonWidget
 from napari_deeplabcut.ui.icons import apply_help_info_icon
 
@@ -391,36 +389,7 @@ class TrackingControls(ViewerSingletonWidget):
         )
 
         # Distinguish tracking results visually
-        try:
-            layer.symbol = "cross"
-        except Exception:
-            pass
-
-        try:
-            layer.opacity = 0.85
-        except Exception:
-            pass
-
-        try:
-            layer.size = get_uniform_point_size(source)
-        except Exception:
-            try:
-                layer.size = deepcopy(source.size)
-            except Exception:
-                pass
-
-        try:
-            # Optional: keep source colors if useful, but still visually distinct
-            layer.face_color = deepcopy(source.face_color)
-            layer.face_color_mode = source.face_color_mode
-        except Exception:
-            pass
-
-        try:
-            layer.border_width = 0.15
-            layer.border_color = "green"
-        except Exception:
-            pass
+        self.lifecycle_manager.apply_points_display_settings(layer, source=source)
 
         return layer
 


### PR DESCRIPTION
## Motivation

A common source of confusion when using the plugin with machine layers is that users wonder why "duplicate" annotations show up, and do not always notice the extra layers/ understand which one is which.

## Proposed solution

- Show machine labels with different display settings from GT labels (X marker, slight alpha)
- New API:
  - Centralized module for layer display settings near layer manager
  - Moved tracking results display logic to this new file
- Added method to layer manager to identify machine labels layers
- Made several layer identity method static for convenience
 
> [!NOTE]
> The dropdown for **setting the marker when adding** new Points to a layer is not automatically updated, so adding new points to a machine labels layer will use the current dropdown value (usually a disc, which is what we use for GT labels).
> This is currently intentional to avoid further monkeypatching of napari internals, but might result in further confusion, unless users remember to manually set the marker.
> This is only expected to occur when users add new points to machine label layers.

---

### Automated summary

This pull request introduces a centralized and declarative system for managing display settings of napari `Points` layers, especially for tracking results and machine label layers. The main changes include the addition of a new `display_settings.py` module, refactoring of display logic out of widget code, and enhancements to the layer lifecycle manager for role-based display styling.

**Centralized display settings for Points layers:**

* Added `display_settings.py` containing the `PointsDisplaySettings` dataclass, `PointsDisplaySource` enum, and functions to apply role-based display settings to `Points` layers, making the styling logic reusable and declarative.

**Layer lifecycle management improvements:**

* Refactored `LayerLifecycleManager` to:
  - Use static methods for determining layer roles (e.g., `is_tracking_result_layer`, `is_machine_label_layer`), improving consistency and testability. [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R445-R507) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L1129-R1195)
  - Add `points_display_role` and `apply_points_display_settings` methods to assign and apply display roles automatically when points layers are set up. [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R445-R507) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48R781)
  - Replace direct display property assignments with calls to the new centralized logic throughout the manager. [[1]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L270-R271) [[2]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L301-R302) [[3]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L1181-R1247) [[4]](diffhunk://#diff-0b6ce8a4e76e333bb9aece8461a16a367da3f55eb4de01b5d6c532a2db21be48L1195-R1261)

**Widget and code cleanup:**

* Refactored `_create_tracking_result_layer` in `tracking/_widgets.py` to use the new `apply_points_display_settings` method instead of manually setting display properties, reducing duplication and potential for errors.
* Removed redundant imports and unused code related to the old display settings approach. [[1]](diffhunk://#diff-e4fe3b095298b64000639b75e6a35feafd6aa99bf7566a6696faf4c951e5e083L2) [[2]](diffhunk://#diff-e4fe3b095298b64000639b75e6a35feafd6aa99bf7566a6696faf4c951e5e083L41)