### PR TITLE
Fix napari 0.9+ import failure and apply point size to new keypoints

### DIFF
--- a/src/napari_deeplabcut/__init__.py
+++ b/src/napari_deeplabcut/__init__.py
@@ -35,9 +35,6 @@ except ImportError:  # pragma: no cover
 
 # ---- Warnings & logging setup ------------------------------------------------
 
-# FIXME: Circumvent the need to access window.qt_viewer
-warnings.filterwarnings("ignore", category=FutureWarning)
-
 import re  # noqa: E402
 
 # Suppress RuntimeWarnings caused by NaN values in dataframe

--- a/src/napari_deeplabcut/_tests/compat/conftest.py
+++ b/src/napari_deeplabcut/_tests/compat/conftest.py
@@ -84,7 +84,7 @@ def ui_env(qtbot):
     qtbot.addWidget(point_controls)
 
     dock_layer_controls = SimpleNamespace(widget=lambda: SimpleNamespace(widgets={layer: point_controls}))
-    viewer = SimpleNamespace(window=SimpleNamespace(qt_viewer=SimpleNamespace(dockLayerControls=dock_layer_controls)))
+    viewer = SimpleNamespace(window=SimpleNamespace(_qt_viewer=SimpleNamespace(dockLayerControls=dock_layer_controls)))
 
     layer_obj = SimpleNamespace(metadata={"colormap_name": "magma"})
 

--- a/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
@@ -58,8 +58,13 @@ def test_apply_points_layer_ui_tweaks_smoke_real_viewer(viewer, qtbot, dropdown_
     assert point_controls._face_color_control.face_color_label.isHidden()
     assert point_controls._border_color_control.border_color_edit.isHidden()
     assert point_controls._border_color_control.border_color_edit_label.isHidden()
-    assert point_controls._out_slice_checkbox_control.out_of_slice_checkbox.isHidden()
-    assert point_controls._out_slice_checkbox_control.out_of_slice_checkbox_label.isHidden()
+    # napari 0.9 dropped the out-of-slice checkbox entirely, so there is nothing to
+    # hide there. Tolerate its absence, but still assert it is hidden where it exists.
+    out_slice_control = getattr(point_controls, "_out_slice_checkbox_control", None)
+    if out_slice_control is not None:
+        assert out_slice_control.out_of_slice_checkbox.isHidden()
+        assert out_slice_control.out_of_slice_checkbox_label.isHidden()
+
     assert point_controls._current_size_slider_control.size_slider.isHidden()
     assert point_controls._current_size_slider_control.size_slider_label.isHidden()
 

--- a/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
@@ -157,7 +157,7 @@ def test_apply_points_layer_ui_tweaks_real_dropdown(qtbot):
     qtbot.addWidget(point_controls)
 
     dock_layer_controls = SimpleNamespace(widget=lambda: SimpleNamespace(widgets={layer: point_controls}))
-    viewer = SimpleNamespace(window=SimpleNamespace(qt_viewer=SimpleNamespace(dockLayerControls=dock_layer_controls)))
+    viewer = SimpleNamespace(window=SimpleNamespace(_qt_viewer=SimpleNamespace(dockLayerControls=dock_layer_controls)))
 
     selector = apply_points_layer_ui_tweaks(viewer, layer, dropdown_cls=DropdownMenu, plt_module=plt)
     assert selector is not None

--- a/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
@@ -14,7 +14,7 @@ from napari_deeplabcut.napari_compat import (
 
 
 def _get_point_controls(viewer, layer):
-    return viewer.window.qt_viewer.dockLayerControls.widget().widgets[layer]
+    return viewer.window._qt_viewer.dockLayerControls.widget().widgets[layer]
 
 
 def test_apply_points_layer_ui_tweaks_smoke_real_viewer(viewer, qtbot, dropdown_cls, plt_module):
@@ -33,7 +33,7 @@ def test_apply_points_layer_ui_tweaks_smoke_real_viewer(viewer, qtbot, dropdown_
     viewer.layers.selection.active = layer
 
     qtbot.waitUntil(
-        lambda: layer in viewer.window.qt_viewer.dockLayerControls.widget().widgets,
+        lambda: layer in viewer.window._qt_viewer.dockLayerControls.widget().widgets,
         timeout=3000,
     )
 

--- a/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_integration.py
@@ -60,6 +60,8 @@ def test_apply_points_layer_ui_tweaks_smoke_real_viewer(viewer, qtbot, dropdown_
     assert point_controls._border_color_control.border_color_edit_label.isHidden()
     assert point_controls._out_slice_checkbox_control.out_of_slice_checkbox.isHidden()
     assert point_controls._out_slice_checkbox_control.out_of_slice_checkbox_label.isHidden()
+    assert point_controls._current_size_slider_control.size_slider.isHidden()
+    assert point_controls._current_size_slider_control.size_slider_label.isHidden()
 
 
 def test_install_add_wrapper_smoke_real_points_layer(viewer):

--- a/src/napari_deeplabcut/_tests/compat/test_compat_internal.py
+++ b/src/napari_deeplabcut/_tests/compat/test_compat_internal.py
@@ -18,7 +18,7 @@ from napari_deeplabcut.napari_compat.points_layer import make_paste_data
 
 
 def test_apply_points_layer_ui_tweaks_returns_none_when_viewer_shape_is_missing():
-    viewer = SimpleNamespace(window=SimpleNamespace(qt_viewer=SimpleNamespace()))
+    viewer = SimpleNamespace(window=SimpleNamespace(_qt_viewer=SimpleNamespace()))
     layer = SimpleNamespace(metadata={})
 
     result = apply_points_layer_ui_tweaks(

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -1,8 +1,11 @@
 # src/napari_deeplabcut/_tests/conftest.py
+from __future__ import annotations
+
 import json
 import logging
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import cv2
 import numpy as np
@@ -16,6 +19,13 @@ from napari_deeplabcut.config.models import DLCHeaderModel
 from napari_deeplabcut.config.settings import set_auto_open_keypoint_controls
 from napari_deeplabcut.core import io as io
 from napari_deeplabcut.core import keypoints
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from napari.layers import Points
+
+    from napari_deeplabcut._widgets import KeypointControls
 
 # os.environ["NAPARI_DLC_HIDE_TUTORIAL"] = "True" # no longer on by default
 
@@ -96,7 +106,11 @@ def only_deeplabcut_debug_logs():
             logger.setLevel(level)
 
 
-def make_real_header(bodyparts=("bodypart1", "bodypart2"), individuals=("",), scorer="S"):
+def make_real_header(
+    bodyparts: tuple[str, ...] = ("bodypart1", "bodypart2"),
+    individuals: tuple[str, ...] = ("",),
+    scorer: str = "S",
+) -> DLCHeaderModel:
     cols = pd.MultiIndex.from_product(
         [[scorer], list(individuals), list(bodyparts), ["x", "y"]],
         names=["scorer", "individuals", "bodyparts", "coords"],
@@ -105,7 +119,7 @@ def make_real_header(bodyparts=("bodypart1", "bodypart2"), individuals=("",), sc
 
 
 @pytest.fixture
-def make_real_header_factory():
+def make_real_header_factory() -> Callable[..., DLCHeaderModel]:
     return make_real_header
 
 
@@ -140,7 +154,7 @@ def viewer(make_napari_viewer_proxy):
 
 
 @pytest.fixture
-def keypoint_controls_and_dock(viewer):
+def keypoint_controls_and_dock(viewer) -> tuple[KeypointControls, QDockWidget]:
     dock, controls = viewer.window.add_plugin_dock_widget(
         "napari-deeplabcut",
         "Keypoint controls",
@@ -149,19 +163,23 @@ def keypoint_controls_and_dock(viewer):
 
 
 @pytest.fixture
-def keypoint_controls(keypoint_controls_and_dock):
+def keypoint_controls(
+    keypoint_controls_and_dock: tuple[KeypointControls, QDockWidget],
+) -> KeypointControls:
     controls, _dock = keypoint_controls_and_dock
     return controls
 
 
 @pytest.fixture
-def keypoint_controls_dock(keypoint_controls_and_dock):
+def keypoint_controls_dock(
+    keypoint_controls_and_dock: tuple[KeypointControls, QDockWidget],
+) -> QDockWidget:
     _controls, dock = keypoint_controls_and_dock
     return dock
 
 
 @pytest.fixture
-def fake_keypoints():
+def fake_keypoints() -> pd.DataFrame:
     n_rows = 10
     n_animals = 2
     n_kpts = 3
@@ -180,7 +198,7 @@ def fake_keypoints():
 
 
 @pytest.fixture
-def points(tmp_path_factory, viewer, fake_keypoints):
+def points(tmp_path_factory, viewer, fake_keypoints: pd.DataFrame) -> Points:
     output_path = str(tmp_path_factory.mktemp("folder") / "fake_data.h5")
     fake_keypoints.to_hdf(output_path, key="data")
     layer = viewer.open(output_path, plugin="napari-deeplabcut")[0]
@@ -221,7 +239,7 @@ class DummyViewerForStore:
 
 
 @pytest.fixture
-def store(points):
+def store(points: Points) -> keypoints.KeypointStore:
     try:
         data = np.asarray(points.data)
         nsteps = int(np.nanmax(data[:, 0])) + 1 if data.size else 1
@@ -240,7 +258,11 @@ def store(points):
 
 
 @pytest.fixture
-def single_animal_store(tmp_path_factory, viewer, fake_keypoints):
+def single_animal_store(
+    tmp_path_factory,
+    viewer,
+    fake_keypoints: pd.DataFrame,
+) -> keypoints.KeypointStore:
     # Keep only columns for one animal
     df = fake_keypoints.xs("animal_0", level="individuals", axis=1)
     # Now df has levels: scorer, bodyparts, coords

--- a/src/napari_deeplabcut/_tests/core/test_keypoints.py
+++ b/src/napari_deeplabcut/_tests/core/test_keypoints.py
@@ -50,17 +50,6 @@ def test_store_keypoints(store, fake_keypoints):
     store.next_keypoint()
 
 
-@pytest.mark.usefixtures("qtbot")
-def test_point_resize(qtbot, viewer, points):
-    viewer.layers.selection.add(points)
-    layer = viewer.layers[0]
-    controls = keypoints.QtPointsControls(layer)
-    qtbot.addWidget(controls)
-    new_size = 10
-    controls.changeCurrentSize(new_size)
-    np.testing.assert_array_equal(points.size, new_size)
-
-
 def test_add_unannotated(store):
     # LOOP mode: after a successful add/move, the viewer advances to the next frame
     store._get_label_mode = lambda: keypoints.LabelMode.LOOP

--- a/src/napari_deeplabcut/_tests/core/test_layers.py
+++ b/src/napari_deeplabcut/_tests/core/test_layers.py
@@ -17,7 +17,7 @@ def test_set_uniform_point_size_resizes_all_existing_points() -> None:
     layer.selected_data = {0}
     original_current_size = float(layer.current_size)
 
-    set_uniform_point_size(layer, 10)
+    set_uniform_point_size(layer, 10, update_new=False)
 
     assert len(layer.size) == 3
     np.testing.assert_array_equal(

--- a/src/napari_deeplabcut/_tests/core/test_layers.py
+++ b/src/napari_deeplabcut/_tests/core/test_layers.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+from napari.layers import Points
+
+from napari_deeplabcut.core.layers import set_uniform_point_size
+
+
+def test_set_uniform_point_size_resizes_all_points_regardless_of_selection() -> None:
+    """Uniform resizing must not be limited to the selected points.
+
+    DeepLabCut treats point size as a layer-wide display setting. This protects
+    that behavior from regressing to napari's selection-scoped current-size
+    semantics.
+    """
+    n_points = 3
+    layer = Points(
+        np.zeros((n_points, 2)),
+        size=[4, 6, 8],
+    )
+    layer.selected_data = {0}
+
+    set_uniform_point_size(layer, 10)
+
+    assert len(layer.size) == n_points
+    np.testing.assert_array_equal(
+        layer.size,
+        np.full(n_points, 10.0),
+    )

--- a/src/napari_deeplabcut/_tests/core/test_layers.py
+++ b/src/napari_deeplabcut/_tests/core/test_layers.py
@@ -1,3 +1,5 @@
+# src/napari_deeplabcut/_tests/core/test_layers.py
+
 from __future__ import annotations
 
 import numpy as np
@@ -6,24 +8,43 @@ from napari.layers import Points
 from napari_deeplabcut.core.layers import set_uniform_point_size
 
 
-def test_set_uniform_point_size_resizes_all_points_regardless_of_selection() -> None:
-    """Uniform resizing must not be limited to the selected points.
-
-    DeepLabCut treats point size as a layer-wide display setting. This protects
-    that behavior from regressing to napari's selection-scoped current-size
-    semantics.
-    """
-    n_points = 3
+def test_set_uniform_point_size_resizes_all_existing_points() -> None:
+    """Existing points are resized uniformly regardless of selection."""
     layer = Points(
-        np.zeros((n_points, 2)),
+        np.zeros((3, 2), dtype=float),
+        size=[4, 6, 8],
+    )
+    layer.selected_data = {0}
+    original_current_size = float(layer.current_size)
+
+    set_uniform_point_size(layer, 10)
+
+    assert len(layer.size) == 3
+    np.testing.assert_array_equal(
+        layer.size,
+        np.full(3, 10.0),
+    )
+    assert float(layer.current_size) == original_current_size
+
+
+def test_set_uniform_point_size_updates_default_for_new_points() -> None:
+    """With update_new enabled, subsequently added points inherit the size."""
+    layer = Points(
+        np.zeros((3, 2), dtype=float),
         size=[4, 6, 8],
     )
     layer.selected_data = {0}
 
-    set_uniform_point_size(layer, 10)
+    set_uniform_point_size(layer, 10, update_new=True)
 
-    assert len(layer.size) == n_points
+    assert len(layer.size) == 3
     np.testing.assert_array_equal(
         layer.size,
-        np.full(n_points, 10.0),
+        np.full(3, 10.0),
     )
+    assert float(layer.current_size) == 10.0
+
+    layer.add([1.0, 1.0])
+
+    assert len(layer.size) == 4
+    assert float(layer.size[-1]) == 10.0

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -16,6 +16,12 @@ def test_point_added_after_panel_size_change_inherits_size(
     qtbot,
 ) -> None:
     """The panel-selected size is inherited by points added through the store."""
+    viewer.add_image(
+        np.zeros((2, 64, 64), dtype=np.uint8),
+        name="frames",
+        metadata={"paths": ["frame0.png", "frame1.png"]},
+    )
+
     header = make_real_header_factory(individuals=("",))
     md = populate_keypoint_layer_properties(
         header,
@@ -47,6 +53,8 @@ def test_point_added_after_panel_size_change_inherits_size(
     )
 
     viewer.dims.set_point(0, 1)
+    qtbot.waitUntil(lambda: store.current_step == 1, timeout=1_000)
+
     store.current_keypoint = keypoints.Keypoint(label="head", id="")
 
     n_before = len(layer.data)

--- a/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_points_layers.py
@@ -4,7 +4,57 @@ import numpy as np
 import pytest
 from napari.layers import Points
 
+from napari_deeplabcut.core import keypoints
 from napari_deeplabcut.core.layers import PointsInteractionObserver, populate_keypoint_layer_properties
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_point_added_after_panel_size_change_inherits_size(
+    viewer,
+    keypoint_controls,
+    make_real_header_factory,
+    qtbot,
+) -> None:
+    """The panel-selected size is inherited by points added through the store."""
+    header = make_real_header_factory(individuals=("",))
+    md = populate_keypoint_layer_properties(
+        header,
+        labels=["head"],
+        ids=[""],
+        likelihood=np.array([1.0], dtype=float),
+        paths=["frame0.png", "frame1.png"],
+        colormap="viridis",
+    )
+    layer = viewer.add_points(
+        np.array([[0.0, 10.0, 20.0]], dtype=float),
+        **md,
+    )
+    viewer.layers.selection.active = layer
+
+    qtbot.waitUntil(
+        lambda: keypoint_controls.get_layer_store(layer) is not None,
+        timeout=5_000,
+    )
+    store = keypoint_controls.get_layer_store(layer)
+    assert store is not None
+
+    keypoint_controls._on_active_points_size_changed(12)
+
+    assert float(layer.current_size) == 12.0
+    np.testing.assert_array_equal(
+        layer.size,
+        np.full(len(layer.data), 12.0),
+    )
+
+    viewer.dims.set_point(0, 1)
+    store.current_keypoint = keypoints.Keypoint(label="head", id="")
+
+    n_before = len(layer.data)
+    store.add(np.array([1.0, 30.0, 40.0], dtype=float))
+
+    assert len(layer.data) == n_before + 1
+    assert len(layer.size) == len(layer.data)
+    assert float(layer.size[-1]) == 12.0
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
+++ b/src/napari_deeplabcut/_tests/e2e/test_routing_and_provenance.py
@@ -690,17 +690,16 @@ def test_projectless_folder_save_can_associate_with_config_and_coerce_paths_to_d
     # E2E readback contract:
     # the plugin should be able to reopen the saved H5 and recover the same
     # plugin-visible annotation.
-    viewer.layers.clear()
-    qtbot.wait(200)
+    existing = set(viewer.layers)
 
     viewer.open(str(expected_h5), plugin="napari-deeplabcut")
     qtbot.waitUntil(
-        lambda: any(isinstance(ly, Points) for ly in viewer.layers),
+        lambda: any(isinstance(ly, Points) and ly not in existing for ly in viewer.layers),
         timeout=10_000,
     )
     qtbot.wait(200)
 
-    reopened = next(ly for ly in viewer.layers if isinstance(ly, Points))
+    reopened = next(ly for ly in viewer.layers if isinstance(ly, Points) and ly not in existing)
 
     _assert_points_layer_has_label_xy(
         reopened,

--- a/src/napari_deeplabcut/_tests/test_point_size_sync.py
+++ b/src/napari_deeplabcut/_tests/test_point_size_sync.py
@@ -1,0 +1,132 @@
+"""Point-size synchronisation between the controls widget and a Points layer.
+
+Covers the widget-side logic that decides *whether* to apply a size:
+- reading the value lives in _tests/core/test_config_sync.py
+- applying it to a layer lives in _tests/core/test_layers.py
+"""
+
+# src/napari_deeplabcut/_tests/test_point_size_sync.py
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pytest
+from napari.layers import Points
+
+from napari_deeplabcut import _widgets
+
+
+def _stub_config(monkeypatch, controls, tmp_path, size):
+    """Resolve a config path for any layer and make it report `size`."""
+    monkeypatch.setattr(
+        controls,
+        "_resolve_config_path_for_layer",
+        lambda _layer: tmp_path / "config.yaml",
+    )
+    monkeypatch.setattr(
+        _widgets,
+        "load_point_size_from_config",
+        lambda _path: size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _maybe_initialize_layer_point_size_from_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_config_point_size_seeds_fresh_layer(monkeypatch, keypoint_controls, tmp_path):
+    """A layer still at a default-ish size is seeded from config."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=6)
+    _stub_config(monkeypatch, keypoint_controls, tmp_path, 14)
+
+    keypoint_controls._maybe_initialize_layer_point_size_from_config(layer)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 14.0))
+    assert float(layer.current_size) == 14.0
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_config_point_size_does_not_clobber_deliberate_size(monkeypatch, keypoint_controls, tmp_path):
+    """An existing size above the conservative threshold is left alone."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=20)
+    _stub_config(monkeypatch, keypoint_controls, tmp_path, 14)
+
+    keypoint_controls._maybe_initialize_layer_point_size_from_config(layer)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 20.0))
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_config_point_size_honours_current_size_on_empty_layer(monkeypatch, keypoint_controls, tmp_path):
+    """On an empty layer, current_size is the only real signal.
+
+    get_uniform_point_size() falls back to its own default when there are no
+    points, so checking it alone would silently overwrite a deliberately chosen
+    size on a layer that has not been annotated yet.
+    """
+    layer = Points(np.empty((0, 2), dtype=float))
+    layer.current_size = 20
+    _stub_config(monkeypatch, keypoint_controls, tmp_path, 14)
+
+    keypoint_controls._maybe_initialize_layer_point_size_from_config(layer)
+
+    assert float(layer.current_size) == 20.0
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_config_point_size_rejects_invalid_value(monkeypatch, keypoint_controls, tmp_path, caplog):
+    """A bad config value is reported and leaves the layer untouched."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=6)
+    _stub_config(monkeypatch, keypoint_controls, tmp_path, -5)
+
+    with caplog.at_level(logging.WARNING):
+        keypoint_controls._maybe_initialize_layer_point_size_from_config(layer)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 6.0))
+    assert float(layer.current_size) == 6.0
+    assert "Invalid point size" in caplog.text
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_config_point_size_skipped_when_config_has_no_value(monkeypatch, keypoint_controls, tmp_path):
+    """No dotsize in the config means the layer keeps whatever it had."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=6)
+    _stub_config(monkeypatch, keypoint_controls, tmp_path, None)
+
+    keypoint_controls._maybe_initialize_layer_point_size_from_config(layer)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 6.0))
+
+
+# ---------------------------------------------------------------------------
+# _on_active_points_size_changed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_panel_size_change_applies_to_layer(monkeypatch, keypoint_controls):
+    """The panel value reaches both existing points and the new-point default."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=6)
+    monkeypatch.setattr(keypoint_controls, "_current_dlc_points_layer", lambda: layer)
+
+    keypoint_controls._on_active_points_size_changed(12)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 12.0))
+    assert float(layer.current_size) == 12.0
+
+
+@pytest.mark.usefixtures("qtbot")
+def test_panel_size_change_rejects_invalid_value(monkeypatch, keypoint_controls, caplog):
+    """An invalid size is ignored rather than propagating out of the Qt slot."""
+    layer = Points(np.zeros((3, 2), dtype=float), size=6)
+    monkeypatch.setattr(keypoint_controls, "_current_dlc_points_layer", lambda: layer)
+
+    with caplog.at_level(logging.WARNING):
+        keypoint_controls._on_active_points_size_changed(-5)
+
+    np.testing.assert_array_equal(layer.size, np.full(3, 6.0))
+    assert "Ignoring invalid point size" in caplog.text

--- a/src/napari_deeplabcut/_tests/test_point_size_sync.py
+++ b/src/napari_deeplabcut/_tests/test_point_size_sync.py
@@ -88,7 +88,7 @@ def test_config_point_size_rejects_invalid_value(monkeypatch, keypoint_controls,
 
     np.testing.assert_array_equal(layer.size, np.full(3, 6.0))
     assert float(layer.current_size) == 6.0
-    assert "Invalid point size" in caplog.text
+    assert "invalid point size" in caplog.text
 
 
 @pytest.mark.usefixtures("qtbot")

--- a/src/napari_deeplabcut/_tests/test_widgets.py
+++ b/src/napari_deeplabcut/_tests/test_widgets.py
@@ -25,17 +25,6 @@ from napari_deeplabcut.ui.plots.trajectory import TrajectoryMatplotlibCanvas
 from .conftest import force_show
 
 
-def test_guess_continuous():
-    import numpy as np
-    from napari.layers.utils import color_manager
-
-    # Patch is applied during KeypointControls init (or import-time depending on your setup)
-    # Expect float -> continuous
-    assert color_manager.guess_continuous(np.array([0.0]))
-    # Expect object/categorical -> NOT continuous
-    assert not color_manager.guess_continuous(np.array(["a", "b"], dtype=object))
-
-
 @pytest.mark.usefixtures("qtbot")
 def test_keypoint_controls(keypoint_controls):
     controls = keypoint_controls

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -989,7 +989,11 @@ class KeypointControls(ViewerSingletonWidget):
         if layer is None:
             return
 
-        set_uniform_point_size(layer, size, update_new=True)
+        try:
+            set_uniform_point_size(layer, size, update_new=True)
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid point size %r", size)
+            return
         mark_layer_presentation_changed(layer)
 
     def _commit_active_points_size_to_config(self, size: int) -> None:
@@ -1021,15 +1025,22 @@ class KeypointControls(ViewerSingletonWidget):
         if config_size is None:
             return
 
-        current_size = get_uniform_point_size(layer)
+        existing_size = get_uniform_point_size(layer)
+        default_size = float(getattr(layer, "current_size", existing_size))
 
-        # Conservative initialization
-        if current_size <= 8:
-            try:
-                set_uniform_point_size(layer, config_size, update_new=True)
-                mark_layer_presentation_changed(layer)
-            except Exception:
-                logger.debug("Could not initialize layer point size from config", exc_info=True)
+        # Conservative: only use config if neither hints show a deliberate size
+        if max(existing_size, default_size) > 8:
+            return
+        try:
+            set_uniform_point_size(layer, config_size, update_new=True)
+        except (ValueError, TypeError):
+            logger.warning("Ignoring invalid point size in config: %r", config_size)
+            self.viewer.status = f"Invalid point size in config {config_size!r}"
+            return
+        except Exception:
+            logger.debug("Could not initialize layer point size from config", exc_info=True)
+            return
+        mark_layer_presentation_changed(layer)
 
     def _connect_layer_status_events(self, layer: Points) -> None:
         """

--- a/src/napari_deeplabcut/_widgets.py
+++ b/src/napari_deeplabcut/_widgets.py
@@ -989,7 +989,7 @@ class KeypointControls(ViewerSingletonWidget):
         if layer is None:
             return
 
-        set_uniform_point_size(layer, size)
+        set_uniform_point_size(layer, size, update_new=True)
         mark_layer_presentation_changed(layer)
 
     def _commit_active_points_size_to_config(self, size: int) -> None:
@@ -1026,7 +1026,7 @@ class KeypointControls(ViewerSingletonWidget):
         # Conservative initialization
         if current_size <= 8:
             try:
-                set_uniform_point_size(layer, config_size)
+                set_uniform_point_size(layer, config_size, update_new=True)
                 mark_layer_presentation_changed(layer)
             except Exception:
                 logger.debug("Could not initialize layer point size from config", exc_info=True)

--- a/src/napari_deeplabcut/core/keypoints.py
+++ b/src/napari_deeplabcut/core/keypoints.py
@@ -7,10 +7,7 @@ from enum import auto
 
 import numpy as np
 from matplotlib import colormaps as mpl_colormaps
-from napari._qt.layer_controls.qt_points_controls import QtPointsControls
 from napari.layers import Points
-from napari.layers.points._points_constants import SYMBOL_TRANSLATION_INVERTED
-from napari.layers.points._points_utils import coerce_symbols
 from napari.utils import colormaps
 from pydantic import ValidationError
 from scipy.spatial import cKDTree
@@ -25,29 +22,6 @@ logger = logging.getLogger(__name__)
 
 class LayerUnavailableError(RuntimeError):
     """Raised when a KeypointStore can no longer resolve its backing layer."""
-
-
-# Monkeypatch the point size slider
-def _change_size(self, value):
-    """Resize all points at once regardless of the current selection."""
-    self.layer._current_size = value
-    if self.layer._update_properties:
-        self.layer.size = (self.layer.size > 0) * value
-        self.layer.refresh()
-        self.layer.events.size()
-
-
-def _change_symbol(self, text):
-    symbol = coerce_symbols(np.array([SYMBOL_TRANSLATION_INVERTED[text]]))[0]
-    self.layer._current_symbol = symbol
-    if self.layer._update_properties:
-        self.layer.symbol = symbol
-        self.layer.events.symbol()
-    self.layer.events.current_symbol()
-
-
-QtPointsControls.changeCurrentSize = _change_size
-QtPointsControls.changeCurrentSymbol = _change_symbol
 
 
 @deprecated(details="Unused currently, should be removed.")

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -266,7 +266,7 @@ def get_uniform_point_size(layer: Points, *, default: int = 6) -> int:
 
 def set_uniform_point_size(
     layer: Points,
-    size: int,
+    size: float,
     *,
     update_new: bool = True,
 ) -> None:

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -278,14 +278,16 @@ def set_uniform_point_size(
         update_new: Whether points added afterward should use size.
     """
     size = float(size)
-    layer.size = size
+    if size < 0:
+        raise ValueError("Point size must be positive")
     if update_new:
         # napari's current_size setter re-applies size to the selected subset and
-        # emits events.size. layer.size above already covered every point, so that
+        # emits events.size. layer.size below already covers every point, so that
         # emission is redundant and napari's own size setter emits nothing, so
         # blocking it keeps event behaviour identical to a plain resize.
         with layer.events.size.blocker():
             layer.current_size = size
+    layer.size = size
 
 
 def infer_frame_count(

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -280,7 +280,12 @@ def set_uniform_point_size(
     size = float(size)
     layer.size = size
     if update_new:
-        layer.current_size = size
+        # napari's current_size setter re-applies size to the selected subset and
+        # emits events.size. layer.size above already covered every point, so that
+        # emission is redundant and napari's own size setter emits nothing, so
+        # blocking it keeps event behaviour identical to a plain resize.
+        with layer.events.size.blocker():
+            layer.current_size = size
 
 
 def infer_frame_count(

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -264,9 +264,23 @@ def get_uniform_point_size(layer: Points, *, default: int = 6) -> int:
             return default
 
 
-def set_uniform_point_size(layer: Points, size: int) -> None:
-    # Scalar assignment keeps it lightweight and applies uniformly.
-    layer.size = float(size)
+def set_uniform_point_size(
+    layer: Points,
+    size: int,
+    *,
+    update_new: bool = False,
+) -> None:
+    """Set a uniform size for existing points.
+
+    Args:
+        layer: Points layer to update.
+        size: Size to apply to all existing points.
+        update_new: Whether points added afterward should use size.
+    """
+    size = float(size)
+    layer.size = size
+    if update_new:
+        layer.current_size = size
 
 
 def infer_frame_count(

--- a/src/napari_deeplabcut/core/layers.py
+++ b/src/napari_deeplabcut/core/layers.py
@@ -268,7 +268,7 @@ def set_uniform_point_size(
     layer: Points,
     size: int,
     *,
-    update_new: bool = False,
+    update_new: bool = True,
 ) -> None:
     """Set a uniform size for existing points.
 

--- a/src/napari_deeplabcut/napari_compat/points_layer.py
+++ b/src/napari_deeplabcut/napari_compat/points_layer.py
@@ -330,7 +330,7 @@ def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> 
         The created colormap selector, or None if unavailable.
     """
     try:
-        controls = viewer.window.qt_viewer.dockLayerControls
+        controls = viewer.window._qt_viewer.dockLayerControls
         point_controls = controls.widget().widgets[layer]
     except Exception:
         logger.debug("Failed to resolve point controls for layer UI tweaks", exc_info=True)

--- a/src/napari_deeplabcut/napari_compat/points_layer.py
+++ b/src/napari_deeplabcut/napari_compat/points_layer.py
@@ -343,6 +343,8 @@ def apply_points_layer_ui_tweaks(viewer, layer, *, dropdown_cls, plt_module) -> 
         ("_border_color_control", "border_color_edit_label"),
         ("_out_slice_checkbox_control", "out_of_slice_checkbox"),
         ("_out_slice_checkbox_control", "out_of_slice_checkbox_label"),
+        ("_current_size_slider_control", "size_slider"),
+        ("_current_size_slider_control", "size_slider_label"),
     ]
 
     for parent_attr, widget_attr in widgets_to_hide:


### PR DESCRIPTION
## Scope

Removes the dead `QtPointsControls` monkeypatch and fixes a related point size bug on new annotations.

## Motivation

`core/keypoints.py` imported `SYMBOL_TRANSLATION_INVERTED` at module level. napari removed it in 0.9.0, so `import napari_deeplabcut` failed outright (#235). DeepLabCut's `[gui]` extra pins `napari-deeplabcut>=0.3.1` and does not pin napari, so napari's version comes entirely from `napari>=0.6.6`. New installs `deeplabcut[gui]` resolve to 0.9.x and cannot start.

That import existed only to serve a monkeypatch of `QtPointsControls.changeCurrentSize` / `changeCurrentSymbol`, which made resizing apply to every point rather than only the selected ones. The patch tracked napari for up to napari < 0.6.5, but napari 0.6.5 moved those handlers into composed sub-widgets and removed both methods from `QtPointsControls`.

## Main changes

- **The patch and its three private napari imports are gone.** This removes the #235 import failure and drops `napari._qt` from `core/keypoints.py`'s import path
- **Point size now applies to newly added points.** With the patch gone, the plugin's own point-size panel is the only control, and it only resized *existing* points instead of newly added ones. `set_uniform_point_size` now sets both
- **napari's own size slider is hidden**, alongside the face/border colour controls already hidden there. It is selection-scoped, so with an empty selection it changed only `current_size` and silently disagreed with the plugin panel
- **`set_uniform_point_size` validates before mutating.** `layer.size` accepts anything broadcastable while `current_size` rejects negatives, so the previous ordering could leave the layer resized and then raise
  - Validation and the `current_size` write both happen before `layer.size`
  - Both call sites translate the resulting error into a warning rather than letting it escape a Qt slot
- **Config seeding also consults `current_size`.** `get_uniform_point_size` returns its own default on an empty layer, so the old guard could overwrite a deliberately chosen size on a layer with no points yet.

## Additional changes

- `set_uniform_point_size` blocks `events.size` around the `current_size` write. napari's setter re-applies the size to the selected subset and emits, but the following `layer.size` assignment covers every point and emits nothing, so the intermediate emission carries no information, and blocking it keeps event behaviour identical to a plain resize. Without this, dragging the size slider with a point selected would newly trigger a full status-panel refresh per tick, via a connection that had never fired before.
- `_tests/conftest.py` gains fixture type hints.
- `test_point_resize` is removed, it constructed `QtPointsControls` and called the patched method, so it cannot survive the deletion. Its contract (resize applies regardless of selection) is preserved in `_tests/core/test_layers.py`, which additionally exercises the selection case the original never did.