### PR TITLE
Prevent loading duplicate bodyparts from config

### DIFF
--- a/src/napari_deeplabcut/_writer.py
+++ b/src/napari_deeplabcut/_writer.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 def write_hdf_napari_dlc(path: str, data, attributes: dict) -> list[str]:
     if not path:
         path = "__dlc__.h5"  # dummy path to trigger napari-deeplabcut-specific handling in write_hdf
+
     if path != "__dlc__.h5":
         logger.info(
             "This function should not be used with a user-specified path."
@@ -23,7 +24,18 @@ def write_hdf_napari_dlc(path: str, data, attributes: dict) -> list[str]:
             "are refined by a human (as we do not want to overwrite machine labels),"
             "but that case is handled separately."
         )
-    return write_hdf(path, data, attributes)
+
+    logger.debug("write_hdf_napari_dlc ENTER path=%r", path)
+
+    written = write_hdf(path, data, attributes)
+
+    logger.debug("write_hdf_napari_dlc RETURN written=%r", written)
+    logger.debug(
+        "write_hdf_napari_dlc EXISTS=%r",
+        [(p, Path(p).exists()) for p in written],
+    )
+
+    return written
 
 
 # TODO rewrite explicitly as napari-facing func

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -373,7 +373,7 @@ class DLCHeaderModel(BaseModel):
 
             if "single" in inds and set(bps) & set(unique_bps):
                 raise ValueError(
-                    "Invalid config.yaml: 'single' individual conflicts with uniquebodyparts."
+                    "Invalid config.yaml: 'single' individual conflicts with uniquebodyparts. "
                     "Do not use 'single' as an individual name if you have uniquebodyparts."
                 )
 

--- a/src/napari_deeplabcut/config/models.py
+++ b/src/napari_deeplabcut/config/models.py
@@ -333,6 +333,16 @@ class DLCHeaderModel(BaseModel):
         # stable unique preserving first seen order
         return list(dict.fromkeys(pairs))
 
+    @staticmethod
+    def _find_duplicates(values: list[str]):
+        seen = set()
+        dupl = []
+        for v in values:
+            if v in seen and v not in dupl:
+                dupl.append(v)
+            seen.add(v)
+        return dupl
+
     @classmethod
     def from_config(cls, config: dict) -> DLCHeaderModel:
         """
@@ -348,6 +358,25 @@ class DLCHeaderModel(BaseModel):
         if multi:
             inds = [str(x) for x in config["individuals"]]
             bps = [str(x) for x in config["multianimalbodyparts"]]
+            unique_bps = [str(x) for x in config.get("uniquebodyparts", [])]
+
+            dup_inds = DLCHeaderModel._find_duplicates(inds)
+            dup_bps = DLCHeaderModel._find_duplicates(bps)
+            dup_unique = DLCHeaderModel._find_duplicates(unique_bps)
+
+            if dup_inds:
+                raise ValueError(f"Duplicate individuals in config.yaml: {dup_inds}")
+            if dup_bps:
+                raise ValueError(f"Duplicate multianimalbodyparts in config.yaml: {dup_bps}")
+            if dup_unique:
+                raise ValueError(f"Duplicate uniquebodyparts in config.yaml: {dup_unique}")
+
+            if "single" in inds and set(bps) & set(unique_bps):
+                raise ValueError(
+                    "Invalid config.yaml: 'single' individual conflicts with uniquebodyparts."
+                    "Do not use 'single' as an individual name if you have uniquebodyparts."
+                )
+
             coords = ["x", "y"]
             for i in inds:
                 for bp in bps:
@@ -360,6 +389,9 @@ class DLCHeaderModel(BaseModel):
             names = ["scorer", "individuals", "bodyparts", "coords"]
         else:
             bps = [str(x) for x in config["bodyparts"]]
+            dup_bps = DLCHeaderModel._find_duplicates(bps)
+            if dup_bps:
+                raise ValueError(f"Duplicate bodyparts in config.yaml: {dup_bps}")
             coords = ["x", "y"]
             for bp in bps:
                 for c in coords:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -420,11 +420,19 @@ def _resolve_multianimalproject_for_write(
 def _atomic_to_hdf(df: pd.DataFrame, out_path: Path, key: str = DLC_CANONICAL_H5_KEY) -> None:
     """Best-effort atomic write: write to temp and replace."""
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = out_path.with_suffix(out_path.suffix + ".tmp")
-    # Write temp
-    df.to_hdf(tmp, key=key, mode="w")
-    # Replace
-    tmp.replace(out_path)
+
+    tmp = out_path.parent / f".{out_path.stem}.tmp{out_path.suffix}"
+
+    try:
+        df.to_hdf(tmp, key=key, mode="w")
+        tmp.replace(out_path)
+    except Exception:
+        logger.exception("Failed atomic HDF write tmp=%s out=%s", tmp, out_path)
+        try:
+            tmp.unlink(missing_ok=True)
+        except Exception:
+            logger.debug("Failed to remove temporary HDF file %s", tmp, exc_info=True)
+        raise
 
 
 def write_hdf(path: str, data, attributes: dict) -> list[str]:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -593,11 +593,21 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
         )
 
     # Write .h5 and .csv
-    _atomic_to_hdf(df_out, out, key=DLC_CANONICAL_H5_KEY)
-    csv_path = out.with_suffix(".csv")
-    df_out.to_csv(csv_path)
+    try:
+        logger.debug("Writing HDF to %s", out)
+        _atomic_to_hdf(df_out, out, key=DLC_CANONICAL_H5_KEY)
 
-    return [str(out), str(csv_path)]
+        csv_path = out.with_suffix(".csv")
+        logger.debug("Writing CSV to %s", csv_path)
+        df_out.to_csv(csv_path)
+
+        written = [str(out), str(csv_path)]
+        logger.debug("write_hdf returning %r exists=%r", written, [(p, Path(p).exists()) for p in written])
+        return written
+
+    except Exception:
+        logger.exception("write_hdf failed during final disk write")
+        raise
 
 
 # =============================================================================

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -600,6 +600,16 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
             list(dict.fromkeys(df_out.columns.get_level_values("individuals").astype(str))),
         )
 
+    cols = df_out.columns
+    logger.debug("FINAL WRITE columns count=%d unique_count=%d", len(cols), len(cols.unique()))
+
+    if cols.has_duplicates:
+        dup = cols[cols.duplicated(keep=False)]
+        logger.error(
+            "FINAL WRITE duplicate columns sample=%s",
+            list(dict.fromkeys(map(str, dup)))[:50],
+        )
+
     # Write .h5 and .csv
     try:
         logger.debug("Writing HDF to %s", out)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -609,6 +609,7 @@ def write_hdf(path: str, data, attributes: dict) -> list[str]:
             "FINAL WRITE duplicate columns sample=%s",
             list(dict.fromkeys(map(str, dup)))[:50],
         )
+        raise ValueError(f"Duplicate columns detected in output DataFrame: {list(dict.fromkeys(map(str, dup)))}")
 
     # Write .h5 and .csv
     try:


### PR DESCRIPTION
### Scope

- Prevents duplicate bodyparts in all modes
- Check for duplicates also for multianimal
- Prevents use of "single" as individual name if uniquebodyparts are present
- Misc:
  - Minor logging additions around h5 saves to improve traceability
  - Swapped tmp and h5 suffixes such that pandas does not attempt saving a .tmp as h5
  - Clean up tmp files when an error occurs during saving

Aims to close #219 