### PR TITLE
Load HDF files with keypoint names stored as numbers

### DIFF
--- a/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from napari_deeplabcut.config.models import AnnotationKind
 from napari_deeplabcut.core.io import read_hdf_single
@@ -126,3 +127,46 @@ def test_read_hdf_single_metadata_contains_root_and_name(tmp_path: Path):
     assert meta["name"] == "CollectedData_John"
     assert meta["metadata"]["root"] == str(h5.parent)
     assert meta["metadata"]["name"] == "CollectedData_John"
+
+
+def _write_h5_multi_animal(path: Path, *, individuals, scorer: str = "John", frames: int = 3):
+    """Write a multi-animal file whose 'individuals' level takes the type given."""
+    bodyparts = ["head", "tail"]
+    cols = pd.MultiIndex.from_product(
+        [[scorer], list(individuals), bodyparts, ["x", "y"]],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
+    index = [f"img{i:03d}.png" for i in range(frames)]
+    values = np.arange(frames * len(cols), dtype=float).reshape(frames, len(cols))
+    df = pd.DataFrame(values, index=index, columns=cols)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_hdf(path, key="df_with_missing", mode="w")
+    return frames * len(individuals) * len(bodyparts)
+
+
+def test_read_hdf_single_multi_animal_string_individuals(tmp_path: Path):
+    """Control for the regression below: string individuals load every annotation."""
+    h5 = tmp_path / "CollectedData_John.h5"
+    expected = _write_h5_multi_animal(h5, individuals=["ind1", "ind2"])
+
+    data, _, _ = read_hdf_single(h5)[0]
+    assert len(data) == expected
+
+
+@pytest.mark.xfail(
+    reason=(
+        "DLCHeaderModel string-normalises every header level, so header.individuals is "
+        "['1','2'] while the file's level stays int64 and the reindex in read_hdf_single "
+        "matches nothing. read_hdf_single now raises rather than returning an empty layer, "
+        "but the values are still not loaded. Fixing this means aligning the types before "
+        "the reindex, not widening the guard."
+    ),
+    strict=True,
+)
+def test_read_hdf_single_multi_animal_numeric_individuals(tmp_path: Path):
+    """Individuals named 1, 2 should load like any other; today they do not."""
+    h5 = tmp_path / "CollectedData_John.h5"
+    expected = _write_h5_multi_animal(h5, individuals=[1, 2])
+
+    data, _, _ = read_hdf_single(h5)[0]
+    assert len(data) == expected

--- a/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
@@ -186,3 +186,38 @@ def test_read_hdf_single_warns_only_when_column_levels_are_not_text(tmp_path: Pa
     read_hdf_single(numeric)
     assert len(seen) == 1
     assert "individuals" in seen[0]
+
+
+def _write_h5_multi_scorer(path: Path, *, scorers, frames: int = 3):
+    """Write a two-scorer file with a likelihood coord, so the scorers are merged on read."""
+    individuals = ["ind1", "ind2"]
+    bodyparts = ["head", "tail"]
+    cols = pd.MultiIndex.from_product(
+        [list(scorers), individuals, bodyparts, ["x", "y", "likelihood"]],
+        names=["scorer", "individuals", "bodyparts", "coords"],
+    )
+    index = [f"img{i:03d}.png" for i in range(frames)]
+    values = np.arange(frames * len(cols), dtype=float).reshape(frames, len(cols))
+    df = pd.DataFrame(values, index=index, columns=cols)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_hdf(path, key="df_with_missing", mode="w")
+    return frames * len(individuals) * len(bodyparts)
+
+
+def test_read_hdf_single_does_not_warn_for_a_discarded_numeric_scorer(tmp_path: Path, monkeypatch):
+    """A numeric scorer that merging drops must not be reported as a coerced level.
+
+    Regression: the level check read columns.levels, which keeps values no column uses.
+    merge_multiple_scorers selects one scorer block by boolean mask, so the discarded
+    scorer's numeric name stayed in the level and every such file notified the user that
+    its keypoint names had been rewritten.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr("napari_deeplabcut.core.io.show_warning", seen.append)
+
+    h5 = tmp_path / "CollectedData_John.h5"
+    expected = _write_h5_multi_scorer(h5, scorers=["John", 2])
+
+    data, _, _ = read_hdf_single(h5)[0]
+    assert len(data) == expected
+    assert seen == [], f"every keypoint name is text; got {seen!r}"

--- a/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from napari_deeplabcut.config.models import AnnotationKind
 from napari_deeplabcut.core.io import read_hdf_single
@@ -153,18 +152,13 @@ def test_read_hdf_single_multi_animal_string_individuals(tmp_path: Path):
     assert len(data) == expected
 
 
-@pytest.mark.xfail(
-    reason=(
-        "DLCHeaderModel string-normalises every header level, so header.individuals is "
-        "['1','2'] while the file's level stays int64 and the reindex in read_hdf_single "
-        "matches nothing. read_hdf_single now raises rather than returning an empty layer, "
-        "but the values are still not loaded. Fixing this means aligning the types before "
-        "the reindex, not widening the guard."
-    ),
-    strict=True,
-)
 def test_read_hdf_single_multi_animal_numeric_individuals(tmp_path: Path):
-    """Individuals named 1, 2 should load like any other; today they do not."""
+    """Individuals named 1, 2 load like any other.
+
+    Regression: DLCHeaderModel string-normalises every header level, so header.individuals
+    is ['1','2'] while the file's level stays int64. Before _normalise_column_levels, the
+    reindex in read_hdf_single matched nothing and the layer loaded silently empty.
+    """
     h5 = tmp_path / "CollectedData_John.h5"
     expected = _write_h5_multi_animal(h5, individuals=[1, 2])
 

--- a/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
+++ b/src/napari_deeplabcut/_tests/core/io/test_hdf_reader.py
@@ -164,3 +164,25 @@ def test_read_hdf_single_multi_animal_numeric_individuals(tmp_path: Path):
 
     data, _, _ = read_hdf_single(h5)[0]
     assert len(data) == expected
+
+
+def test_read_hdf_single_warns_only_when_column_levels_are_not_text(tmp_path: Path, monkeypatch):
+    """Notify for a numeric level, stay silent otherwise.
+
+    Regression: the level check originally tested dtype. pandas 3 gives string levels a
+    dedicated `str` dtype rather than `object`, so every level looked coerced and every
+    file opened with a spurious notification.
+    """
+    seen: list[str] = []
+    monkeypatch.setattr("napari_deeplabcut.core.io.show_warning", seen.append)
+
+    text = tmp_path / "text" / "CollectedData_John.h5"
+    _write_h5_multi_animal(text, individuals=["ind1", "ind2"])
+    read_hdf_single(text)
+    assert seen == [], "a file with text keypoint names must not notify"
+
+    numeric = tmp_path / "numeric" / "CollectedData_John.h5"
+    _write_h5_multi_animal(numeric, individuals=[1, 2])
+    read_hdf_single(numeric)
+    assert len(seen) == 1
+    assert "individuals" in seen[0]

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -204,12 +204,24 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     if isinstance(temp.index, pd.MultiIndex):
         temp.index = [str(Path(*row)) for row in temp.index]
 
-    df = (
-        temp.stack(["individuals", "bodyparts"])
-        .reindex(header.individuals, level="individuals")
-        .reindex(header.bodyparts, level="bodyparts")
-        .reset_index()
-    )
+    # Reindex aligns the stacked frame to the header's ordering. It is a silent filter:
+    # values the header does not list are dropped. DLCHeaderModel string-normalises every
+    # level, so a file whose 'individuals' or 'bodyparts' level is numeric on disk matches
+    # nothing and the layer loads empty with no error. Raise instead - an empty layer is
+    # valid, but only when the file was empty to begin with.
+    stacked = temp.stack(["individuals", "bodyparts"])
+    df = stacked
+    for level, expected in (("individuals", header.individuals), ("bodyparts", header.bodyparts)):
+        before = len(df)
+        df = df.reindex(expected, level=level)
+        if before and df.empty:
+            found = stacked.index.get_level_values(level).unique().tolist()
+            raise ValueError(
+                f"Reading {file}: aligning the '{level}' level dropped every row. "
+                f"The file contains {found!r} but the header expects {list(expected)!r}. "
+                f"These usually differ only by type, the header being string-normalised."
+            )
+    df = df.reset_index()
 
     nrows = df.shape[0]
     data = np.empty((nrows, 3))

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -147,15 +147,16 @@ def _normalise_column_levels(columns: pd.MultiIndex) -> tuple[pd.MultiIndex, lis
     'bodyparts' level is numeric on disk would then align against nothing and load as an
     empty layer, so the frame is brought into the same representation as the header.
     """
-    frame = columns.to_frame(index=False)
+    # Test the values, not the dtype: pandas 2 stores string levels as object while
+    # pandas 3 gives them a dedicated str dtype, so any dtype check is version-specific.
     coerced = [
         name
-        for name, dtype in zip(columns.names, frame.dtypes, strict=False)
-        if not pd.api.types.is_object_dtype(dtype)
+        for name, level in zip(columns.names, columns.levels, strict=False)
+        if not all(isinstance(value, str) for value in level)
     ]
     if not coerced:
         return columns, []
-    return pd.MultiIndex.from_frame(frame.astype(str)), coerced
+    return pd.MultiIndex.from_frame(columns.to_frame(index=False).astype(str)), coerced
 
 
 def _read_hdf_any_key(file: Path) -> pd.DataFrame:

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -140,19 +140,23 @@ def write_config(config_path: str | Path, params: dict[str, Any]) -> None:
 # and attaches provenance via attach_source_and_io_to_layer_kwargs.
 
 
-def _normalise_column_levels(columns: pd.MultiIndex) -> tuple[pd.MultiIndex, list[str]]:
+def _normalise_column_levels(columns: pd.Index) -> tuple[pd.Index, list[str]]:
     """Coerce every column level to str, reporting which were not already strings.
 
     DLCHeaderModel string-normalises every level it reads. A file whose 'individuals' or
     'bodyparts' level is numeric on disk would then align against nothing and load as an
     empty layer, so the frame is brought into the same representation as the header.
     """
-    # Test the values, not the dtype: pandas 2 stores string levels as object while
-    # pandas 3 gives them a dedicated str dtype, so any dtype check is version-specific.
+    if not isinstance(columns, pd.MultiIndex):
+        return columns, []
+    # Test the values in use, not the dtype and not columns.levels. A dtype check is
+    # version-specific (pandas 2 stores string levels as object, pandas 3 gives them a
+    # dedicated str dtype), and columns.levels keeps entries no column uses, which
+    # merge_multiple_scorers leaves behind when it masks down to one scorer block.
     coerced = [
-        name
-        for name, level in zip(columns.names, columns.levels, strict=False)
-        if not all(isinstance(value, str) for value in level)
+        name if name is not None else f"level_{level}"
+        for level, name in enumerate(columns.names)
+        if not all(isinstance(value, str) for value in columns.get_level_values(level))
     ]
     if not coerced:
         return columns, []
@@ -244,7 +248,7 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
         before = len(df)
         df = df.reindex(expected, level=level)
         dropped = before - len(df)
-        if not dropped:
+        if dropped <= 0:
             continue
         found = stacked.index.get_level_values(level).unique().tolist()
         message = (

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -238,23 +238,22 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     if isinstance(temp.index, pd.MultiIndex):
         temp.index = [str(Path(*row)) for row in temp.index]
 
-    # Reindex aligns the stacked frame to the header's ordering. It is a silent filter:
-    # values the header does not list are dropped. DLCHeaderModel string-normalises every
-    # level, so a file whose 'individuals' or 'bodyparts' level is numeric on disk matches
-    # nothing and the layer loads empty with no error. Raise instead - an empty layer is
-    # valid, but only when the file was empty to begin with.
     stacked = temp.stack(["individuals", "bodyparts"])
     df = stacked
     for level, expected in (("individuals", header.individuals), ("bodyparts", header.bodyparts)):
         before = len(df)
         df = df.reindex(expected, level=level)
-        if before and df.empty:
-            found = stacked.index.get_level_values(level).unique().tolist()
-            raise ValueError(
-                f"Reading {file}: aligning the '{level}' level dropped every row. "
-                f"The file contains {found!r} but the header expects {list(expected)!r}. "
-                f"The two describe different keypoints, so no annotation could be matched."
-            )
+        dropped = before - len(df)
+        if not dropped:
+            continue
+        found = stacked.index.get_level_values(level).unique().tolist()
+        message = (
+            f"Reading {file}: aligning the '{level}' level dropped {dropped} of {before} rows. "
+            f"The file contains {found!r} but the header expects {list(expected)!r}."
+        )
+        if df.empty:
+            raise ValueError(message)
+        logger.warning(message)
     df = df.reset_index()
 
     nrows = df.shape[0]

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -139,6 +139,24 @@ def write_config(config_path: str | Path, params: dict[str, Any]) -> None:
 # and attaches provenance via attach_source_and_io_to_layer_kwargs.
 
 
+def _normalise_column_levels(columns: pd.MultiIndex) -> tuple[pd.MultiIndex, list[str]]:
+    """Coerce every column level to str, reporting which were not already strings.
+
+    DLCHeaderModel string-normalises every level it reads. A file whose 'individuals' or
+    'bodyparts' level is numeric on disk would then align against nothing and load as an
+    empty layer, so the frame is brought into the same representation as the header.
+    """
+    frame = columns.to_frame(index=False)
+    coerced = [
+        name
+        for name, dtype in zip(columns.names, frame.dtypes, strict=False)
+        if not pd.api.types.is_object_dtype(dtype)
+    ]
+    if not coerced:
+        return columns, []
+    return pd.MultiIndex.from_frame(frame.astype(str)), coerced
+
+
 def _read_hdf_any_key(file: Path) -> pd.DataFrame:
     """Read an HDF file without knowing the key in advance. Try common DLC keys."""
     file = str(file)
@@ -180,6 +198,16 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
     # temp = pd.read_hdf(str(file))
     temp = _read_hdf_any_key(file)
     temp = merge_multiple_scorers(temp)
+
+    temp.columns, coerced = _normalise_column_levels(temp.columns)
+    if coerced:
+        logger.warning(
+            "%s: column level(s) %s are not strings on disk and were normalised for "
+            "reading. Saving this file will write the normalised form.",
+            file,
+            coerced,
+        )
+
     header = DLCHeaderModel(columns=temp.columns)
     temp = temp.droplevel("scorer", axis=1)
     logger.debug("READ_HDF file=%s", file)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -40,6 +40,7 @@ import yaml
 from dask import delayed
 from dask_image.imread import imread
 from napari.types import LayerData
+from napari.utils.notifications import show_warning
 from natsort import natsorted
 from pydantic import ValidationError
 
@@ -206,6 +207,10 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
             "reading. Saving this file will write the normalised form.",
             file,
             coerced,
+        )
+        show_warning(
+            f"{Path(file).name}: keypoint names in {coerced} were stored as numbers and "
+            f"normalised to text. Saving will write the normalised form."
         )
 
     header = DLCHeaderModel(columns=temp.columns)

--- a/src/napari_deeplabcut/core/io.py
+++ b/src/napari_deeplabcut/core/io.py
@@ -247,7 +247,7 @@ def read_hdf_single(file: Path, *, kind: AnnotationKind | None = None) -> list[L
             raise ValueError(
                 f"Reading {file}: aligning the '{level}' level dropped every row. "
                 f"The file contains {found!r} but the header expects {list(expected)!r}. "
-                f"These usually differ only by type, the header being string-normalised."
+                f"The two describe different keypoints, so no annotation could be matched."
             )
     df = df.reset_index()
 


### PR DESCRIPTION
### Scope

Fixes a possible silent annotation loss in `read_hdf_single` for files whose `individuals` or `bodyparts` column level is numeric on disk, and adds a guard so that any remaining header/file mismatch fails loudly instead of producing an empty layer. Reader only; the write path and the header model are unchanged. Does not repair files already overwritten.

### Motivation

`DLCHeaderModel` string-normalises every column level it reads, so `header.individuals` is `["1", "2"]` for a file whose level holds `1, 2`. The frame keeps the dtype pandas stored it with. `read_hdf_single` aligns the two with `reindex`: absent values are dropped. `"1"` does not match `1`, so every row is dropped and the layer loads empty.

Saving over such a layer writes back to both the `.h5` and the `.csv`, making the loss permanent. Files already overwritten this way cannot be recovered.

**DeepLabCut's typed config rejects numeric keypoint names, so a current DLC project cannot declare them, but the reader is registered for `*.h5` and takes whatever file it is given.** 

Conversion scripts, SuperAnimal table remapping, merges and older projects all build columns without passing through that schema, so **the reader cannot assume its producer validated anything.**

### Main changes

- `_normalise_column_levels` coerces the frame's column levels to `str` before anything compares them to the header, which is what makes these files load.
- The `reindex` chain becomes a per-level loop that counts dropped rows: losing every row raises `ValueError` naming the level, the file's values and the header's, and a partial drop is logged. A file that was empty to begin with still loads as a valid empty layer. The guard has no known trigger once the coercion is in place; it is there because the input surface is open and the failure mode is silent data loss.
- A `logger.warning` and a `show_warning` report which levels were coerced, since the plugin writes the normalised form on the next save and that is otherwise invisible.
- The level check tests values rather than dtype, because pandas 2 stores string levels as `object` while pandas 3 gives them a dedicated `str` dtype; a dtype check reports every level as coerced on pandas 3 and notifies on every file opened.

### Regarding pandas version

- `_normalise_column_levels` was run against pandas 2.3.3 and 3.0.3 with identical results. `napari-deeplabcut` declares a bare `pandas` while DeepLabCut 3.0.1 pins `pandas<3,>=2.2`, so CI resolves pandas 3 while `deeplabcut[gui]` users run pandas 2, and neither version is currently pinned or tested here.
- The `object`-versus-`str` distinction is the same migration issue tracked in [DeepLabCut#3360](https://github.com/DeepLabCut/DeepLabCut/pull/3360); note no other instance of that pattern exists in this package.
