### PR TITLE
Add CI concurrency guards

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,6 +3,12 @@
 
 name: tests
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+
 on:
   push:
     branches:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -88,7 +88,8 @@ jobs:
 
     if: |
       always() && (
-        (github.event_name == 'workflow_dispatch' && inputs.force_deploy) ||
+        (github.event_name == 'workflow_dispatch' && inputs.force_deploy && github.ref == 'refs/heads/main'
+        ) ||
         (startsWith(github.ref, 'refs/tags/v') && needs.test.result == 'success')
       )
     steps:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -81,6 +81,11 @@ jobs:
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: pypi-deploy
+      cancel-in-progress: false
+
     if: |
       always() && (
         (github.event_name == 'workflow_dispatch' && inputs.force_deploy) ||


### PR DESCRIPTION
## Scope

Adds a few useful CI tweaks:

- Add cancel-in-progress concurrency guards for PRs only, preventing wasting compute on older commits
- Add concurrency without deletion to the deploy step, ensuring deploys are queued rather than run simultaneously
- Prevent force deploying from any other branch than main

This should make the CI workflow to test and deploy more efficient and safer.