### PR TITLE
Fix crash when deleting Points layer immediately after loading

### DIFF
--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -253,16 +253,11 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     assert canvas.ax.get_xlabel() == "Frame"
     assert canvas.ax.get_ylabel() == "Y position"
 
-    # Test slider updates using a value inside the current slider range.
+    # Test slider updates
     initial_window = canvas._window
-    target_window = min(initial_window + 100, canvas.slider.maximum())
-
-    if target_window == initial_window:
-        target_window = max(canvas.slider.minimum(), initial_window - 1)
-    canvas.slider.setValue(target_window)
-
-    assert canvas._window == target_window
-    assert canvas.slider_value.text() == str(target_window)
+    canvas.slider.setValue(initial_window + 100)
+    assert canvas._window == initial_window + 100
+    assert canvas.slider_value.text() == str(initial_window + 100)
 
     # Test plot refresh does nothing when plot is hidden
     canvas.update_plot_range(event=type("Event", (), {"value": [5]}))

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -253,21 +253,21 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     assert canvas.ax.get_xlabel() == "Frame"
     assert canvas.ax.get_ylabel() == "Y position"
 
-    # Test slider updates
-    initial_window = canvas._window
-    canvas.slider.setValue(initial_window + 100)
-    assert canvas._window == initial_window + 100
-    assert canvas.slider_value.text() == str(initial_window + 100)
+    # Test slider updates using a valid value inside the current slider range.
+    slider_min = canvas.slider.minimum()
+    slider_max = canvas.slider.maximum()
+    current_value = canvas.slider.value()
 
-    # Test plot refresh does nothing when plot is hidden
-    canvas.update_plot_range(event=type("Event", (), {"value": [5]}))
-    assert canvas._n == 0
-    # Test plot refresh on frame change (forced as it is hidden)
-    canvas.update_plot_range(event=type("Event", (), {"value": [5]}), force=True)
-    assert canvas._n == 5
-    # Check that x-limits reflect the new window
-    start, end = canvas.ax.get_xlim()
-    assert start <= 5 <= end
+    assert slider_min < slider_max
+    assert slider_min <= current_value <= slider_max
+
+    target_window = slider_min if current_value != slider_min else slider_max
+
+    canvas.slider.setValue(target_window)
+
+    assert canvas.slider.value() == target_window
+    assert canvas._window == target_window
+    assert canvas.slider_value.text() == str(target_window)
 
 
 @pytest.fixture(autouse=True)

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -245,7 +245,7 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
 
     # Simulate adding a Points layer (triggers _load_dataframe)
     viewer.layers.selection.add(points)
-    canvas._load_dataframe()
+    canvas._load_dataframe(allow_fallback=True)
 
     # Ensure dataframe loaded and lines plotted
     assert canvas.df is not None

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -253,11 +253,16 @@ def test_matplotlib_canvas_initialization_and_slider(viewer, points, qtbot):
     assert canvas.ax.get_xlabel() == "Frame"
     assert canvas.ax.get_ylabel() == "Y position"
 
-    # Test slider updates
+    # Test slider updates using a value inside the current slider range.
     initial_window = canvas._window
-    canvas.slider.setValue(initial_window + 100)
-    assert canvas._window == initial_window + 100
-    assert canvas.slider_value.text() == str(initial_window + 100)
+    target_window = min(initial_window + 100, canvas.slider.maximum())
+
+    if target_window == initial_window:
+        target_window = max(canvas.slider.minimum(), initial_window - 1)
+    canvas.slider.setValue(target_window)
+
+    assert canvas._window == target_window
+    assert canvas.slider_value.text() == str(target_window)
 
     # Test plot refresh does nothing when plot is hidden
     canvas.update_plot_range(event=type("Event", (), {"value": [5]}))

--- a/src/napari_deeplabcut/_tests/ui/test_traj_plot.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_plot.py
@@ -222,5 +222,5 @@ def test_selected_line_keys_uses_strict_layer_resolution(viewer, qtbot, monkeypa
 
     monkeypatch.setattr(canvas, "_get_plot_points_layer", _fake_get_plot_points_layer)
 
-    assert canvas._selected_line_keys_from_points_layer() == set()
+    assert canvas._selected_line_keys_from_points_layer() is None
     assert calls == [False]

--- a/src/napari_deeplabcut/_tests/ui/test_traj_plot.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_plot.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from napari.layers import Points
+
+from napari_deeplabcut.ui.plots.plot_models import TrajectoryPlotState
+from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
+
+
+class DummyTrajectoryLayerManager:
+    def __init__(self, viewer, *, plottable_layer=None, suggested_layer=None):
+        self.viewer = viewer
+        self.plottable_layer = plottable_layer
+        self.suggested_layer = suggested_layer
+
+    def _same_layer(self, a, b):
+        if a is None or b is None:
+            return False
+        return getattr(a, "name", None) == getattr(b, "name", None)
+
+    def is_plottable_traj_layer(self, layer):
+        return isinstance(layer, Points) and self._same_layer(layer, self.plottable_layer)
+
+    def active_plottable_traj_layer(self):
+        active = getattr(self.viewer.layers.selection, "active", None)
+        return active if self.is_plottable_traj_layer(active) else None
+
+    def suggest_plottable_traj_layer(self):
+        return self.suggested_layer
+
+    def is_tracking_result_layer(self, layer):
+        return False
+
+
+def _make_canvas(viewer, qtbot, *, layer_manager=None, get_color_mode=None):
+    canvas = TrajectoryMatplotlibCanvas(
+        viewer,
+        layer_manager=layer_manager,
+        get_color_mode=get_color_mode,
+    )
+    qtbot.addWidget(canvas)
+
+    # Keep tests deterministic: do not let the initial deferred refresh run.
+    canvas._cancel_scheduled("initial_trajectory_refresh")
+
+    return canvas
+
+
+def _select_layer(viewer, layer):
+    viewer.layers.selection.clear()
+    viewer.layers.selection.add(layer)
+    viewer.layers.selection.active = layer
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_get_plot_points_layer_strict_does_not_fallback_when_active_is_none(viewer, qtbot):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    viewer.layers.selection.clear()
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=points,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    assert viewer.layers.selection.active is None
+    assert canvas._get_plot_points_layer(allow_fallback=False) is None
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_get_plot_points_layer_allows_fallback_for_explicit_initialization(viewer, qtbot):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    viewer.layers.selection.clear()
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=points,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    assert canvas._get_plot_points_layer(allow_fallback=True) is points
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_get_plot_points_layer_strict_returns_active_plottable_layer(viewer, qtbot):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=None,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    _select_layer(viewer, points)
+
+    result = canvas._get_plot_points_layer(allow_fallback=False)
+
+    assert result is not None
+    assert isinstance(result, type(points))
+    assert result.name == points.name
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_get_plot_points_layer_rejects_suggested_layer_not_in_viewer(viewer, qtbot):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=points,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    viewer.layers.remove(points)
+
+    assert canvas._get_plot_points_layer(allow_fallback=True) is None
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_refresh_from_viewer_layers_strict_does_not_build_from_fallback_layer(viewer, qtbot, monkeypatch):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    viewer.layers.selection.clear()
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=points,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    def _fail_if_called(layer):
+        raise AssertionError("Trajectory plot should not build from fallback layer in strict mode")
+
+    monkeypatch.setattr(canvas, "_build_plot_state", _fail_if_called)
+
+    canvas.refresh_from_viewer_layers(allow_fallback=False)
+
+    assert canvas._plot_state is None
+    assert canvas._plot_layer is None
+    assert canvas._lines == {}
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_refresh_from_viewer_layers_allows_fallback_for_explicit_initialization(viewer, qtbot, monkeypatch):
+    points = viewer.add_points(
+        np.array([[0, 0], [1, 1]]),
+        properties={"label": np.array(["nose", "tail"], dtype=object)},
+    )
+
+    viewer.layers.selection.clear()
+
+    manager = DummyTrajectoryLayerManager(
+        viewer,
+        plottable_layer=points,
+        suggested_layer=points,
+    )
+    canvas = _make_canvas(viewer, qtbot, layer_manager=manager)
+
+    calls = []
+
+    def _fake_build_plot_state(layer):
+        calls.append(layer)
+
+        df = pd.DataFrame(index=[0, 1])
+        state = TrajectoryPlotState(
+            df=df,
+            series=(),
+            frame_min=0.0,
+            frame_max=1.0,
+            image_height=None,
+        )
+        return df, state
+
+    monkeypatch.setattr(canvas, "_build_plot_state", _fake_build_plot_state)
+
+    canvas.refresh_from_viewer_layers(allow_fallback=True)
+
+    assert calls == [points]
+    assert canvas._plot_state is not None
+    assert canvas._plot_layer is points
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("qtbot")
+def test_selected_line_keys_uses_strict_layer_resolution(viewer, qtbot, monkeypatch):
+    canvas = _make_canvas(viewer, qtbot)
+
+    calls = []
+
+    def _fake_get_plot_points_layer(*, allow_fallback=False):
+        calls.append(allow_fallback)
+        return None
+
+    monkeypatch.setattr(canvas, "_get_plot_points_layer", _fake_get_plot_points_layer)
+
+    assert canvas._selected_line_keys_from_points_layer() == set()
+    assert calls == [False]

--- a/src/napari_deeplabcut/_tests/ui/test_traj_select.py
+++ b/src/napari_deeplabcut/_tests/ui/test_traj_select.py
@@ -1,3 +1,4 @@
+# src/napari_deeplabcut/_tests/ui/test_traj_select.py
 from __future__ import annotations
 
 import numpy as np
@@ -18,7 +19,7 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
     qtbot.add_widget(canvas)
 
     # Force the visibility sync to use this test layer directly.
-    canvas._get_plot_points_layer = lambda: layer
+    canvas._get_plot_points_layer = lambda *, allow_fallback=False: layer
 
     # canvas._plot_state.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
@@ -28,6 +29,7 @@ def test_sync_visible_lines_to_points_selection_shows_all_when_no_points_selecte
         ("", "nose"): [line_nose],
         ("", "tail"): [line_tail],
     }
+    canvas._plot_layer = layer
 
     layer.selected_data.clear()
     canvas.sync_visible_lines_to_points_selection()
@@ -48,7 +50,7 @@ def test_sync_visible_lines_to_points_selection_filters_by_selected_labels_in_bo
     qtbot.add_widget(canvas)
 
     # Force the visibility sync to use this test layer directly.
-    canvas._get_plot_points_layer = lambda: layer
+    canvas._get_plot_points_layer = lambda *, allow_fallback=False: layer
 
     # canvas._plot_state.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
@@ -59,6 +61,7 @@ def test_sync_visible_lines_to_points_selection_filters_by_selected_labels_in_bo
         ("", "nose"): [line_nose],
         ("", "tail"): [line_tail],
     }
+    canvas._plot_layer = layer
 
     # Select a point whose label is "tail"
     layer.selected_data.select_only(1)
@@ -82,7 +85,7 @@ def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_poin
     qtbot.add_widget(canvas)
 
     # Force the visibility sync to use this test layer directly.
-    canvas._get_plot_points_layer = lambda: layer
+    canvas._get_plot_points_layer = lambda *, allow_fallback=False: layer
 
     # canvas._plot_state.df = object()
     (line_nose,) = canvas.ax.plot([0, 1], [0, 1])
@@ -93,7 +96,7 @@ def test_sync_visible_lines_to_points_selection_shows_label_if_any_selected_poin
         ("", "nose"): [line_nose],
         ("", "tail"): [line_tail],
     }
-
+    canvas._plot_layer = layer
     # Select both nose points
     layer.selected_data.update({0, 2})
     canvas.sync_visible_lines_to_points_selection()

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1286,7 +1286,7 @@ class KeypointControls(ViewerSingletonWidget):
         layer = getattr(event, "value", None)
 
         with log_timing(
-            logger, f"on_active_layer_change value={getattr(event.value, 'name', None)!r}", threshold_ms=0.0
+            logger, f"on_active_layer_change value={getattr(layer, 'name', None)!r}", threshold_ms=0.0
         ):
             self._color_grp.setVisible(self.layer_manager.is_multianimal(layer))
             # self._update_color_scheme() # if needed

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -783,7 +783,7 @@ class KeypointControls(ViewerSingletonWidget):
         if Qt.CheckState(state) == Qt.CheckState.Checked:
             self._ensure_traj_canvas_docked()
             if self._mpl_docked:
-                self._traj_mpl_canvas.refresh_from_viewer_layers()
+                self._traj_mpl_canvas.refresh_from_viewer_layers(allow_fallback=True)
                 self._traj_mpl_canvas._apply_napari_theme()
                 self._traj_mpl_canvas.update_plot_range(
                     Event(type_name="", value=[self.viewer.dims.current_step[0]]),

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -1285,9 +1285,7 @@ class KeypointControls(ViewerSingletonWidget):
         """
         layer = getattr(event, "value", None)
 
-        with log_timing(
-            logger, f"on_active_layer_change value={getattr(layer, 'name', None)!r}", threshold_ms=0.0
-        ):
+        with log_timing(logger, f"on_active_layer_change value={getattr(layer, 'name', None)!r}", threshold_ms=0.0):
             self._color_grp.setVisible(self.layer_manager.is_multianimal(layer))
             # self._update_color_scheme() # if needed
             self._sync_dropdown_visibility()

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 from datetime import datetime
 from functools import cached_property
 from pathlib import Path
+from types import SimpleNamespace
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -420,7 +421,7 @@ class KeypointControls(ViewerSingletonWidget):
         traj_canvas = self._safe_get_traj_canvas()
         if traj_canvas is not None:
             try:
-                traj_canvas.refresh_from_viewer_layers()
+                traj_canvas.refresh_from_viewer_layers(allow_fallback=True)
             except Exception:
                 logger.debug("Failed to refresh trajectory plot after color mode change", exc_info=True)
 
@@ -599,6 +600,33 @@ class KeypointControls(ViewerSingletonWidget):
             sorted((layer.metadata or {}).keys()),
         )
 
+    def _sync_current_active_layer_state(self) -> None:
+        """
+        Ensure sync after adding a layer.
+        This prevents partial initialization states where the sync called on layer selection
+        never fires since loading a layer is not considered a selection change, but the new layer is already active.
+        """
+        try:
+            active = self.viewer.layers.selection.active
+        except Exception:
+            active = None
+
+        if active is None:
+            return
+
+        try:
+            self.on_active_layer_change(SimpleNamespace(value=active))
+            logger.debug(
+                "Synced active layer state after setup for layer=%r",
+                getattr(active, "name", active),
+            )
+        except Exception:
+            logger.debug(
+                "Failed to sync current active layer state for layer=%r",
+                getattr(active, "name", active),
+                exc_info=True,
+            )
+
     def _on_points_layer_setup_requested(self, req: PointsLayerSetupRequest) -> None:
         layer = req.layer
         store = req.store
@@ -627,6 +655,7 @@ class KeypointControls(ViewerSingletonWidget):
             self._maybe_initialize_layer_point_size_from_config(layer)
             self._connect_layer_status_events(layer)
             self._complete_points_layer_ui_setup(layer, store)
+            self._sync_current_active_layer_state()
 
         except Exception:
             logger.debug(
@@ -1254,10 +1283,12 @@ class KeypointControls(ViewerSingletonWidget):
         * Sets the visibility of the "Color mode" box to True if the selected layer
             is a multi-animal one, or False otherwise
         """
+        layer = getattr(event, "value", None)
+
         with log_timing(
             logger, f"on_active_layer_change value={getattr(event.value, 'name', None)!r}", threshold_ms=0.0
         ):
-            self._color_grp.setVisible(self.layer_manager.is_multianimal(event.value))
+            self._color_grp.setVisible(self.layer_manager.is_multianimal(layer))
             # self._update_color_scheme() # if needed
             self._sync_dropdown_visibility()
 

--- a/src/napari_deeplabcut/config/settings.py
+++ b/src/napari_deeplabcut/config/settings.py
@@ -11,6 +11,9 @@ DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP = "Set3"
 # UI settings
 _OVERWRITE_CONFIRM_ENABLED_KEY = "napari_deeplabcut/overwrite/confirm_enabled"
 AUTO_OPEN_KEYPOINT_CONTROLS_KEY = "napari_deeplabcut/ui/auto_open_keypoint_controls"
+## Trajectory plot
+_MIN_TRAJ_PLOT_WINDOW = 1
+_DEFAULT_TRAJ_PLOT_WINDOW = 50
 
 # Tracking settings
 TRACKING_SHORTCUTS_ENABLED = os.environ.get("NAPARI_DLC_TRACKING_SHORTCUTS_ENABLED", "1") == "1"

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -294,7 +294,7 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
         """
         active = getattr(self.viewer.layers.selection, "active", None)
 
-        if self.is_plottable_traj_layer(active):
+        if self.is_plottable_traj_layer(active) and active in self.viewer.layers:
             return active
 
         return None

--- a/src/napari_deeplabcut/core/layer_lifecycle/manager.py
+++ b/src/napari_deeplabcut/core/layer_lifecycle/manager.py
@@ -283,6 +283,22 @@ class LayerLifecycleManager(QObject, OwnedTimersMixin):
             if isinstance(layer, Points) and self.is_plottable_traj_layer(layer):
                 yield layer
 
+    def active_plottable_traj_layer(self) -> Points | None:
+        """
+        Return the currently active plottable trajectory layer, without fallback.
+
+        Use this for selection-driven or removal-driven refreshes. During deletion,
+        napari may temporarily set active=None while the removed layer is still in
+        viewer.layers. Falling back to the first managed layer in that state can
+        resurrect a layer that is actively being removed.
+        """
+        active = getattr(self.viewer.layers.selection, "active", None)
+
+        if self.is_plottable_traj_layer(active):
+            return active
+
+        return None
+
     def suggest_plottable_traj_layer(self) -> Points | None:
         """
         Suggest the best Points layer to display in the trajectory plot.

--- a/src/napari_deeplabcut/ui/base_widget/__init__.py
+++ b/src/napari_deeplabcut/ui/base_widget/__init__.py
@@ -1,3 +1,4 @@
+from ._qt_timers import OwnedTimersMixin
 from .singleton_widget import ViewerSingletonWidget
 
-__all__ = ["ViewerSingletonWidget"]
+__all__ = ["ViewerSingletonWidget", "OwnedTimersMixin"]

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -824,7 +824,7 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
         logger.debug(f"Determining visible trajectory lines from points layer: {points_layer!r}")
 
         if points_layer is None:
-            return set()
+            return None
 
         # If the active layer is not the layer currently rendered, do not inspect
         # its selected_data.
@@ -894,6 +894,8 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
             return
 
         visible = self._selected_line_keys_from_points_layer()
+        if visible is None:
+            return
         if not visible:
             self._show_all_keypoints()
             return

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -25,6 +25,8 @@ from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayou
 
 import napari_deeplabcut.core.io as io
 from napari_deeplabcut.config.settings import (
+    _DEFAULT_TRAJ_PLOT_WINDOW,
+    _MIN_TRAJ_PLOT_WINDOW,
     DEFAULT_MULTI_ANIMAL_INDIVIDUAL_CMAP,
     DEFAULT_SINGLE_ANIMAL_CMAP,
 )
@@ -120,9 +122,9 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
         self.canvas.mpl_connect("button_press_event", self.on_doubleclick)
 
         self.slider = QSlider(Qt.Horizontal)
-        self.slider.setMinimum(50)
+        self.slider.setMinimum(_MIN_TRAJ_PLOT_WINDOW)
         self.slider.setMaximum(10000)
-        self.slider.setValue(50)
+        self.slider.setValue(_DEFAULT_TRAJ_PLOT_WINDOW)
         self.slider.setToolTip("Adjust the range of frames to display around the current frame")
         self.slider.setTickPosition(QSlider.TicksBelow)
         self.slider.setTickInterval(50)
@@ -248,6 +250,40 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
         if not text or text.lower() == "nan":
             return ""
         return text
+
+    @staticmethod
+    def _clamp(value: float, low: float, high: float) -> float:
+        """Clamp value to [low, high]."""
+        if high < low:
+            low, high = high, low
+        return max(low, min(high, value))
+
+    @staticmethod
+    def _small_span_padding(span: float) -> float:
+        """
+        Return padding for short trajectories.
+
+        For tiny frame ranges, a fixed half-frame padding keeps points and the
+        current-frame marker readable instead of pinned to the axes border.
+        """
+        if not np.isfinite(span) or span <= 0:
+            return 0.5
+        return max(0.5, 0.05 * span)
+
+    def _effective_window(self, state: TrajectoryPlotState) -> float:
+        """
+        Return a display window that is valid for the current frame extent.
+
+        The slider stores the requested window, but for short videos the actual
+        usable window cannot exceed the available frame span.
+        """
+        frame_span = float(state.frame_max - state.frame_min)
+
+        if not np.isfinite(frame_span) or frame_span <= 0:
+            return 1.0
+
+        requested = max(float(self._window), float(_MIN_TRAJ_PLOT_WINDOW))
+        return min(requested, frame_span)
 
     def on_doubleclick(self, event):
         if getattr(event, "dblclick", False):
@@ -610,6 +646,7 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
                 state.frame_max,
             )
 
+            self._update_slider_max()
             self._render_plot_state(state)
             self._refresh_canvas(value=self._n)
 
@@ -639,17 +676,52 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
             return
 
         with mplstyle.context(self.mpl_style_sheet_path):
-            half = self._window / 2.0
-            start = max(state.frame_min, value - half)
-            start = min(start, state.frame_max - self._window)
-            end = min(state.frame_max, value + half)
-            end = max(end, state.frame_min + self._window)
+            frame_min = float(state.frame_min)
+            frame_max = float(state.frame_max)
 
-            if end <= start:
-                end = start + 1.0
+            if frame_max < frame_min:
+                frame_min, frame_max = frame_max, frame_min
+
+            frame_span = frame_max - frame_min
+
+            if not np.isfinite(frame_span) or frame_span <= 0:
+                pad = 0.5
+                start = frame_min - pad
+                end = frame_max + pad
+            else:
+                window = self._effective_window(state)
+
+                if window >= frame_span:
+                    pad = self._small_span_padding(frame_span)
+                    start = frame_min - pad
+                    end = frame_max + pad
+                else:
+                    center = self._clamp(float(value), frame_min, frame_max)
+                    half = window / 2.0
+
+                    start = center - half
+                    end = center + half
+
+                    # Keep the window inside the available frame span
+                    if start < frame_min:
+                        end += frame_min - start
+                        start = frame_min
+
+                    if end > frame_max:
+                        start -= end - frame_max
+                        end = frame_max
+
+                    start = max(start, frame_min)
+                    end = min(end, frame_max)
+
+                    # Avoid visually collapsed limits for very small windows
+                    if end <= start:
+                        pad = self._small_span_padding(frame_span)
+                        start = center - pad
+                        end = center + pad
 
             self.ax.set_xlim(start, end)
-            self.vline.set_xdata([value])
+            self.vline.set_xdata([value, value])
             self.canvas.draw_idle()
 
     def set_window(self, value: int) -> None:
@@ -670,19 +742,51 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
         self._refresh_canvas(value)
 
     def _update_slider_max(self, event=None) -> None:
-        img = get_first_video_image_layer(self.viewer)
-        if img is None:
-            return
+        """
+        Update the trajectory window slider maximum.
 
+        Prefer the rendered plot state's frame bounds when available, because
+        the trajectory layer may cover fewer frames than the video layer.
+        """
+        max_window = None
+
+        if self._plot_state is not None:
+            try:
+                span = float(self._plot_state.frame_max - self._plot_state.frame_min)
+                if np.isfinite(span):
+                    max_window = max(_MIN_TRAJ_PLOT_WINDOW, int(np.ceil(span)))
+            except Exception:
+                logger.debug("Trajectory plot: failed to derive slider max from plot state", exc_info=True)
+
+        if max_window is None:
+            img = get_first_video_image_layer(self.viewer)
+            if img is None:
+                return
+
+            try:
+                n_frames = int(img.data.shape[0])
+            except Exception:
+                return
+
+            max_window = max(_MIN_TRAJ_PLOT_WINDOW, n_frames - 1)
+
+        self.slider.blockSignals(True)
         try:
-            n_frames = img.data.shape[0]
-        except Exception:
-            return
+            self.slider.setMinimum(_MIN_TRAJ_PLOT_WINDOW)
+            self.slider.setMaximum(max_window)
 
-        if n_frames < self.slider.minimum():
-            self.slider.setMaximum(self.slider.minimum())
-        else:
-            self.slider.setMaximum(n_frames - 1)
+            if self.slider.value() > max_window:
+                self.slider.setValue(max_window)
+                self._window = max_window
+                self.slider_value.setText(str(max_window))
+
+            tick_interval = max(1, max_window // 10)
+            self.slider.setTickInterval(tick_interval)
+        finally:
+            self.slider.blockSignals(False)
+
+        if self._plot_state is not None:
+            self._refresh_canvas(value=self._n)
 
     def _set_visible_keypoints(self, visible_keys: set) -> None:
         if not self._lines:

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -19,7 +19,7 @@ import pandas as pd
 from matplotlib.backends.backend_qtagg import FigureCanvas, NavigationToolbar2QT
 from napari.layers import Points
 from napari.utils.events import Event
-from qtpy.QtCore import QSize, Qt, QTimer
+from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QSlider, QVBoxLayout, QWidget
 
@@ -34,6 +34,7 @@ from napari_deeplabcut.core.layers import (
     get_first_image_layer,
     get_first_video_image_layer,
 )
+from napari_deeplabcut.ui.base_widget import OwnedTimersMixin
 from napari_deeplabcut.utils.deprecations import deprecated
 
 from .plot_models import TrajectoryPlotState, TrajectorySeries
@@ -87,7 +88,7 @@ class NapariNavigationToolbar(NavigationToolbar2QT):
                 self._actions["zoom"].setIcon(self._qicon(Path(icon_dir) / "Zoom.png"))
 
 
-class TrajectoryMatplotlibCanvas(QWidget):
+class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
     """Trajectory plot using matplotlib for keypoints (t-y plot)."""
 
     def __init__(
@@ -99,6 +100,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         get_color_mode: callable = None,
     ):
         super().__init__(parent=parent)
+        self._init_owned_timers()
 
         self.viewer = napari_viewer
         self._get_color_mode = get_color_mode or (lambda: "bodypart")
@@ -154,6 +156,7 @@ class TrajectoryMatplotlibCanvas(QWidget):
         self.frames = []
         self.keypoints = []
         self._plot_state: TrajectoryPlotState | None = None
+        self._plot_layer: Points | None = None
         self.setMinimumSize(280, 350)
 
         self.viewer.dims.events.current_step.connect(self.update_plot_range)
@@ -164,9 +167,15 @@ class TrajectoryMatplotlibCanvas(QWidget):
         )
         self._apply_axis_theme()
 
-        self.viewer.layers.events.inserted.connect(lambda event=None: self.refresh_from_viewer_layers())
-        self.viewer.layers.events.removed.connect(lambda event=None: self.refresh_from_viewer_layers())
-        self.viewer.layers.selection.events.active.connect(lambda event=None: self.refresh_from_viewer_layers())
+        self.viewer.layers.events.inserted.connect(
+            lambda event=None: self.refresh_from_viewer_layers(allow_fallback=False)
+        )
+        self.viewer.layers.events.removed.connect(
+            lambda event=None: self.refresh_from_viewer_layers(allow_fallback=False)
+        )
+        self.viewer.layers.selection.events.active.connect(
+            lambda event=None: self.refresh_from_viewer_layers(allow_fallback=False)
+        )
         self.viewer.dims.events.range.connect(self._update_slider_max)
         self._lines: dict[tuple[str, str], list] = {}
 
@@ -175,7 +184,11 @@ class TrajectoryMatplotlibCanvas(QWidget):
         # If layers already existed before this widget was created
         # (e.g. drag-and-drop load before opening the plugin), populate
         # the plot from the current viewer state on the next event-loop turn.
-        QTimer.singleShot(0, self.refresh_from_viewer_layers)
+        self._schedule_once(
+            "initial_trajectory_refresh",
+            0,
+            lambda: self.refresh_from_viewer_layers(allow_fallback=True),
+        )
 
     @property
     def df(self) -> pd.DataFrame | None:
@@ -246,12 +259,23 @@ class TrajectoryMatplotlibCanvas(QWidget):
                     line.set_visible(not show)
             self._refresh_canvas(value=self._n)
 
-    def refresh_from_viewer_layers(self) -> None:
+    def refresh_from_viewer_layers(self, *, allow_fallback: bool = False) -> None:
         """
         Refresh the trajectory plot from the current viewer state.
+
+        Parameters
+        ----------
+        allow_fallback:
+            If True, choose a sensible plottable layer even when the active layer
+            is not plottable. This is appropriate for explicit plot initialization
+            or when the user opens the trajectory plot.
+
+            If False, use only the currently active plottable Points layer. This is
+            important for selection/layer-removal events, where napari may
+            transiently set active=None while a removed layer is still present.
         """
         try:
-            self._load_dataframe()
+            self._load_dataframe(allow_fallback=allow_fallback)
         except Exception:
             logger.debug("Trajectory plot: failed to load dataframe from viewer layers", exc_info=True)
 
@@ -265,15 +289,36 @@ class TrajectoryMatplotlibCanvas(QWidget):
         except Exception:
             logger.debug("Trajectory plot: failed to sync visible lines to point selection", exc_info=True)
 
-    def _get_plot_points_layer(self) -> Points | None:
+    def _get_plot_points_layer(self, *, allow_fallback: bool = False) -> Points | None:
         """
-        Return the manager-selected Points layer for the trajectory plot.
+        Return the Points layer to use for the trajectory plot.
+
+        Automatic refreshes should not fallback, because during layer deletion
+        napari temporarily has active=None while the removed layer may still be in
+        viewer.layers. Falling back in that state can rebuild the plot from a
+        tearing-down Points layer.
+
+        Explicit initialization/showing may allow fallback.
         """
-        return self.layer_manager.suggest_plottable_traj_layer()
+        if allow_fallback:
+            layer = self.layer_manager.suggest_plottable_traj_layer()
+        else:
+            layer = getattr(self.viewer.layers.selection, "active", None)
+            if not self.layer_manager.is_plottable_traj_layer(layer):
+                return None
+
+        if not isinstance(layer, Points):
+            return None
+
+        if layer not in self.viewer.layers:
+            return None
+
+        return layer
 
     def _clear_plot(self) -> None:
         """Clear plotted trajectories and reset axes."""
         self._plot_state = None
+        self._plot_layer = None
         self._lines = {}
 
         self._reset_axes()
@@ -521,9 +566,9 @@ class TrajectoryMatplotlibCanvas(QWidget):
 
         self._apply_napari_theme()
 
-    def _load_dataframe(self, event=None) -> None:
+    def _load_dataframe(self, event=None, *, allow_fallback: bool = False) -> None:
         with mplstyle.context(self.mpl_style_sheet_path):
-            points_layer = self._get_plot_points_layer()
+            points_layer = self._get_plot_points_layer(allow_fallback=allow_fallback)
             logger.debug(f"Loading trajectory plot DataFrame from layer: {points_layer!r}")
             if points_layer is None:
                 # No plottable DLC points layer present -> clear the plot quietly.
@@ -669,9 +714,18 @@ class TrajectoryMatplotlibCanvas(QWidget):
             self._refresh_canvas(value=self._n)
 
     def _selected_line_keys_from_points_layer(self) -> set:
-        points_layer = self._get_plot_points_layer()
+        # Selection sync must be strict. If there is no active plottable Points
+        # layer, do not fallback to another managed Points layer, especially during
+        # layer removal.
+        points_layer = self._get_plot_points_layer(allow_fallback=False)
         logger.debug(f"Determining visible trajectory lines from points layer: {points_layer!r}")
+
         if points_layer is None:
+            return set()
+
+        # If the active layer is not the layer currently rendered, do not inspect
+        # its selected_data.
+        if self._plot_layer is not None and points_layer is not self._plot_layer:
             return set()
 
         selected = getattr(points_layer, "selected_data", None)

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -339,9 +339,7 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
         if allow_fallback:
             layer = self.layer_manager.suggest_plottable_traj_layer()
         else:
-            layer = getattr(self.viewer.layers.selection, "active", None)
-            if not self.layer_manager.is_plottable_traj_layer(layer):
-                return None
+            layer = self.layer_manager.active_plottable_traj_layer()
 
         if not isinstance(layer, Points):
             return None

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -743,26 +743,45 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
 
     def _update_slider_max(self, event=None) -> None:
         """
-        Keep the slider stable and backward-compatible.
+        Update the trajectory window slider maximum.
 
-        The slider value represents the requested frame window. The actual
-        displayed range is clamped in _refresh_canvas(), so short videos do not
-        need to shrink the slider maximum.
+        Prefer the rendered plot state's frame bounds when available, because
+        the trajectory layer may cover fewer frames than the video layer.
         """
+        max_window = None
+
+        if self._plot_state is not None:
+            try:
+                span = float(self._plot_state.frame_max - self._plot_state.frame_min)
+                if np.isfinite(span):
+                    max_window = max(_MIN_TRAJ_PLOT_WINDOW, int(np.ceil(span)))
+            except Exception:
+                logger.debug("Trajectory plot: failed to derive slider max from plot state", exc_info=True)
+
+        if max_window is None:
+            img = get_first_video_image_layer(self.viewer)
+            if img is None:
+                return
+
+            try:
+                n_frames = int(img.data.shape[0])
+            except Exception:
+                return
+
+            max_window = max(_MIN_TRAJ_PLOT_WINDOW, n_frames - 1)
+
         self.slider.blockSignals(True)
         try:
             self.slider.setMinimum(_MIN_TRAJ_PLOT_WINDOW)
-            self.slider.setMaximum(10000)
+            self.slider.setMaximum(max_window)
 
-            value = int(self.slider.value())
+            if self.slider.value() > max_window:
+                self.slider.setValue(max_window)
+                self._window = max_window
+                self.slider_value.setText(str(max_window))
 
-            if value < _MIN_TRAJ_PLOT_WINDOW:
-                value = _MIN_TRAJ_PLOT_WINDOW
-                self.slider.setValue(value)
-
-            self._window = value
-            self.slider_value.setText(str(value))
-            self.slider.setTickInterval(50)
+            tick_interval = max(1, max_window // 10)
+            self.slider.setTickInterval(tick_interval)
         finally:
             self.slider.blockSignals(False)
 

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -599,6 +599,7 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
                 return
 
             self._plot_state = state
+            self._plot_layer = points_layer
 
             logger.debug(
                 "Trajectory plot built: layer=%r df_shape=%s n_series=%d frame_bounds=(%s, %s)",

--- a/src/napari_deeplabcut/ui/plots/trajectory.py
+++ b/src/napari_deeplabcut/ui/plots/trajectory.py
@@ -743,45 +743,26 @@ class TrajectoryMatplotlibCanvas(QWidget, OwnedTimersMixin):
 
     def _update_slider_max(self, event=None) -> None:
         """
-        Update the trajectory window slider maximum.
+        Keep the slider stable and backward-compatible.
 
-        Prefer the rendered plot state's frame bounds when available, because
-        the trajectory layer may cover fewer frames than the video layer.
+        The slider value represents the requested frame window. The actual
+        displayed range is clamped in _refresh_canvas(), so short videos do not
+        need to shrink the slider maximum.
         """
-        max_window = None
-
-        if self._plot_state is not None:
-            try:
-                span = float(self._plot_state.frame_max - self._plot_state.frame_min)
-                if np.isfinite(span):
-                    max_window = max(_MIN_TRAJ_PLOT_WINDOW, int(np.ceil(span)))
-            except Exception:
-                logger.debug("Trajectory plot: failed to derive slider max from plot state", exc_info=True)
-
-        if max_window is None:
-            img = get_first_video_image_layer(self.viewer)
-            if img is None:
-                return
-
-            try:
-                n_frames = int(img.data.shape[0])
-            except Exception:
-                return
-
-            max_window = max(_MIN_TRAJ_PLOT_WINDOW, n_frames - 1)
-
         self.slider.blockSignals(True)
         try:
             self.slider.setMinimum(_MIN_TRAJ_PLOT_WINDOW)
-            self.slider.setMaximum(max_window)
+            self.slider.setMaximum(10000)
 
-            if self.slider.value() > max_window:
-                self.slider.setValue(max_window)
-                self._window = max_window
-                self.slider_value.setText(str(max_window))
+            value = int(self.slider.value())
 
-            tick_interval = max(1, max_window // 10)
-            self.slider.setTickInterval(tick_interval)
+            if value < _MIN_TRAJ_PLOT_WINDOW:
+                value = _MIN_TRAJ_PLOT_WINDOW
+                self.slider.setValue(value)
+
+            self._window = value
+            self.slider_value.setText(str(value))
+            self.slider.setTickInterval(50)
         finally:
             self.slider.blockSignals(False)
 

--- a/tools/launch_napari_debug.py
+++ b/tools/launch_napari_debug.py
@@ -1,4 +1,12 @@
 # tools/launch_napari_debug.py
+"""This script launches napari with aggressive logging and crash diagnostics for debugging.
+
+While the logging is far too low level for most dev work,
+when segmentation faults or Qt-related C++ errors start surfacing,
+this script can help capture the events leading up to the crash,
+and potentially the stack trace of the crash directly.
+"""
+
 from __future__ import annotations
 
 import argparse

--- a/tools/launch_napari_debug.py
+++ b/tools/launch_napari_debug.py
@@ -1,0 +1,270 @@
+# tools/launch_napari_debug.py
+from __future__ import annotations
+
+import argparse
+import faulthandler
+import logging
+import os
+import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------
+# Environment variables: set these BEFORE importing napari/Qt/vispy.
+# ---------------------------------------------------------------------
+
+os.environ.setdefault("PYTHONFAULTHANDLER", "1")
+os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+# Useful Qt/VisPy diagnostics. Keep these non-invasive by default.
+os.environ.setdefault("QT_LOGGING_RULES", "*.debug=false;qt.qpa.*=true")
+os.environ.setdefault("VISPY_LOG_LEVEL", "debug")
+
+# Optional diagnostics you can enable from CLI flags below:
+#   QT_OPENGL=software
+#   QT_FATAL_WARNINGS=1
+
+
+class Tee:
+    """Write stdout/stderr to terminal and log file at the same time."""
+
+    def __init__(self, *streams):
+        self._streams = streams
+
+    def write(self, data):
+        for stream in self._streams:
+            try:
+                stream.write(data)
+                stream.flush()
+            except Exception:
+                pass
+
+    def flush(self):
+        for stream in self._streams:
+            try:
+                stream.flush()
+            except Exception:
+                pass
+
+
+def _install_logging(log_dir: Path) -> Path:
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    log_path = log_dir / f"napari-debug-{timestamp}.log"
+
+    log_file = log_path.open("w", encoding="utf-8", buffering=1)
+
+    # Tee print output and tracebacks.
+    sys.stdout = Tee(sys.__stdout__, log_file)
+    sys.stderr = Tee(sys.__stderr__, log_file)
+
+    faulthandler.enable(file=log_file, all_threads=True)
+
+    # Periodic stack dumps help if the UI hangs before crashing.
+    faulthandler.dump_traceback_later(
+        15,
+        repeat=True,
+        file=log_file,
+    )
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s.%(msecs)03d : %(levelname)s : %(threadName)s : %(name)s : %(message)s",
+        datefmt="%H:%M:%S",
+        handlers=[
+            logging.StreamHandler(sys.stderr),
+            logging.FileHandler(log_path, mode="a", encoding="utf-8"),
+        ],
+        force=True,
+    )
+
+    for logger_name in [
+        "napari",
+        "vispy",
+        "qt",
+        "napari_deeplabcut",
+        "napari_deeplabcut.core.layer_lifecycle.manager",
+    ]:
+        logging.getLogger(logger_name).setLevel(logging.DEBUG)
+
+    def excepthook(exc_type, exc, tb):
+        logging.critical("Uncaught Python exception", exc_info=(exc_type, exc, tb))
+        traceback.print_exception(exc_type, exc, tb)
+        try:
+            log_file.flush()
+        except Exception:
+            pass
+        sys.__excepthook__(exc_type, exc, tb)
+
+    sys.excepthook = excepthook
+
+    logging.critical("Debug logging installed")
+    logging.critical("PID: %s", os.getpid())
+    logging.critical("Log file: %s", log_path)
+
+    return log_path
+
+
+def _install_qt_message_handler():
+    from qtpy.QtCore import qInstallMessageHandler
+
+    def qt_message_handler(mode, context, message):
+        logging.getLogger("qt").warning(
+            "Qt message mode=%r file=%s line=%s function=%s: %s",
+            mode,
+            getattr(context, "file", None),
+            getattr(context, "line", None),
+            getattr(context, "function", None),
+            message,
+        )
+
+    qInstallMessageHandler(qt_message_handler)
+    logging.critical("Qt message handler installed")
+
+
+def _install_viewer_event_trace(viewer):
+    """Trace layer/selection events leading up to the crash."""
+    logger = logging.getLogger("napari_deeplabcut.crash_trace")
+
+    def lname(layer):
+        if layer is None:
+            return None
+        return f"{type(layer).__name__}({getattr(layer, 'name', None)!r}, id={id(layer)})"
+
+    def log_event(label):
+        def _handler(event=None):
+            try:
+                value = getattr(event, "value", None)
+                index = getattr(event, "index", None)
+                active = viewer.layers.selection.active
+
+                logger.critical(
+                    "%s event_type=%r index=%r value=%s active=%s selected=%s layers=%s",
+                    label,
+                    getattr(event, "type", None),
+                    index,
+                    lname(value),
+                    lname(active),
+                    [lname(layer) for layer in viewer.layers.selection],
+                    [lname(layer) for layer in viewer.layers],
+                )
+            except Exception:
+                logger.exception("Failed to log viewer event: %s", label)
+
+        return _handler
+
+    layer_events = viewer.layers.events
+
+    for name in [
+        "inserting",
+        "inserted",
+        "removing",
+        "removed",
+        "reordered",
+        "changed",
+    ]:
+        if hasattr(layer_events, name):
+            getattr(layer_events, name).connect(log_event(f"layers.{name}"))
+
+    selection_events = viewer.layers.selection.events
+
+    if hasattr(selection_events, "active"):
+        selection_events.active.connect(log_event("selection.active"))
+
+    if hasattr(selection_events, "changed"):
+        selection_events.changed.connect(log_event("selection.changed"))
+
+    logger.critical("Viewer event tracing installed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Launch napari with aggressive crash/event logging for napari-deeplabcut debugging."
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Optional files/folders to open after napari starts.",
+    )
+    parser.add_argument(
+        "--log-dir",
+        default="crash-logs",
+        help="Directory where debug logs are written. Default: crash-logs",
+    )
+    parser.add_argument(
+        "--software-gl",
+        action="store_true",
+        help="Set QT_OPENGL=software before importing napari. Useful to test GPU/driver involvement.",
+    )
+    parser.add_argument(
+        "--fatal-qt-warnings",
+        action="store_true",
+        help="Set QT_FATAL_WARNINGS=1. Useful but may abort on unrelated Qt warnings.",
+    )
+    parser.add_argument(
+        "--no-event-trace",
+        action="store_true",
+        help="Disable napari layer/selection event tracing.",
+    )
+
+    args = parser.parse_args()
+
+    if args.software_gl:
+        os.environ["QT_OPENGL"] = "software"
+
+    if args.fatal_qt_warnings:
+        os.environ["QT_FATAL_WARNINGS"] = "1"
+
+    log_path = _install_logging(Path(args.log_dir))
+
+    logging.critical("Environment snapshot:")
+    for key in [
+        "PYTHONFAULTHANDLER",
+        "PYTHONUNBUFFERED",
+        "QT_OPENGL",
+        "QT_FATAL_WARNINGS",
+        "QT_LOGGING_RULES",
+        "VISPY_LOG_LEVEL",
+        "QT_API",
+    ]:
+        logging.critical("  %s=%r", key, os.environ.get(key))
+
+    # Import Qt/napari only after env/logging setup.
+    _install_qt_message_handler()
+
+    import napari
+
+    logging.critical("Imported napari from: %s", getattr(napari, "__file__", None))
+    logging.critical("napari version: %s", getattr(napari, "__version__", None))
+
+    viewer = napari.Viewer(show=True)
+
+    if not args.no_event_trace:
+        _install_viewer_event_trace(viewer)
+
+    for path in args.paths:
+        try:
+            logging.critical("Opening path via viewer.open: %s", path)
+            viewer.open(path)
+        except Exception:
+            logging.exception("Failed to open path: %s", path)
+
+    logging.critical("Starting napari event loop")
+    logging.critical("If this process crashes, inspect log file: %s", log_path)
+
+    try:
+        napari.run()
+    finally:
+        logging.critical("napari.run() returned")
+        try:
+            faulthandler.cancel_dump_traceback_later()
+        except Exception:
+            pass
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Crash description

- Load any project
- Do not select any layers other than the Points layer
- Immediately delete the layer

This produced a hard crash but did not occur if any other layer was selected prior to deletion.

## Cause

During layer deletion, selection can transiently become empty while the layer being removed is still present in viewer.layers:
```python
active=None
selected=[]
layers=[Image, Points(deleted)]
```
The trajectory plot reacted to selection/removal events by using a fallback layer selection intended for better UX (by selecting another available layer if any). 
In that transient state, fallback could select the managed Points layer currently being deleted, causing the plot to rebuild from a  layer mid-deletion. This triggered a hard crash downstream while the remaining Image layer was redrawn.

## Fix

- Added stricter active trajectory layer resolution for event-driven refreshes.
  - Kept fallback behavior only for user-induced trajectory plot (re)loading
- Prevented selection sync from inspecting a different layer than the one currently rendered
- Replaced loose QTimer.singleShot(...) usage in the trajectory widget with OwnedTimersMixin.
- Synced current active layer UI state after managed Points layer setup, covering cases where the layer is already active and no "selection changed" event emits
- Tweaked plot window to be more usable on low frame amount
- Added extra tests for new behavior

## Misc

Added tools/launch_napari_debug.py, a diagnostic launcher that enables faulthandler, Qt/VisPy logging, and layer/selection event tracing for future native crash debugging. This actually shows all errors when hard crashing instead of only a minimal report of the very last failure.