### PR TITLE
Fix: cannot add point label after selecting a keypoint

### DIFF
--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -271,3 +271,74 @@ def test_current_keypoint_change_does_not_affect_other_layer(
         other_layer.properties["id"],
         other_ids,
     )
+
+
+def test_add_keypoints_out_of_sequence(store):
+    store._get_label_mode = lambda: keypoints.LabelMode.SEQUENTIAL
+
+    layer = store.layer
+    frame = store.current_step
+
+    assert len(store._keypoints) >= 3
+
+    # Start with an unannotated current frame.
+    indices = np.flatnonzero(store.current_mask).tolist()
+    layer.remove(indices)
+
+    assert not store.annotated_keypoints
+
+    # Deliberately differ from the header-defined keypoint order.
+    requested_order = [
+        store._keypoints[0],
+        store._keypoints[2],
+        store._keypoints[1],
+    ]
+
+    for offset, requested in enumerate(requested_order):
+        store.current_keypoint = requested
+        assert store.current_keypoint == requested
+
+        n_points_before = len(layer.data)
+
+        store.add((frame, offset + 1, offset + 1))
+
+        assert len(layer.data) == n_points_before + 1
+        assert requested in store.annotated_keypoints
+
+        added_index = len(layer.data) - 1
+        assert layer.properties["label"][added_index] == requested.label
+        assert layer.properties["id"][added_index] == requested.id
+
+    assert set(store.annotated_keypoints) == set(requested_order)
+
+
+def test_sequential_add_advances_from_manually_selected_keypoint(store):
+    store._get_label_mode = lambda: keypoints.LabelMode.SEQUENTIAL
+
+    layer = store.layer
+    frame = store.current_step
+
+    assert len(store._keypoints) >= 3
+
+    # Start with an unannotated current frame.
+    indices = np.flatnonzero(store.current_mask).tolist()
+    layer.remove(indices)
+
+    requested_index = 1
+    requested = store._keypoints[requested_index]
+    expected_next = store._keypoints[requested_index + 1]
+
+    # Select a keypoint that is not first in the configured sequence.
+    store.current_keypoint = requested
+    assert store.current_keypoint == requested
+
+    store.add((frame, 1, 1))
+
+    # The added point must retain the pair selected when add() began.
+    added_index = len(layer.data) - 1
+    assert layer.properties["label"][added_index] == requested.label
+    assert layer.properties["id"][added_index] == requested.id
+    assert requested in store.annotated_keypoints
+
+    # Sequential advancement starts from the manually selected pair.
+    assert store.current_keypoint == expected_next

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -342,3 +342,53 @@ def test_sequential_add_advances_from_manually_selected_keypoint(store):
 
     # Sequential advancement starts from the manually selected pair.
     assert store.current_keypoint == expected_next
+
+
+def test_sequential_add_advances_from_requested_keypoint_when_event_changes_current(
+    store,
+):
+    store._get_label_mode = lambda: keypoints.LabelMode.SEQUENTIAL
+
+    layer = store.layer
+    frame = store.current_step
+
+    assert len(store._keypoints) >= 4
+
+    # Start with no annotations on the current frame.
+    layer.remove(np.flatnonzero(store.current_mask).tolist())
+    assert not store.annotated_keypoints
+
+    requested = store._keypoints[1]
+    expected_next = store._keypoints[2]
+    event_keypoint = store._keypoints[3]
+
+    callback_calls = 0
+
+    def change_current_on_properties_event(event):
+        nonlocal callback_calls
+        callback_calls += 1
+        store.current_keypoint = event_keypoint
+
+    layer.events.properties.connect(
+        change_current_on_properties_event,
+    )
+
+    try:
+        store.current_keypoint = requested
+        store.add((frame, 1, 1))
+    finally:
+        layer.events.properties.disconnect(
+            change_current_on_properties_event,
+        )
+
+    assert callback_calls >= 1
+
+    added_index = len(layer.data) - 1
+
+    # Property assignment uses the pair captured at the start of add().
+    assert layer.properties["label"][added_index] == requested.label
+    assert layer.properties["id"][added_index] == requested.id
+
+    # Sequential advancement must also use the captured pair, not the
+    # keypoint installed by the event callback.
+    assert store.current_keypoint == expected_next

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -237,8 +237,11 @@ def test_current_keypoint_change_does_not_affect_other_layer(
     viewer,
 ):
     active_layer = store.layer
-    other_layer = active_layer.copy()
-    viewer.add_layer(other_layer)
+    other_layer = viewer.add_points(
+        active_layer.data.copy(),
+        properties={name: np.asarray(values).copy() for name, values in active_layer.properties.items()},
+        name="other_layer",
+    )
 
     other_layer.selected_data = {0}
 

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -153,3 +153,118 @@ def test_store_layer_setter_updates_layer_id_and_keypoints(store, viewer):
     assert store.layer is new_layer
     assert store.layer_id == id(new_layer)
     assert store.layer_id != old_layer_id or new_layer is old_layer
+
+
+def test_current_keypoint_change_does_not_relabel_selected_point(store):
+    layer = store.layer
+    selected_index = 0
+
+    original_label = layer.properties["label"][selected_index]
+    original_id = layer.properties["id"][selected_index]
+
+    new_keypoint = keypoints.Keypoint(
+        label="kpt_1",
+        id="animal_1",
+    )
+
+    layer.selected_data = {selected_index}
+    store.current_keypoint = new_keypoint
+
+    assert store.current_keypoint == new_keypoint
+    assert set(layer.selected_data) == {selected_index}
+
+    assert layer.properties["label"][selected_index] == original_label
+    assert layer.properties["id"][selected_index] == original_id
+
+
+def test_current_id_change_preserves_label_and_selected_point(store):
+    layer = store.layer
+    selected_index = 0
+
+    store.current_keypoint = keypoints.Keypoint(
+        label="kpt_0",
+        id="animal_0",
+    )
+
+    original_properties = {name: np.asarray(values).copy() for name, values in layer.properties.items()}
+
+    layer.selected_data = {selected_index}
+    store.current_id = "animal_1"
+
+    assert store.current_keypoint == keypoints.Keypoint(
+        label="kpt_0",
+        id="animal_1",
+    )
+    assert set(layer.selected_data) == {selected_index}
+
+    np.testing.assert_array_equal(
+        layer.properties["label"],
+        original_properties["label"],
+    )
+    np.testing.assert_array_equal(
+        layer.properties["id"],
+        original_properties["id"],
+    )
+
+
+def test_switch_to_existing_keypoint_does_not_modify_points(store):
+    layer = store.layer
+
+    existing = store.annotated_keypoints[0]
+    original_data = layer.data.copy()
+    original_labels = layer.properties["label"].copy()
+    original_ids = layer.properties["id"].copy()
+
+    layer.selected_data = {0}
+    store.current_keypoint = existing
+
+    assert store.current_keypoint == existing
+    assert set(layer.selected_data) == {0}
+
+    np.testing.assert_array_equal(layer.data, original_data)
+    np.testing.assert_array_equal(
+        layer.properties["label"],
+        original_labels,
+    )
+    np.testing.assert_array_equal(
+        layer.properties["id"],
+        original_ids,
+    )
+
+
+def test_current_keypoint_change_does_not_affect_other_layer(
+    store,
+    viewer,
+):
+    active_layer = store.layer
+    other_layer = active_layer.copy()
+    viewer.add_layer(other_layer)
+
+    other_layer.selected_data = {0}
+
+    other_current = {name: np.asarray(values).copy() for name, values in other_layer.current_properties.items()}
+    other_labels = other_layer.properties["label"].copy()
+    other_ids = other_layer.properties["id"].copy()
+
+    active_layer.selected_data = {0}
+    store.current_keypoint = keypoints.Keypoint(
+        label="kpt_1",
+        id="animal_1",
+    )
+
+    assert set(other_layer.selected_data) == {0}
+
+    for name, values in other_current.items():
+        np.testing.assert_array_equal(
+            other_layer.current_properties[name],
+            values,
+        )
+
+    np.testing.assert_array_equal(
+        other_layer.properties["label"],
+        other_labels,
+    )
+    np.testing.assert_array_equal(
+        other_layer.properties["id"],
+        other_ids,
+    )

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -141,18 +141,42 @@ class KeypointStore:
         id_: str | None = None,
     ) -> None:
         """Set defaults for the next point without editing selected points."""
-        current_properties = {name: np.asarray(values).copy() for name, values in self.layer.current_properties.items()}
+        layer = self.layer
+        before = self.current_keypoint
+
+        requested = Keypoint(
+            label=before.label if label is None else label,
+            id=before.id if id_ is None else id_,
+        )
+
+        current_properties = {name: np.asarray(values).copy() for name, values in layer.current_properties.items()}
 
         if label is not None:
-            current_properties["label"] = np.asarray([label], dtype=object)
+            current_properties["label"] = np.asarray(
+                [label],
+                dtype=object,
+            )
 
         if id_ is not None:
-            current_properties["id"] = np.asarray([id_], dtype=object)
+            current_properties["id"] = np.asarray(
+                [id_],
+                dtype=object,
+            )
 
         # Keep the current selection, but prevent Napari from applying the new
         # defaults to selected points.
-        with self.layer.block_update_properties():
-            self.layer.current_properties = current_properties
+        with layer.block_update_properties():
+            layer.current_properties = current_properties
+
+        actual = self.current_keypoint
+        if actual != requested:
+            logger.warning(
+                "Keypoint switch mismatch layer=%r frame=%d requested=%r actual=%r",
+                getattr(layer, "name", None),
+                self.current_step,
+                requested,
+                actual,
+            )
 
     def set_label_mode_getter(self, getter: Callable[[], LabelMode]):
         self._get_label_mode = getter
@@ -352,16 +376,19 @@ class KeypointStore:
         get_mode = getattr(self, "_get_label_mode", None)
         label_mode = get_mode() if callable(get_mode) else None
 
+        layer = self.layer
+        requested = self.current_keypoint
+        annotated_before = self.annotated_keypoints
+        already_annotated = requested in annotated_before
+
         changed = False
 
-        if self.current_keypoint not in self.annotated_keypoints:
-            layer = self.layer
-
+        if not already_annotated:
             # 1) append data
             layer.data = np.append(layer.data, coord, axis=0)
 
             # 2) append/align properties to match number of points
-            kp = self.current_keypoint
+            kp = requested
             n_new = coord.shape[0]
             n_total = len(layer.data)
             n_old = n_total - n_new

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -134,6 +134,26 @@ class KeypointStore:
 
         self.viewer.dims.set_current_step(0, 0)
 
+    def _set_current_keypoint_properties(
+        self,
+        *,
+        label: str | None = None,
+        id_: str | None = None,
+    ) -> None:
+        """Set defaults for the next point without editing selected points."""
+        current_properties = {name: np.asarray(values).copy() for name, values in self.layer.current_properties.items()}
+
+        if label is not None:
+            current_properties["label"] = np.asarray([label], dtype=object)
+
+        if id_ is not None:
+            current_properties["id"] = np.asarray([id_], dtype=object)
+
+        # Keep the current selection, but prevent Napari from applying the new
+        # defaults to selected points.
+        with self.layer.block_update_properties():
+            self.layer.current_properties = current_properties
+
     def set_label_mode_getter(self, getter: Callable[[], LabelMode]):
         self._get_label_mode = getter
 
@@ -256,14 +276,8 @@ class KeypointStore:
         return Keypoint(label=label, id=id_)
 
     @current_keypoint.setter
-    def current_keypoint(self, keypoint: Keypoint):
-        layer = self.layer
-        # Avoid changing the properties of a selected point
-        if not len(layer.selected_data):
-            current_properties = layer.current_properties
-            current_properties["label"] = np.asarray([keypoint.label])
-            current_properties["id"] = np.asarray([keypoint.id])
-            layer.current_properties = current_properties
+    def current_keypoint(self, keypoint: Keypoint) -> None:
+        self._set_current_keypoint_properties(label=keypoint.label, id_=keypoint.id)
 
     def next_keypoint(self, *args):
         ind = self._keypoints.index(self.current_keypoint) + 1
@@ -280,24 +294,16 @@ class KeypointStore:
         return self.layer.current_properties["label"][0]
 
     @current_label.setter
-    def current_label(self, label: str):
-        layer = self.layer
-        if not len(layer.selected_data):
-            current_properties = layer.current_properties
-            current_properties["label"] = np.asarray([label])
-            layer.current_properties = current_properties
+    def current_label(self, label: str) -> None:
+        self._set_current_keypoint_properties(label=label)
 
     @property
     def current_id(self) -> str:
         return self.layer.current_properties["id"][0]
 
     @current_id.setter
-    def current_id(self, id_: str):
-        layer = self.layer
-        if not len(layer.selected_data):
-            current_properties = layer.current_properties
-            current_properties["id"] = np.asarray([id_])
-            layer.current_properties = current_properties
+    def current_id(self, id_: str) -> None:
+        self._set_current_keypoint_properties(id_=id_)
 
     def _advance_step(self, event):
         ind = (self.current_step + 1) % self.n_steps

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -303,10 +303,26 @@ class KeypointStore:
     def current_keypoint(self, keypoint: Keypoint) -> None:
         self._set_current_keypoint_properties(label=keypoint.label, id_=keypoint.id)
 
+    def _next_keypoint_after(self, keypoint: Keypoint) -> Keypoint | None:
+        try:
+            index = self._keypoints.index(keypoint)
+        except ValueError:
+            logger.warning(
+                "Cannot advance from keypoint outside configured sequence: %r",
+                keypoint,
+            )
+            return None
+
+        next_index = index + 1
+        if next_index >= len(self._keypoints):
+            return None
+
+        return self._keypoints[next_index]
+
     def next_keypoint(self, *args):
-        ind = self._keypoints.index(self.current_keypoint) + 1
-        if ind <= len(self._keypoints) - 1:
-            self.current_keypoint = self._keypoints[ind]
+        next_kp = self._next_keypoint_after(self.current_keypoint)
+        if next_kp is not None:
+            self.current_keypoint = next_kp
 
     def prev_keypoint(self, *args):
         ind = self._keypoints.index(self.current_keypoint) - 1
@@ -420,8 +436,7 @@ class KeypointStore:
             changed = True
 
         elif label_mode is LabelMode.QUICK:
-            layer = self.layer
-            ind = self.annotated_keypoints.index(self.current_keypoint)
+            ind = annotated_before.index(requested)
             data = layer.data
             data[np.flatnonzero(self.current_mask)[ind]] = coord.squeeze()
             layer.data = data
@@ -432,9 +447,10 @@ class KeypointStore:
         if label_mode is LabelMode.LOOP:
             if changed:
                 self.layer.events.query_next_frame()
-        else:
-            if changed:
-                self.next_keypoint()
+        elif changed:
+            next_kp = self._next_keypoint_after(requested)
+            if next_kp is not None:
+                self.current_keypoint = next_kp
 
 
 @deprecated(details="Temporary compat shim, remove once KeypointStore.add is properly integrated.")


### PR DESCRIPTION
This PR fixes keypoint switching and out-of-order annotation when Napari events occur during an add.
Closes #233

### Fix

- Update next point properties inside napari's `block_update_properties()` so selected points are not relabeled and remain selected
- Captures the requested `(bodypart, individual)` pair once at the start of `add()`, such that duplicate detection, property assignment, and QUICK-mode lookup use a consistent keypoint
- Resolves the backing layer once per operation without rebinding it

### Why

Previously, `add()` read `current_keypoint` multiple times. Updating layer data could trigger events that changed the current properties mid-operation, causing the new point to receive an incorrect pair or leaving the store in an inconsistent sequence state.

### Tests

Regression tests added:

- Switching the complete `(bodypart, individual)` pair does not relabel or deselect an existing point
- Changing only the individual preserves the bodypart and existing annotations
- Switching to an already annotated keypoint does not modify point data or properties
- Changing the current keypoint does not affect another independently managed Points layer