### PR TITLE
Run tests in parallel with pytest-xdist

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -72,6 +72,13 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
 
+      - name: Coverage summary
+        if: matrix.platform == 'ubuntu-latest' && matrix.python-version == '3.12'
+        shell: bash
+        run: |
+          python -m pip install coverage
+          python -m coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
+
       - name: Coverage
         uses: codecov/codecov-action@v6
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -75,6 +75,32 @@ jobs:
       - name: Coverage
         uses: codecov/codecov-action@v6
 
+  # Every job above resolves napari to latest. This one pins the declared floor so
+  # a regression against the oldest supported napari is not silently shipped.
+  test-napari-floor:
+    name: napari floor (0.6.6) py3.10
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - uses: tlambert03/setup-qt-libs@v1
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools tox
+
+      - name: Test against the napari floor
+        uses: aganders3/headless-gui@v2
+        with:
+          run: python -m tox -e napari-floor
+
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
     # and requires that you have put your twine API key in your

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
   "pytest",
   "pytest-cov",
   "pytest-qt",
+  "pytest-xdist",
   "tox",
 ]
 tracking = [

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -38,6 +38,17 @@ logging.getLogger("napari_deeplabcut").propagate = True
 # logging.getLogger("napari-deeplabcut").propagate = True # use the underscore variant to match __name__ throughout.
 
 
+def pytest_report_header(config):
+    """Point developers at parallel runs; the napari viewer fixture dominates runtime."""
+    if getattr(config.option, "numprocesses", None):
+        return None
+    return (
+        "napari-deeplabcut: running serially (~5x slower). "
+        "Use `pytest -n auto --dist loadfile` - pytest-xdist is in the dev extra. "
+        "Note: breakpoints and Debug Test do not work under xdist."
+    )
+
+
 def force_show(widget, qtbot, *, process_ms: int = 50):
     """
     Best-effort show of a widget and all its Qt parents, even under

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -39,13 +39,10 @@ os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
 logging.getLogger("napari_deeplabcut").propagate = True
 # logging.getLogger("napari-deeplabcut").propagate = True # use the underscore variant to match __name__ throughout.
 
-# Keep the suite out of the real settings store
-_settings_dir = Path(tempfile.gettempdir()) / (
-    f"napari-dlc-test-settings-{os.environ.get('PYTEST_XDIST_WORKER', 'main')}"
-)
-_settings_dir.mkdir(parents=True, exist_ok=True)
+# Keep the suite out of the real settings store.
+_settings_tmp = tempfile.TemporaryDirectory(prefix="napari-dlc-test-settings-", ignore_cleanup_errors=True)
 QSettings.setDefaultFormat(QSettings.Format.IniFormat)  # because of Win registry
-QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(_settings_dir))
+QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, _settings_tmp.name)
 
 
 def pytest_report_header(config):

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,11 +13,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from napari.utils.events import Event
+from qtpy.QtCore import QSettings
 from qtpy.QtWidgets import QApplication, QDockWidget
 from skimage.io import imsave
 
 from napari_deeplabcut.config.models import DLCHeaderModel
-from napari_deeplabcut.config.settings import set_auto_open_keypoint_controls
+from napari_deeplabcut.config.settings import get_auto_open_keypoint_controls, set_auto_open_keypoint_controls
 from napari_deeplabcut.core import io as io
 from napari_deeplabcut.core import keypoints
 
@@ -36,6 +38,14 @@ os.environ["NAPARI_ASYNC"] = "0"  # avoid async teardown surprises in tests
 # os.environ["PYTEST_QT_API"] = "pyqt6" # only for local testing with pyqt6, we use pyside6 otherwise
 logging.getLogger("napari_deeplabcut").propagate = True
 # logging.getLogger("napari-deeplabcut").propagate = True # use the underscore variant to match __name__ throughout.
+
+# Keep the suite out of the real settings store
+_settings_dir = Path(tempfile.gettempdir()) / (
+    f"napari-dlc-test-settings-{os.environ.get('PYTEST_XDIST_WORKER', 'main')}"
+)
+_settings_dir.mkdir(parents=True, exist_ok=True)
+QSettings.setDefaultFormat(QSettings.Format.IniFormat)  # because of Win registry
+QSettings.setPath(QSettings.Format.IniFormat, QSettings.Scope.UserScope, str(_settings_dir))
 
 
 def pytest_report_header(config):
@@ -80,7 +90,8 @@ def force_show(widget, qtbot, *, process_ms: int = 50):
 @pytest.fixture(autouse=True)
 def disable_auto_open_keypoint_controls():
     """Disable auto-opening of keypoint controls in tests by default."""
-    original_value = set_auto_open_keypoint_controls(False)
+    original_value = get_auto_open_keypoint_controls()
+    set_auto_open_keypoint_controls(False)
     yield
     set_auto_open_keypoint_controls(original_value)
 

--- a/src/napari_deeplabcut/_tests/conftest.py
+++ b/src/napari_deeplabcut/_tests/conftest.py
@@ -104,7 +104,7 @@ def only_deeplabcut_debug_logs():
             original_levels[name] = logger.level
 
             if not (name.startswith("napari_deeplabcut") or name.startswith("napari-deeplabcut")):
-                logger.setLevel(logging.INFO)
+                logger.setLevel(max(logger.getEffectiveLevel(), logging.INFO))
 
         # Ensure our plugin is verbose
         logging.getLogger("napari_deeplabcut").setLevel(logging.DEBUG)

--- a/src/napari_deeplabcut/_tests/test_ci.py
+++ b/src/napari_deeplabcut/_tests/test_ci.py
@@ -1,0 +1,41 @@
+import configparser
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+TOX_INI = REPO_ROOT / "tox.ini"
+
+# Both files only exist in a source checkout; an installed-wheel test run has
+# nothing to compare.
+pytestmark = pytest.mark.skipif(
+    not (PYPROJECT.is_file() and TOX_INI.is_file()),
+    reason="requires a source checkout",
+)
+
+
+def test_napari_floor_matches_declared_lower_bound():
+    """Keep the tox floor env aligned with the napari lower bound in pyproject."""
+    declared_floor = re.search(
+        r"""["']napari\s*(?:\[[^\]]*\])?\s*>=\s*([0-9][^,"'\s]*)""",
+        PYPROJECT.read_text(encoding="utf-8"),
+    )
+    assert declared_floor is not None, f"Expected a napari lower bound in {PYPROJECT.name}"
+
+    # interpolation=None: tox commands are free to contain '%'.
+    config = configparser.ConfigParser(interpolation=None)
+    config.read(TOX_INI, encoding="utf-8")
+    commands_pre = config["testenv:napari-floor"]["commands_pre"]
+
+    pinned_floor = re.search(
+        r"""pip install ["']napari==([^"']+)["']""",
+        commands_pre,
+    )
+    assert pinned_floor is not None, "Expected the napari-floor environment to install an exact napari version"
+
+    assert pinned_floor.group(1) == declared_floor.group(1), (
+        "The napari floor in tox.ini does not match the lower bound declared in "
+        f"pyproject.toml: {pinned_floor.group(1)} != {declared_floor.group(1)}"
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,6 @@ extras =
 commands = pytest -v --color=yes -n auto --dist loadfile --cov=napari_deeplabcut --cov-report=xml
 
 [testenv:napari-floor]
-# Guards the napari>=0.6.6 lower bound. Every other job resolves napari to latest,
-# so without this nothing tests the oldest version we claim to support.
-# commands_pre forces the downgrade after the package install, which would
-# otherwise be free to resolve a newer napari.
+# Keep this exact pin aligned with the napari lower bound in pyproject.toml.
 commands_pre = pip install "napari==0.6.6"
 commands = pytest -v --color=yes -n auto --dist loadfile

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,11 @@ extras =
     dev
     tracking
 commands = pytest -v --color=yes -n auto --dist loadfile --cov=napari_deeplabcut --cov-report=xml
+
+[testenv:napari-floor]
+# Guards the napari>=0.6.6 lower bound. Every other job resolves napari to latest,
+# so without this nothing tests the oldest version we claim to support.
+# commands_pre forces the downgrade after the package install, which would
+# otherwise be free to resolve a newer napari.
+commands_pre = pip install "napari==0.6.6"
+commands = pytest -v --color=yes -n auto --dist loadfile

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,4 @@ passenv =
 extras =
     dev
     tracking
-commands = pytest -v --color=yes --cov=napari_deeplabcut --cov-report=xml
+commands = pytest -v --color=yes -n auto --dist loadfile --cov=napari_deeplabcut --cov-report=xml


### PR DESCRIPTION
## Scope

Runs the test suite in parallel, which saves a lot of time otherwise spent on creating napari fixtures. Suite goes from ~300s locally to ~60s for my machine.

- [x] Checked on CI
  - **3-7min instead of 8-10min** 
  - If macOS or Windows jobs become flaky or start timing out, `-n 2` is the conservative fallback
- [x] Confirm the codecov number does not drop
  - [x] Added coverage report to CI summary since Codecov is not setup correctly anymore 
- [x] Add actual CI tests for napari version floor in deps

Parallelising did reveal one pre-existing order-dependent test (`test_guess_continuous`), removed in #236. 

## Motivation

The suite took ~290s locally for me. Most of that is napari's own `make_napari_viewer` fixture, which is function-scoped and, per test, builds a full Qt main window with a vispy canvas and GL context, then on top of that calls `gc.collect()`, resets the settings model twice, and clears the `lru_cache` on `_initialize_plugins` and `init_qactions`, forcing npe2 plugin re-discovery and a Qt action-model rebuild for every single test.

## Main changes

- `pytest-xdist` added to the `dev` extra
- `tox.ini` runs `-n auto --dist loadfile`

`--dist loadfile` rather than the default: it keeps a file's tests on one worker, which suits napari's per-worker `QtViewer` leak assertion and the module-level state in the e2e files.

## Using locally

- Note that `python.testing.pytestArgs` is not set here; running the suite in parallel from an editor is a local setting.
- Under xdist, breakpoints and "Debug Test" do not work, since workers cannot be attached to.
